### PR TITLE
test: ignore `TYPE_CHECKING` blocks when computing coverage

### DIFF
--- a/Runner/.coveragerc
+++ b/Runner/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+exclude_lines =
+    pragma: no cover
+    if\s+(typing\.)?TYPE_CHECKING:


### PR DESCRIPTION
### Summary of Changes

`TYPE_CHECKING` blocks are supposed to be never executed, so they can also never be covered by tests. Now they are also no longer included in the test coverage.