### PR TITLE
test: reference containing class from parent type list

### DIFF
--- a/src/language/scoping/safe-ds-scope-computation.ts
+++ b/src/language/scoping/safe-ds-scope-computation.ts
@@ -42,6 +42,7 @@ export class SafeDsScopeComputation extends DefaultScopeComputation {
         const description = this.descriptions.createDescription(node, name, document);
 
         this.addToScopesIfKeyIsDefined(scopes, node.parameterList, description);
+        this.addToScopesIfKeyIsDefined(scopes, node.parentTypeList, description);
         this.addToScopesIfKeyIsDefined(scopes, node.constraintList, description);
         this.addToScopesIfKeyIsDefined(scopes, node.body, description);
 

--- a/tests/resources/scoping/named types/to containing named type declaration/main.sdstest
+++ b/tests/resources/scoping/named types/to containing named type declaration/main.sdstest
@@ -4,7 +4,8 @@ package test.scoping.namedTypes.toContainingNamedTypeDeclaration
 class »MyClass«<T>(
     // $TEST$ references outerClass
     p: »MyClass«
-) where {
+// $TEST$ references outerClass
+) sub »MyClass« where {
     // $TEST$ references outerClass
     T sub »MyClass«
 } {
@@ -65,7 +66,10 @@ class »MyClass«<T>(
 
         // $TEST$ unresolved
         p2: »MyEnum«,
-    ) {
+
+    // $TEST$ references innerClass
+    // $TEST$ unresolved
+    ) sub »MyClass«, »MyEnum« {
         // $TEST$ references innerClass
         attr a1: »MyClass«
 


### PR DESCRIPTION
Closes #29
Closes partially #540

### Summary of Changes

Test that containing classes can be referenced from the parent type list.