### PR TITLE
feat: error if left operand of type parameter constraint does not belong to declaration with constraint

### DIFF
--- a/src/language/validation/other/declarations/typeParameterConstraints.ts
+++ b/src/language/validation/other/declarations/typeParameterConstraints.ts
@@ -1,0 +1,25 @@
+import {isSdsDeclaration, SdsTypeParameterConstraint} from '../../../generated/ast.js';
+import {getContainerOfType, ValidationAcceptor} from 'langium';
+
+export const CODE_TYPE_PARAMETER_CONSTRAINT_LEFT_OPERAND = 'type-parameter-constraint/left-operand';
+
+export const typeParameterConstraintLeftOperandMustBeOwnTypeParameter = (
+    node: SdsTypeParameterConstraint,
+    accept: ValidationAcceptor,
+) => {
+    const typeParameter = node.leftOperand.ref
+    if (!typeParameter) {
+        return;
+    }
+
+    const declarationWithConstraint = getContainerOfType(node.$container, isSdsDeclaration);
+    const declarationWithTypeParameters = getContainerOfType(typeParameter.$container, isSdsDeclaration);
+
+    if (declarationWithConstraint !== declarationWithTypeParameters) {
+        accept('error', 'The left operand must refer to a type parameter of the declaration with the constraint.', {
+            node,
+            property: 'leftOperand',
+            code: CODE_TYPE_PARAMETER_CONSTRAINT_LEFT_OPERAND,
+        });
+    }
+};

--- a/src/language/validation/other/declarations/typeParameterConstraints.ts
+++ b/src/language/validation/other/declarations/typeParameterConstraints.ts
@@ -1,5 +1,5 @@
-import {isSdsDeclaration, SdsTypeParameterConstraint} from '../../../generated/ast.js';
-import {getContainerOfType, ValidationAcceptor} from 'langium';
+import { isSdsDeclaration, SdsTypeParameterConstraint } from '../../../generated/ast.js';
+import { getContainerOfType, ValidationAcceptor } from 'langium';
 
 export const CODE_TYPE_PARAMETER_CONSTRAINT_LEFT_OPERAND = 'type-parameter-constraint/left-operand';
 
@@ -7,7 +7,7 @@ export const typeParameterConstraintLeftOperandMustBeOwnTypeParameter = (
     node: SdsTypeParameterConstraint,
     accept: ValidationAcceptor,
 ) => {
-    const typeParameter = node.leftOperand.ref
+    const typeParameter = node.leftOperand.ref;
     if (!typeParameter) {
         return;
     }

--- a/src/language/validation/safe-ds-validator.ts
+++ b/src/language/validation/safe-ds-validator.ts
@@ -19,9 +19,7 @@ import { templateStringMustHaveExpressionBetweenTwoStringParts } from './other/e
 import { yieldMustNotBeUsedInPipeline } from './other/statements/assignments.js';
 import { attributeMustHaveTypeHint, parameterMustHaveTypeHint, resultMustHaveTypeHint } from './types.js';
 import { moduleDeclarationsMustMatchFileKind, moduleWithDeclarationsMustStatePackage } from './other/modules.js';
-import {
-    typeParameterConstraintLeftOperandMustBeOwnTypeParameter
-} from "./other/declarations/typeParameterConstraints.js";
+import { typeParameterConstraintLeftOperandMustBeOwnTypeParameter } from './other/declarations/typeParameterConstraints.js';
 
 /**
  * Register custom validation checks.

--- a/src/language/validation/safe-ds-validator.ts
+++ b/src/language/validation/safe-ds-validator.ts
@@ -19,6 +19,9 @@ import { templateStringMustHaveExpressionBetweenTwoStringParts } from './other/e
 import { yieldMustNotBeUsedInPipeline } from './other/statements/assignments.js';
 import { attributeMustHaveTypeHint, parameterMustHaveTypeHint, resultMustHaveTypeHint } from './types.js';
 import { moduleDeclarationsMustMatchFileKind, moduleWithDeclarationsMustStatePackage } from './other/modules.js';
+import {
+    typeParameterConstraintLeftOperandMustBeOwnTypeParameter
+} from "./other/declarations/typeParameterConstraints.js";
 
 /**
  * Register custom validation checks.
@@ -40,6 +43,7 @@ export const registerValidationChecks = function (services: SafeDsServices) {
         SdsResult: [resultMustHaveTypeHint],
         SdsSegment: [segmentResultListShouldNotBeEmpty],
         SdsTemplateString: [templateStringMustHaveExpressionBetweenTwoStringParts],
+        SdsTypeParameterConstraint: [typeParameterConstraintLeftOperandMustBeOwnTypeParameter],
         SdsUnionType: [unionTypeShouldNotHaveASingularTypeArgument],
         SdsYield: [yieldMustNotBeUsedInPipeline],
     };

--- a/tests/resources/validation/other/declarations/type parameter constraints/left operand must be own type parameter/main.sdstest
+++ b/tests/resources/validation/other/declarations/type parameter constraints/left operand must be own type parameter/main.sdstest
@@ -1,0 +1,67 @@
+package tests.validation.other.declarations.typeParameterConstraints.typeParameterOnContainer
+
+annotation MyAnnotation where {
+    // $TEST$ no error "The left operand must refer to a type parameter of the declaration with the constraint."
+    »Unresolved« sub MyGlobalClass,
+}
+
+class MyGlobalClass<T1> where {
+    // $TEST$ no error "The left operand must refer to a type parameter of the declaration with the constraint."
+    »T1« sub MyGlobalClass,
+
+    // $TEST$ no error "The left operand must refer to a type parameter of the declaration with the constraint."
+    »Unresolved« sub MyGlobalClass
+} {
+    class MyNestedClass<T2> where {
+        // $TEST$ error "The left operand must refer to a type parameter of the declaration with the constraint."
+        »T1« sub MyGlobalClass,
+
+        // $TEST$ no error "The left operand must refer to a type parameter of the declaration with the constraint."
+        »T2« sub MyGlobalClass,
+
+        // $TEST$ no error "The left operand must refer to a type parameter of the declaration with the constraint."
+        »Unresolved« sub MyGlobalClass,
+    }
+
+    enum MyNestedEnum {
+        MyEnumVariant<T2> where {
+            // $TEST$ error "The left operand must refer to a type parameter of the declaration with the constraint."
+            »T1« sub MyGlobalClass,
+
+            // $TEST$ no error "The left operand must refer to a type parameter of the declaration with the constraint."
+            »T2« sub MyGlobalClass,
+
+            // $TEST$ no error "The left operand must refer to a type parameter of the declaration with the constraint."
+            »Unresolved« sub MyGlobalClass,
+        }
+    }
+
+    fun myMethod<T2>() where {
+        // $TEST$ error "The left operand must refer to a type parameter of the declaration with the constraint."
+        »T1« sub MyGlobalClass,
+
+        // $TEST$ no error "The left operand must refer to a type parameter of the declaration with the constraint."
+        »T2« sub MyGlobalClass,
+
+        // $TEST$ no error "The left operand must refer to a type parameter of the declaration with the constraint."
+        »Unresolved« sub MyGlobalClass,
+    }
+}
+
+enum MyGlobalEnum {
+    MyEnumVariant<T1> where {
+        // $TEST$ no error "The left operand must refer to a type parameter of the declaration with the constraint."
+        »T1« sub MyGlobalClass,
+
+        // $TEST$ no error "The left operand must refer to a type parameter of the declaration with the constraint."
+        »Unresolved« sub MyGlobalClass,
+    }
+}
+
+fun myGlobalFunction<T1>() where {
+    // $TEST$ no error "The left operand must refer to a type parameter of the declaration with the constraint."
+    »T1« sub MyGlobalClass,
+
+    // $TEST$ no error "The left operand must refer to a type parameter of the declaration with the constraint."
+    »Unresolved« sub MyGlobalClass,
+}


### PR DESCRIPTION
Closes #562

### Summary of Changes

Show an error if the left operand of a type parameter constraint refers to a type parameter that does not belong to the declaration with the constraint (but a declaration that contains it).