### PR TITLE
feat: scoping of arguments

### DIFF
--- a/src/language/typing/model.ts
+++ b/src/language/typing/model.ts
@@ -23,7 +23,7 @@ export class CallableType extends Type {
     override isNullable: boolean = false;
 
     constructor(
-        readonly callable: SdsCallable,
+        readonly sdsCallable: SdsCallable,
         readonly inputType: NamedTupleType,
         readonly outputType: NamedTupleType,
     ) {
@@ -48,7 +48,7 @@ export class CallableType extends Type {
         }
 
         return (
-            other.callable === this.callable &&
+            other.sdsCallable === this.sdsCallable &&
             other.inputType.equals(this.inputType) &&
             other.outputType.equals(this.outputType)
         );

--- a/src/language/typing/safe-ds-type-computer.ts
+++ b/src/language/typing/safe-ds-type-computer.ts
@@ -357,14 +357,12 @@ export class SafeDsTypeComputer {
         const receiverType = this.computeType(node.receiver);
 
         if (receiverType instanceof CallableType) {
-            if (!isSdsAnnotation(receiverType.callable)) {
+            if (!isSdsAnnotation(receiverType.sdsCallable)) {
                 return receiverType.outputType;
             }
         } else if (receiverType instanceof StaticType) {
             const instanceType = receiverType.instanceType;
-            const declaration = instanceType.sdsDeclaration;
-
-            if (isSdsClass(declaration) || isSdsEnumVariant(declaration)) {
+            if (isSdsCallable(instanceType.sdsDeclaration)) {
                 return instanceType;
             }
         }

--- a/tests/resources/scoping/arguments/of annotation calls/main.sdstest
+++ b/tests/resources/scoping/arguments/of annotation calls/main.sdstest
@@ -1,0 +1,20 @@
+package tests.scoping.arguments.ofAnnotationCalls
+
+annotation MyAnnotation(
+    // $TEST$ target a
+    »a«: Int,
+    // $TEST$ target b
+    »b«: Int = 0,
+    // $TEST$ target c
+    vararg »c«: Int
+)
+
+@MyAnnotation(
+    // $TEST$ references c
+    »c« = 0,
+    // $TEST$ references a
+    »a« = 0,
+    // $TEST$ references b
+    »b« = 0
+)
+pipeline myPipeline {}

--- a/tests/resources/scoping/arguments/of annotation calls/to parameter/main.sdstest
+++ b/tests/resources/scoping/arguments/of annotation calls/to parameter/main.sdstest
@@ -1,4 +1,4 @@
-package tests.scoping.arguments.ofAnnotationCalls
+package tests.scoping.arguments.ofAnnotationCalls.toParameter
 
 annotation MyAnnotation(
     // $TEST$ target a

--- a/tests/resources/scoping/arguments/of annotation calls/to something other than parameter/main.sdstest
+++ b/tests/resources/scoping/arguments/of annotation calls/to something other than parameter/main.sdstest
@@ -1,0 +1,9 @@
+package tests.scoping.arguments.ofAnnotationCalls.toSomethingOtherThanParameter
+
+annotation MyAnnotation(a: Int)
+
+@MyAnnotation(
+    // $TEST$ unresolved
+    »MyAnnotation« = 0,
+)
+pipeline myPipeline {}

--- a/tests/resources/scoping/arguments/of annotation calls/unresolved/main.sdstest
+++ b/tests/resources/scoping/arguments/of annotation calls/unresolved/main.sdstest
@@ -1,0 +1,13 @@
+package tests.scoping.arguments.ofAnnotationCalls.unresolved
+
+annotation MyAnnotation(a: Int)
+
+@MyAnnotation(
+    // $TEST$ unresolved
+    »unresolved« = 0,
+)
+@Unresolved(
+    // $TEST$ unresolved
+    »a« = 0
+)
+pipeline myPipeline {}

--- a/tests/resources/scoping/arguments/of calls/to parameter of annotation/main.sdstest
+++ b/tests/resources/scoping/arguments/of calls/to parameter of annotation/main.sdstest
@@ -1,0 +1,31 @@
+package tests.scoping.arguments.ofCalls.toParameterOfAnnotation
+
+annotation MyAnnotation(
+    // $TEST$ target a
+    »a«: Int,
+    // $TEST$ target b
+    »b«: Int = 0,
+    // $TEST$ target c
+    vararg »c«: Int
+)
+
+pipeline myPipeline {
+    MyAnnotation(
+        // $TEST$ references c
+        »c« = 0,
+        // $TEST$ references a
+        »a« = 0,
+        // $TEST$ references b
+        »b« = 0
+    );
+
+    val alias = MyAnnotation;
+    alias(
+        // $TEST$ references c
+        »c« = 0,
+        // $TEST$ references a
+        »a« = 0,
+        // $TEST$ references b
+        »b« = 0
+    );
+}

--- a/tests/resources/scoping/arguments/of calls/to parameter of block lambda/main.sdstest
+++ b/tests/resources/scoping/arguments/of calls/to parameter of block lambda/main.sdstest
@@ -1,0 +1,21 @@
+package tests.scoping.arguments.ofCalls.toParameterOfBlockLambda
+
+pipeline myPipeline {
+    val myBlockLambda = (
+        // $TEST$ target a
+        »a«: Int,
+        // $TEST$ target b
+        »b«: Int = 0,
+        // $TEST$ target c
+        vararg »c«: Int
+    ) {};
+
+    myBlockLambda(
+        // $TEST$ references c
+        »c« = 0,
+        // $TEST$ references a
+        »a« = 0,
+        // $TEST$ references b
+        »b« = 0
+    );
+}

--- a/tests/resources/scoping/arguments/of calls/to parameter of callable type/main.sdstest
+++ b/tests/resources/scoping/arguments/of calls/to parameter of callable type/main.sdstest
@@ -1,0 +1,29 @@
+package tests.scoping.arguments.ofCalls.toParameterOfCallableType
+
+segment mySegment(myCallableType: (
+    // $TEST$ target a
+    »a«: Int,
+    // $TEST$ target b
+    »b«: Int = 0,
+    // $TEST$ target c
+    vararg »c«: Int
+) -> ()) {
+    myCallableType(
+        // $TEST$ references c
+        »c« = 0,
+        // $TEST$ references a
+        »a« = 0,
+        // $TEST$ references b
+        »b« = 0
+    );
+
+    val alias = myCallableType;
+    alias(
+        // $TEST$ references c
+        »c« = 0,
+        // $TEST$ references a
+        »a« = 0,
+        // $TEST$ references b
+        »b« = 0
+    );
+}

--- a/tests/resources/scoping/arguments/of calls/to parameter of class/main.sdstest
+++ b/tests/resources/scoping/arguments/of calls/to parameter of class/main.sdstest
@@ -1,0 +1,31 @@
+package tests.scoping.arguments.ofCalls.toParameterOfClass
+
+class MyClass(
+    // $TEST$ target a
+    »a«: Int,
+    // $TEST$ target b
+    »b«: Int = 0,
+    // $TEST$ target c
+    vararg »c«: Int
+) {}
+
+pipeline myPipeline {
+    MyClass(
+        // $TEST$ references c
+        »c« = 0,
+        // $TEST$ references a
+        »a« = 0,
+        // $TEST$ references b
+        »b« = 0
+    );
+
+    val alias = MyClass;
+    alias(
+        // $TEST$ references c
+        »c« = 0,
+        // $TEST$ references a
+        »a« = 0,
+        // $TEST$ references b
+        »b« = 0
+    );
+}

--- a/tests/resources/scoping/arguments/of calls/to parameter of enum variant/main.sdstest
+++ b/tests/resources/scoping/arguments/of calls/to parameter of enum variant/main.sdstest
@@ -1,0 +1,34 @@
+package tests.scoping.arguments.ofCalls.toParameterOfEnumVariant
+
+enum MyEnum {
+    MyEnumVariant(
+        // $TEST$ target a
+        »a«: Int,
+        // $TEST$ target b
+        »b«: Int = 0,
+        // $TEST$ target c
+        vararg »c«: Int
+    )
+}
+
+
+pipeline myPipeline {
+    MyEnum.MyEnumVariant(
+        // $TEST$ references c
+        »c« = 0,
+        // $TEST$ references a
+        »a« = 0,
+        // $TEST$ references b
+        »b« = 0
+    );
+
+    val alias = MyEnum.MyEnumVariant;
+    alias(
+        // $TEST$ references c
+        »c« = 0,
+        // $TEST$ references a
+        »a« = 0,
+        // $TEST$ references b
+        »b« = 0
+    );
+}

--- a/tests/resources/scoping/arguments/of calls/to parameter of expression lambda/main.sdstest
+++ b/tests/resources/scoping/arguments/of calls/to parameter of expression lambda/main.sdstest
@@ -1,0 +1,21 @@
+package tests.scoping.arguments.ofCalls.toParameterOfExpressionLambda
+
+pipeline myPipeline {
+    val myExpressionLambda = (
+        // $TEST$ target a
+        »a«: Int,
+        // $TEST$ target b
+        »b«: Int = 0,
+        // $TEST$ target c
+        vararg »c«: Int
+    ) -> 1;
+
+    myExpressionLambda(
+        // $TEST$ references c
+        »c« = 0,
+        // $TEST$ references a
+        »a« = 0,
+        // $TEST$ references b
+        »b« = 0
+    );
+}

--- a/tests/resources/scoping/arguments/of calls/to parameter of function/main.sdstest
+++ b/tests/resources/scoping/arguments/of calls/to parameter of function/main.sdstest
@@ -1,0 +1,31 @@
+package tests.scoping.arguments.ofCalls.toParameterOfFunction
+
+fun myFunction(
+    // $TEST$ target a
+    »a«: Int,
+    // $TEST$ target b
+    »b«: Int = 0,
+    // $TEST$ target c
+    vararg »c«: Int
+)
+
+pipeline myPipeline {
+    myFunction(
+        // $TEST$ references c
+        »c« = 0,
+        // $TEST$ references a
+        »a« = 0,
+        // $TEST$ references b
+        »b« = 0
+    );
+
+    val alias = myFunction;
+    alias(
+        // $TEST$ references c
+        »c« = 0,
+        // $TEST$ references a
+        »a« = 0,
+        // $TEST$ references b
+        »b« = 0
+    );
+}

--- a/tests/resources/scoping/arguments/of calls/to parameter of segment/main.sdstest
+++ b/tests/resources/scoping/arguments/of calls/to parameter of segment/main.sdstest
@@ -1,0 +1,31 @@
+package tests.scoping.arguments.ofCalls.toParameterOfSegment
+
+segment mySegment(
+    // $TEST$ target a
+    »a«: Int,
+    // $TEST$ target b
+    »b«: Int = 0,
+    // $TEST$ target c
+    vararg »c«: Int
+) {}
+
+pipeline myPipeline {
+    mySegment(
+        // $TEST$ references c
+        »c« = 0,
+        // $TEST$ references a
+        »a« = 0,
+        // $TEST$ references b
+        »b« = 0
+    );
+
+    val alias = mySegment;
+    alias(
+        // $TEST$ references c
+        »c« = 0,
+        // $TEST$ references a
+        »a« = 0,
+        // $TEST$ references b
+        »b« = 0
+    );
+}

--- a/tests/resources/scoping/arguments/of calls/to something other than parameter/main.sdstest
+++ b/tests/resources/scoping/arguments/of calls/to something other than parameter/main.sdstest
@@ -1,0 +1,8 @@
+package tests.scoping.arguments.ofCalls.toSomethingOtherThanParameter
+
+fun f(a: Int)
+
+pipeline myPipeline {
+    // $TEST$ unresolved
+    f(»f« = 1);
+}

--- a/tests/resources/scoping/arguments/of calls/unresolved/main.sdstest
+++ b/tests/resources/scoping/arguments/of calls/unresolved/main.sdstest
@@ -1,0 +1,11 @@
+package tests.scoping.arguments.ofCalls.unresolved
+
+fun f(a: Int)
+
+pipeline myPipeline {
+    // $TEST$ unresolved
+    f(»unresolved« = 1);
+
+    // $TEST$ unresolved
+    unresolved(»a« = 1);
+}


### PR DESCRIPTION
Closes partially #540.

### Summary of Changes

Named arguments now correctly point to their corresponding parameter.