### PR TITLE
feat: error if function pointers are used

### DIFF
--- a/src/language/validation/other/expressions/references.ts
+++ b/src/language/validation/other/expressions/references.ts
@@ -1,9 +1,11 @@
 import {
     isSdsAnnotation,
     isSdsCall,
-    isSdsFunction, isSdsMemberAccess,
+    isSdsFunction,
+    isSdsMemberAccess,
     isSdsPipeline,
-    isSdsSchema, isSdsSegment,
+    isSdsSchema,
+    isSdsSegment,
     SdsReference,
 } from '../../../generated/ast.js';
 import { AstNode, ValidationAcceptor } from 'langium';
@@ -24,10 +26,14 @@ export const referenceMustNotBeFunctionPointer = (node: SdsReference, accept: Va
     }
 
     if (!isSdsCall(container)) {
-        accept('error', 'Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead.', {
-            node,
-            code: CODE_REFERENCE_FUNCTION_POINTER,
-        });
+        accept(
+            'error',
+            'Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead.',
+            {
+                node,
+                code: CODE_REFERENCE_FUNCTION_POINTER,
+            },
+        );
     }
 };
 

--- a/src/language/validation/other/expressions/references.ts
+++ b/src/language/validation/other/expressions/references.ts
@@ -1,7 +1,35 @@
-import { isSdsAnnotation, isSdsPipeline, isSdsSchema, SdsReference } from '../../../generated/ast.js';
-import { ValidationAcceptor } from 'langium';
+import {
+    isSdsAnnotation,
+    isSdsCall,
+    isSdsFunction, isSdsMemberAccess,
+    isSdsPipeline,
+    isSdsSchema, isSdsSegment,
+    SdsReference,
+} from '../../../generated/ast.js';
+import { AstNode, ValidationAcceptor } from 'langium';
 
+export const CODE_REFERENCE_FUNCTION_POINTER = 'reference/function-pointer';
 export const CODE_REFERENCE_TARGET = 'reference/target';
+
+export const referenceMustNotBeFunctionPointer = (node: SdsReference, accept: ValidationAcceptor): void => {
+    const target = node.target?.ref;
+    if (!isSdsFunction(target) && !isSdsSegment(target)) {
+        return;
+    }
+
+    //
+    let container: AstNode | undefined = node.$container;
+    if (isSdsMemberAccess(container) && node.$containerProperty === 'member') {
+        container = container.$container;
+    }
+
+    if (!isSdsCall(container)) {
+        accept('error', 'Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead.', {
+            node,
+            code: CODE_REFERENCE_FUNCTION_POINTER,
+        });
+    }
+};
 
 export const referenceTargetMustNotBeAnnotationPipelineOrSchema = (
     node: SdsReference,

--- a/src/language/validation/safe-ds-validator.ts
+++ b/src/language/validation/safe-ds-validator.ts
@@ -45,7 +45,10 @@ import {
 } from './other/types/callableTypes.js';
 import { typeArgumentListMustNotHavePositionalArgumentsAfterNamedArguments } from './other/types/typeArgumentLists.js';
 import { argumentListMustNotHavePositionalArgumentsAfterNamedArguments } from './other/argumentLists.js';
-import { referenceTargetMustNotBeAnnotationPipelineOrSchema } from './other/expressions/references.js';
+import {
+    referenceMustNotBeFunctionPointer,
+    referenceTargetMustNotBeAnnotationPipelineOrSchema,
+} from './other/expressions/references.js';
 import {
     annotationCallAnnotationShouldNotBeDeprecated,
     argumentCorrespondingParameterShouldNotBeDeprecated,
@@ -141,6 +144,7 @@ export const registerValidationChecks = function (services: SafeDsServices) {
         SdsPipeline: [pipelineMustContainUniqueNames],
         SdsPlaceholder: [placeholdersMustNotBeAnAlias, placeholderShouldBeUsed(services)],
         SdsReference: [
+            referenceMustNotBeFunctionPointer,
             referenceTargetMustNotBeAnnotationPipelineOrSchema,
             referenceTargetShouldNotBeDeprecated(services),
             referenceTargetShouldNotExperimental(services),

--- a/tests/resources/validation/other/expressions/references/function pointer/main.sdstest
+++ b/tests/resources/validation/other/expressions/references/function pointer/main.sdstest
@@ -1,0 +1,68 @@
+package tests.validation.other.expressions.references.target
+
+class MyClass {
+    fun myInstanceMethod()
+    static fun myStaticMethod()
+}
+
+fun myFunction1()
+fun myFunction2(p: Any)
+
+segment mySegment1() {}
+
+segment mySegment2() {
+    // $TEST$ error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    MyClass().»myInstanceMethod«;
+    // $TEST$ error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    MyClass().»myInstanceMethod«.a;
+    // $TEST$ error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    MyClass().»myInstanceMethod«.a();
+    // $TEST$ error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    myFunction2(MyClass().»myInstanceMethod«);
+    // $TEST$ no error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    MyClass().»myInstanceMethod«();
+
+    // $TEST$ error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    MyClass.»myStaticMethod«;
+    // $TEST$ error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    MyClass.»myStaticMethod«.a;
+    // $TEST$ error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    MyClass.»myStaticMethod«.a();
+    // $TEST$ error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    myFunction2(MyClass.»myStaticMethod«);
+    // $TEST$ no error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    MyClass.»myStaticMethod«();
+
+    // $TEST$ error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    »myFunction1«;
+    // $TEST$ error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    »myFunction1«.a;
+    // $TEST$ error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    »myFunction1«.a();
+    // $TEST$ error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    myFunction2(»myFunction1«);
+    // $TEST$ no error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    »myFunction1«();
+
+    // $TEST$ error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    »mySegment1«;
+    // $TEST$ error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    »mySegment1«.a;
+    // $TEST$ error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    »mySegment1«.a();
+    // $TEST$ error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    myFunction2(»mySegment1«);
+    // $TEST$ no error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    »mySegment1«();
+
+    // $TEST$ no error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    »unresolved«;
+    // $TEST$ no error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    »unresolved«.a;
+    // $TEST$ no error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    »unresolved«.a();
+    // $TEST$ no error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    myFunction2(»unresolved«);
+    // $TEST$ no error "Function pointers are not allowed to provide a cleaner graphical view. Use a lambda instead."
+    »unresolved«();
+}


### PR DESCRIPTION
Closes #565
Closes partially #543

### Summary of Changes

To provide a cleaner graphical view, this PR makes the use of function pointers (to functions/segments) an error. Lambdas can be used instead.