### PR TITLE
feat: compute types of lambdas that are passed as arguments

### DIFF
--- a/src/language/helpers/safe-ds-node-mapper.ts
+++ b/src/language/helpers/safe-ds-node-mapper.ts
@@ -23,10 +23,10 @@ import { argumentsOrEmpty, parametersOrEmpty, typeArgumentsOrEmpty, typeParamete
 import { isNamedArgument, isNamedTypeArgument } from './checks.js';
 
 export class SafeDsNodeMapper {
-    private readonly typeComputer: SafeDsTypeComputer;
+    private readonly typeComputer: () => SafeDsTypeComputer;
 
     constructor(services: SafeDsServices) {
-        this.typeComputer = new SafeDsTypeComputer(services);
+        this.typeComputer = () => services.types.TypeComputer;
     }
 
     /**
@@ -36,7 +36,7 @@ export class SafeDsNodeMapper {
         if (isSdsAnnotationCall(node)) {
             return node.annotation?.ref;
         } else if (isSdsCall(node)) {
-            const receiverType = this.typeComputer.computeType(node.receiver);
+            const receiverType = this.typeComputer().computeType(node.receiver);
             if (receiverType instanceof CallableType) {
                 return receiverType.sdsCallable;
             } else if (receiverType instanceof StaticType) {

--- a/tests/resources/typing/declarations/parameters/of block lambdas/that are isolated/main.sdstest
+++ b/tests/resources/typing/declarations/parameters/of block lambdas/that are isolated/main.sdstest
@@ -1,4 +1,4 @@
-package tests.typing.declarations.parameters.ofBlockLambdas
+package tests.typing.declarations.parameters.ofBlockLambdas.thatAreIsolated
 
 segment mySegment() {
     // $TEST$ serialization $Unknown

--- a/tests/resources/typing/declarations/parameters/of block lambdas/that are passed as arguments/main.sdstest
+++ b/tests/resources/typing/declarations/parameters/of block lambdas/that are passed as arguments/main.sdstest
@@ -1,4 +1,4 @@
-package tests.typing.declarations.parameters.ofBlockLambdas
+package tests.typing.declarations.parameters.ofBlockLambdas.thatArePassedAsArguments
 
 // $TEST$ equivalence_class parameterType1
 fun higherOrderFunction1(param: (a: »String«) -> ())

--- a/tests/resources/typing/declarations/parameters/of block lambdas/that are yielded/main.sdstest
+++ b/tests/resources/typing/declarations/parameters/of block lambdas/that are yielded/main.sdstest
@@ -1,4 +1,4 @@
-package tests.typing.declarations.parameters.ofBlockLambdas
+package tests.typing.declarations.parameters.ofBlockLambdas.thatAreYielded
 
 segment mySegment() -> (
     // $TEST$ equivalence_class parameterType2

--- a/tests/resources/typing/declarations/parameters/of block lambdas/with manifest types/main.sdstest
+++ b/tests/resources/typing/declarations/parameters/of block lambdas/with manifest types/main.sdstest
@@ -1,10 +1,10 @@
-package tests.typing.declarations.parameters.ofExpressionLambdas
+package tests.typing.declarations.parameters.ofBlockLambdas.withManifestTypes
 
 segment mySegment() {
     // $TEST$ equivalence_class parameterType3
     // $TEST$ equivalence_class parameterType3
-    (»p«: »Int«) -> 1;
+    (»p«: »Int«) {};
 
     // $TEST$ serialization vararg<String>
-    (vararg »p«: String) -> 1;
+    (vararg »p«: String) {};
 }

--- a/tests/resources/typing/declarations/parameters/of expression lambdas/that are isolated.sdstest
+++ b/tests/resources/typing/declarations/parameters/of expression lambdas/that are isolated.sdstest
@@ -1,6 +1,0 @@
-package tests.typing.declarations.parameters.ofExpressionLambdas
-
-segment mySegment() {
-    // $TEST$ serialization $Unknown
-    (»p«) -> 1;
-}

--- a/tests/resources/typing/declarations/parameters/of expression lambdas/that are isolated/main.sdstest
+++ b/tests/resources/typing/declarations/parameters/of expression lambdas/that are isolated/main.sdstest
@@ -1,0 +1,6 @@
+package tests.typing.declarations.parameters.ofExpressionLambdas.thatAreIsolated
+
+segment mySegment() {
+    // $TEST$ serialization $Unknown
+    (»p«) -> 1;
+}

--- a/tests/resources/typing/declarations/parameters/of expression lambdas/that are passed as arguments/main.sdstest
+++ b/tests/resources/typing/declarations/parameters/of expression lambdas/that are passed as arguments/main.sdstest
@@ -1,4 +1,4 @@
-package tests.typing.declarations.parameters.ofExpressionLambdas
+package tests.typing.declarations.parameters.ofExpressionLambdas.thatArePassedAsArguments
 
 // $TEST$ equivalence_class parameterType1
 fun higherOrderFunction1(param: (a: »String«) -> r: String)

--- a/tests/resources/typing/declarations/parameters/of expression lambdas/that are yielded/main.sdstest
+++ b/tests/resources/typing/declarations/parameters/of expression lambdas/that are yielded/main.sdstest
@@ -1,4 +1,4 @@
-package tests.typing.declarations.parameters.ofExpressionLambdas
+package tests.typing.declarations.parameters.ofExpressionLambdas.thatAreYielded
 
 segment mySegment() -> (
     // $TEST$ equivalence_class parameterType2

--- a/tests/resources/typing/declarations/parameters/of expression lambdas/with manifest types/main.sdstest
+++ b/tests/resources/typing/declarations/parameters/of expression lambdas/with manifest types/main.sdstest
@@ -1,10 +1,10 @@
-package tests.typing.declarations.parameters.ofBlockLambdas
+package tests.typing.declarations.parameters.ofExpressionLambdas.withManifestTypes
 
 segment mySegment() {
     // $TEST$ equivalence_class parameterType3
     // $TEST$ equivalence_class parameterType3
-    (»p«: »Int«) {};
+    (»p«: »Int«) -> 1;
 
     // $TEST$ serialization vararg<String>
-    (vararg »p«: String) {};
+    (vararg »p«: String) -> 1;
 }

--- a/tests/resources/typing/expressions/block lambdas/that are isolated/main.sdstest
+++ b/tests/resources/typing/expressions/block lambdas/that are isolated/main.sdstest
@@ -1,4 +1,4 @@
-package tests.typing.expressions.blockLambdas
+package tests.typing.expressions.blockLambdas.thatAreIsolated
 
 segment mySegment() {
     // $TEST$ serialization (p: $Unknown) -> (r: Int, s: $Unknown)

--- a/tests/resources/typing/expressions/block lambdas/that are passed as arguments/main.sdstest
+++ b/tests/resources/typing/expressions/block lambdas/that are passed as arguments/main.sdstest
@@ -3,6 +3,7 @@ package tests.typing.expressions.blockLambdas.thatArePassedAsArguments
 fun higherOrderFunction1(param: (p: String) -> (r: Int, s: String))
 fun higherOrderFunction2(param: () -> ())
 fun normalFunction(param: Int)
+fun parameterlessFunction()
 
 segment mySegment() {
     // $TEST$ serialization (p: String) -> (r: Int, s: String)
@@ -35,6 +36,11 @@ segment mySegment() {
 
     // $TEST$ serialization (p: $Unknown) -> (r: Int, s: $Unknown)
     normalFunction(param = »(p) {
+        yield r, yield s = 1;
+    }«);
+
+    // $TEST$ serialization (p: $Unknown) -> (r: Int, s: $Unknown)
+    parameterlessFunction(»(p) {
         yield r, yield s = 1;
     }«);
 }

--- a/tests/resources/typing/expressions/block lambdas/that are passed as arguments/main.sdstest
+++ b/tests/resources/typing/expressions/block lambdas/that are passed as arguments/main.sdstest
@@ -1,4 +1,4 @@
-package tests.typing.expressions.blockLambdas
+package tests.typing.expressions.blockLambdas.thatArePassedAsArguments
 
 fun higherOrderFunction1(param: (p: String) -> (r: Int, s: String))
 fun higherOrderFunction2(param: () -> ())

--- a/tests/resources/typing/expressions/block lambdas/that are yielded/main.sdstest
+++ b/tests/resources/typing/expressions/block lambdas/that are yielded/main.sdstest
@@ -1,4 +1,4 @@
-package tests.typing.expressions.blockLambdas
+package tests.typing.expressions.blockLambdas.thatAreYielded
 
 segment mySegment() -> (
     r: (p: String) -> (r: Int, s: String),

--- a/tests/resources/typing/expressions/block lambdas/with manifest types/main.sdstest
+++ b/tests/resources/typing/expressions/block lambdas/with manifest types/main.sdstest
@@ -1,4 +1,4 @@
-package tests.typing.expressions.blockLambdas
+package tests.typing.expressions.blockLambdas.withManifestTypes
 
 segment mySegment() {
     // $TEST$ serialization (p: Int) -> (r: Int, s: String)

--- a/tests/resources/typing/expressions/expression lambdas/that are isolated/main.sdstest
+++ b/tests/resources/typing/expressions/expression lambdas/that are isolated/main.sdstest
@@ -1,4 +1,4 @@
-package tests.typing.expressions.expressionLambdas
+package tests.typing.expressions.expressionLambdas.thatAreIsolated
 
 segment mySegment() {
     // $TEST$ serialization (p: $Unknown) -> (result: Int)

--- a/tests/resources/typing/expressions/expression lambdas/that are passed as arguments/main.sdstest
+++ b/tests/resources/typing/expressions/expression lambdas/that are passed as arguments/main.sdstest
@@ -1,4 +1,4 @@
-package tests.typing.expressions.expressionLambdas
+package tests.typing.expressions.expressionLambdas.thatArePassedAsArguments
 
 fun higherOrderFunction1(param: (p: String) -> (r: Int))
 fun higherOrderFunction2(param: () -> ())

--- a/tests/resources/typing/expressions/expression lambdas/that are passed as arguments/main.sdstest
+++ b/tests/resources/typing/expressions/expression lambdas/that are passed as arguments/main.sdstest
@@ -3,6 +3,7 @@ package tests.typing.expressions.expressionLambdas.thatArePassedAsArguments
 fun higherOrderFunction1(param: (p: String) -> (r: Int))
 fun higherOrderFunction2(param: () -> ())
 fun normalFunction(param: Int)
+fun parameterlessFunction()
 
 segment mySegment() {
     // $TEST$ serialization (p: String) -> (result: Int)
@@ -22,4 +23,7 @@ segment mySegment() {
 
     // $TEST$ serialization (p: $Unknown) -> (result: Int)
     normalFunction(param = »(p) -> 1«);
+
+    // $TEST$ serialization (p: $Unknown) -> (result: Int)
+    parameterlessFunction(»(p) -> 1«);
 }

--- a/tests/resources/typing/expressions/expression lambdas/that are yielded/main.sdstest
+++ b/tests/resources/typing/expressions/expression lambdas/that are yielded/main.sdstest
@@ -1,4 +1,4 @@
-package tests.typing.expressions.expressionLambdas
+package tests.typing.expressions.expressionLambdas.thatAreYielded
 
 segment mySegment() -> (
     r: (p: String) -> (),

--- a/tests/resources/typing/expressions/expression lambdas/with manifest types/main.sdstest
+++ b/tests/resources/typing/expressions/expression lambdas/with manifest types/main.sdstest
@@ -1,4 +1,4 @@
-package tests.typing.expressions.expressionLambdas
+package tests.typing.expressions.expressionLambdas.withManifestTypes
 
 segment mySegment() {
     // $TEST$ serialization (p: Int) -> (result: Int)


### PR DESCRIPTION
Closes partially #541

### Summary of Changes

* Compute the type of parameters of lambdas that are passed as arguments.
* Compute the type of lambdas that are passed as arguments.