### PR TITLE
test: properly check for syntax errors in test files

### DIFF
--- a/src/language/workspace/safe-ds-package-manager.ts
+++ b/src/language/workspace/safe-ds-package-manager.ts
@@ -125,6 +125,7 @@ export class SafeDsPackageManager {
         for (const description of this.indexManager.allElements()) {
             const node = this.loadAstNode(description);
             if (!node) {
+                /* c8 ignore next 2 */
                 continue;
             }
 
@@ -148,9 +149,9 @@ export class SafeDsPackageManager {
         if (this.langiumDocuments.hasDocument(nodeDescription.documentUri)) {
             const document = this.langiumDocuments.getOrCreateDocument(nodeDescription.documentUri);
             return this.astNodeLocator.getAstNode(document.parseResult.value, nodeDescription.path);
-        }
-
-        return undefined;
+        } /* c8 ignore start */ else {
+            return undefined;
+        } /* c8 ignore stop */
     }
 
     /**

--- a/tests/helpers/diagnostics.ts
+++ b/tests/helpers/diagnostics.ts
@@ -1,6 +1,8 @@
-import { validationHelper } from 'langium/test';
+import { parseHelper } from 'langium/test';
 import { LangiumServices } from 'langium';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver-types';
+
+let nextId = 0;
 
 /**
  * Get syntax errors from a code snippet.
@@ -10,8 +12,8 @@ import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver-types';
  * @returns The syntax errors.
  */
 export const getSyntaxErrors = async (services: LangiumServices, code: string): Promise<Diagnostic[]> => {
-    const validationResult = await validationHelper(services)(code);
-    return validationResult.diagnostics.filter(
+    const diagnostics = await getDiagnostics(services, code);
+    return diagnostics.filter(
         (d) =>
             d.severity === DiagnosticSeverity.Error &&
             (d.data?.code === 'lexing-error' || d.data?.code === 'parsing-error'),
@@ -26,11 +28,27 @@ export const getSyntaxErrors = async (services: LangiumServices, code: string): 
  * @returns The errors.
  */
 export const getLinkingErrors = async (services: LangiumServices, code: string): Promise<Diagnostic[]> => {
-    const validationResult = await validationHelper(services)(code);
-    return validationResult.diagnostics.filter(
+    const diagnostics = await getDiagnostics(services, code);
+    return diagnostics.filter(
         (d) => d.severity === DiagnosticSeverity.Error && d.data?.code === 'linking-error',
     );
 };
+
+/**
+ * Get all diagnostics from a code snippet.
+ *
+ * @param services The language services.
+ * @param code The code snippet to check.
+ * @returns The diagnostics.
+ */
+const getDiagnostics = async (services: LangiumServices, code: string): Promise<Diagnostic[]> => {
+    const parse = parseHelper(services);
+    const document = await parse(code, {
+        documentUri: `file:///$autogen$${nextId++}.sdstest`,
+        validation: true,
+    });
+    return document.diagnostics ?? [];
+}
 
 /**
  * The code contains syntax errors.

--- a/tests/helpers/diagnostics.ts
+++ b/tests/helpers/diagnostics.ts
@@ -29,9 +29,7 @@ export const getSyntaxErrors = async (services: LangiumServices, code: string): 
  */
 export const getLinkingErrors = async (services: LangiumServices, code: string): Promise<Diagnostic[]> => {
     const diagnostics = await getDiagnostics(services, code);
-    return diagnostics.filter(
-        (d) => d.severity === DiagnosticSeverity.Error && d.data?.code === 'linking-error',
-    );
+    return diagnostics.filter((d) => d.severity === DiagnosticSeverity.Error && d.data?.code === 'linking-error');
 };
 
 /**
@@ -48,7 +46,7 @@ const getDiagnostics = async (services: LangiumServices, code: string): Promise<
         validation: true,
     });
     return document.diagnostics ?? [];
-}
+};
 
 /**
  * The code contains syntax errors.

--- a/tests/language/formatting/creator.ts
+++ b/tests/language/formatting/creator.ts
@@ -5,7 +5,6 @@ import { Diagnostic } from 'vscode-languageserver-types';
 import { createSafeDsServices } from '../../../src/language/safe-ds-module.js';
 import { EmptyFileSystem } from 'langium';
 import { getSyntaxErrors } from '../../helpers/diagnostics.js';
-import { clearDocuments } from 'langium/test';
 
 const services = createSafeDsServices(EmptyFileSystem).SafeDs;
 const root = 'formatting';

--- a/tests/language/formatting/creator.ts
+++ b/tests/language/formatting/creator.ts
@@ -30,14 +30,12 @@ const createFormattingTest = async (relativeResourcePath: string): Promise<Forma
     const expectedFormattedCode = normalizeLineBreaks(parts[1]).trim();
 
     // Original code must not contain syntax errors
-    await clearDocuments(services);
     const syntaxErrorsInOriginalCode = await getSyntaxErrors(services, originalCode);
     if (syntaxErrorsInOriginalCode.length > 0) {
         return invalidTest(relativeResourcePath, new SyntaxErrorsInOriginalCodeError(syntaxErrorsInOriginalCode));
     }
 
     // Expected formatted code must not contain syntax errors
-    await clearDocuments(services);
     const syntaxErrorsInExpectedFormattedCode = await getSyntaxErrors(services, expectedFormattedCode);
     if (syntaxErrorsInExpectedFormattedCode.length > 0) {
         return invalidTest(

--- a/tests/language/helpers/safe-ds-node-mapper/assigneeToAssignedObjectOrUndefined.test.ts
+++ b/tests/language/helpers/safe-ds-node-mapper/assigneeToAssignedObjectOrUndefined.test.ts
@@ -25,7 +25,7 @@ describe('SafeDsNodeMapper', () => {
     });
 
     describe('assigneeToAssignedObjectOrUndefined', () => {
-        it('should return an empty list if passed undefined', async () => {
+        it('should return undefined if passed undefined', async () => {
             expect(nodeMapper.assigneeToAssignedObjectOrUndefined(undefined)?.$type).toBeUndefined();
         });
 

--- a/tests/language/partialEvaluation/creator.ts
+++ b/tests/language/partialEvaluation/creator.ts
@@ -10,7 +10,6 @@ import { URI } from 'vscode-uri';
 import { getSyntaxErrors, SyntaxErrorsInCodeError } from '../../helpers/diagnostics.js';
 import { EmptyFileSystem } from 'langium';
 import { createSafeDsServices } from '../../../src/language/safe-ds-module.js';
-import { clearDocuments } from 'langium/test';
 
 const services = createSafeDsServices(EmptyFileSystem).SafeDs;
 const root = 'partial evaluation';
@@ -41,7 +40,6 @@ const createPartialEvaluationTest = async (
         const code = fs.readFileSync(absolutePath).toString();
 
         // File must not contain any syntax errors
-        await clearDocuments(services);
         const syntaxErrors = await getSyntaxErrors(services, code);
         if (syntaxErrors.length > 0) {
             return invalidTest(

--- a/tests/language/scoping/creator.ts
+++ b/tests/language/scoping/creator.ts
@@ -10,7 +10,6 @@ import { URI } from 'vscode-uri';
 import { getSyntaxErrors, SyntaxErrorsInCodeError } from '../../helpers/diagnostics.js';
 import { EmptyFileSystem } from 'langium';
 import { createSafeDsServices } from '../../../src/language/safe-ds-module.js';
-import { clearDocuments } from 'langium/test';
 
 const services = createSafeDsServices(EmptyFileSystem).SafeDs;
 const root = 'scoping';
@@ -40,7 +39,6 @@ const createScopingTest = async (
         const code = fs.readFileSync(absolutePath).toString();
 
         // File must not contain any syntax errors
-        await clearDocuments(services);
         const syntaxErrors = await getSyntaxErrors(services, code);
         if (syntaxErrors.length > 0) {
             return invalidTest(

--- a/tests/language/typing/creator.ts
+++ b/tests/language/typing/creator.ts
@@ -10,7 +10,6 @@ import { URI } from 'vscode-uri';
 import { getSyntaxErrors, SyntaxErrorsInCodeError } from '../../helpers/diagnostics.js';
 import { EmptyFileSystem } from 'langium';
 import { createSafeDsServices } from '../../../src/language/safe-ds-module.js';
-import { clearDocuments } from 'langium/test';
 
 const services = createSafeDsServices(EmptyFileSystem).SafeDs;
 const root = 'typing';
@@ -40,7 +39,6 @@ const createTypingTest = async (
         const code = fs.readFileSync(absolutePath).toString();
 
         // File must not contain any syntax errors
-        await clearDocuments(services);
         const syntaxErrors = await getSyntaxErrors(services, code);
         if (syntaxErrors.length > 0) {
             return invalidTest(

--- a/tests/language/validation/creator.ts
+++ b/tests/language/validation/creator.ts
@@ -10,7 +10,6 @@ import { getSyntaxErrors, SyntaxErrorsInCodeError } from '../../helpers/diagnost
 import { EmptyFileSystem } from 'langium';
 import { createSafeDsServices } from '../../../src/language/safe-ds-module.js';
 import { DocumentUri, Range } from 'vscode-languageserver-types';
-import { clearDocuments } from 'langium/test';
 
 const services = createSafeDsServices(EmptyFileSystem).SafeDs;
 const root = 'validation';
@@ -39,7 +38,6 @@ const createValidationTest = async (
         const code = fs.readFileSync(absolutePath).toString();
 
         // File must not contain any syntax errors
-        await clearDocuments(services);
         const syntaxErrors = await getSyntaxErrors(services, code);
         if (syntaxErrors.length > 0) {
             return invalidTest(

--- a/tests/resources/validation/other/modules/must state package/stub file (only imports).sdsstub
+++ b/tests/resources/validation/other/modules/must state package/stub file (only imports).sdsstub
@@ -1,3 +1,3 @@
 // $TEST$ no error "A module with declarations must state its package."
 
-import myPackage
+from myPackage import MyClass


### PR DESCRIPTION
### Summary of Changes

The previous way to check for syntax errors in test resources did not fully take the semantics of promises into account. Thus, it could sometimes happen that syntax errors were missed. This PR rectifies this. As a side effect, the warnings `Attempted reference resolution before document reached ComputedScopes state` are gone too.