### PR TITLE
ci: configure Dependabot for the Langium component

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,9 @@ updates:
     directory: '/Runner'
     schedule:
       interval: 'monthly'
+
+  # DSL-langium
+  - package-ecosystem: 'npm'
+    directory: '/DSL-langium'
+    schedule:
+      interval: 'monthly'


### PR DESCRIPTION
### Summary of Changes

* Let Dependabot keep the Langium component up-to-date
