### PR TITLE
feat: error if single use annotations are used multiple times

### DIFF
--- a/src/language/builtins/safe-ds-annotations.ts
+++ b/src/language/builtins/safe-ds-annotations.ts
@@ -31,6 +31,14 @@ export class SafeDsAnnotations extends SafeDsModuleMembers<SdsAnnotation> {
         return this.getAnnotation(CORE_ANNOTATIONS_URI, 'Expert');
     }
 
+    isRepeatable(node: SdsAnnotation | undefined): boolean {
+        return this.hasAnnotationCallOf(node, this.Repeatable);
+    }
+
+    private get Repeatable(): SdsAnnotation | undefined {
+        return this.getAnnotation(CORE_ANNOTATIONS_URI, 'Repeatable');
+    }
+
     private hasAnnotationCallOf(node: SdsAnnotatedObject | undefined, expected: SdsAnnotation | undefined): boolean {
         return annotationCallsOrEmpty(node).some((it) => {
             const actual = it.annotation?.ref;

--- a/src/language/validation/builtins/repeatable.ts
+++ b/src/language/validation/builtins/repeatable.ts
@@ -1,0 +1,22 @@
+import { ValidationAcceptor } from 'langium';
+import { SdsAnnotatedObject } from '../../generated/ast.js';
+import { SafeDsServices } from '../../safe-ds-module.js';
+import { annotationCallsOrEmpty } from '../../helpers/nodeProperties.js';
+import { duplicatesBy } from '../../helpers/collectionUtils.js';
+
+export const CODE_ANNOTATION_NOT_REPEATABLE = 'annotation/not-repeatable';
+
+export const singleUseAnnotationsMustNotBeRepeated =
+    (services: SafeDsServices) => (node: SdsAnnotatedObject, accept: ValidationAcceptor) => {
+        const callsOfSingleUseAnnotations = annotationCallsOrEmpty(node).filter((it) => {
+            const annotation = it.annotation?.ref;
+            return annotation && !services.builtins.Annotations.isRepeatable(annotation);
+        });
+
+        for (const duplicate of duplicatesBy(callsOfSingleUseAnnotations, (it) => it.annotation?.ref)) {
+            accept('error', `The annotation '${duplicate.annotation.$refText}' is not repeatable.`, {
+                node: duplicate,
+                code: CODE_ANNOTATION_NOT_REPEATABLE,
+            });
+        }
+    };

--- a/src/language/validation/safe-ds-validator.ts
+++ b/src/language/validation/safe-ds-validator.ts
@@ -76,6 +76,7 @@ import {
 } from './other/declarations/annotationCalls.js';
 import { memberAccessMustBeNullSafeIfReceiverIsNullable } from './other/expressions/memberAccesses.js';
 import { importPackageMustExist, importPackageShouldNotBeEmpty } from './other/imports.js';
+import {singleUseAnnotationsMustNotBeRepeated} from "./builtins/repeatable.js";
 
 /**
  * Register custom validation checks.
@@ -97,6 +98,9 @@ export const registerValidationChecks = function (services: SafeDsServices) {
             annotationCallAnnotationShouldNotBeDeprecated(services),
             annotationCallAnnotationShouldNotBeExperimental(services),
             annotationCallArgumentListShouldBeNeeded,
+        ],
+        SdsAnnotatedObject: [
+            singleUseAnnotationsMustNotBeRepeated(services),
         ],
         SdsArgument: [
             argumentCorrespondingParameterShouldNotBeDeprecated(services),

--- a/src/language/validation/safe-ds-validator.ts
+++ b/src/language/validation/safe-ds-validator.ts
@@ -76,7 +76,7 @@ import {
 } from './other/declarations/annotationCalls.js';
 import { memberAccessMustBeNullSafeIfReceiverIsNullable } from './other/expressions/memberAccesses.js';
 import { importPackageMustExist, importPackageShouldNotBeEmpty } from './other/imports.js';
-import {singleUseAnnotationsMustNotBeRepeated} from "./builtins/repeatable.js";
+import { singleUseAnnotationsMustNotBeRepeated } from './builtins/repeatable.js';
 
 /**
  * Register custom validation checks.
@@ -99,9 +99,7 @@ export const registerValidationChecks = function (services: SafeDsServices) {
             annotationCallAnnotationShouldNotBeExperimental(services),
             annotationCallArgumentListShouldBeNeeded,
         ],
-        SdsAnnotatedObject: [
-            singleUseAnnotationsMustNotBeRepeated(services),
-        ],
+        SdsAnnotatedObject: [singleUseAnnotationsMustNotBeRepeated(services)],
         SdsArgument: [
             argumentCorrespondingParameterShouldNotBeDeprecated(services),
             argumentCorrespondingParameterShouldNotBeExperimental(services),

--- a/tests/resources/validation/builtins/annotations/repeatable/main.sdstest
+++ b/tests/resources/validation/builtins/annotations/repeatable/main.sdstest
@@ -1,0 +1,24 @@
+package tests.validation.builtins.annotations.repeatable
+
+annotation SingleUse
+
+@Repeatable
+annotation MultiUse
+
+// $TEST$ no error r"The annotation '\w*' is not repeatable\."
+»@SingleUse«
+// $TEST$ no error r"The annotation '\w*' is not repeatable\."
+»@MultiUse«
+// $TEST$ no error r"The annotation '\w*' is not repeatable\."
+»@MultiUse«
+// $TEST$ no error r"The annotation '\w*' is not repeatable\."
+»@UnresolvedAnnotation«
+// $TEST$ no error r"The annotation '\w*' is not repeatable\."
+»@UnresolvedAnnotation«
+class CorrectUse
+
+// $TEST$ no error r"The annotation '\w*' is not repeatable\."
+»@SingleUse«
+// $TEST$ error "The annotation 'SingleUse' is not repeatable."
+»@SingleUse«
+class IncorrectUse

--- a/tests/resources/validation/other/statements/assignments/nothing assigned/main.sdstest
+++ b/tests/resources/validation/other/statements/assignments/nothing assigned/main.sdstest
@@ -58,6 +58,7 @@ segment mySegment() -> (
     // $TEST$ error "No value is assigned to this assignee."
     »val k«, »val l« = unresolved();
 
+
     // $TEST$ error "No value is assigned to this assignee."
     »yield r1« = noResults();
     // $TEST$ no error "No value is assigned to this assignee."


### PR DESCRIPTION
Closes partially #543

### Summary of Changes

Show an error if annotation that is not repeatable (default, unless it has the `@Repeatable` annotation) is repeated.