### PR TITLE
fix: duplicate error if annotation call has no argument list and lacks required parameters

### DIFF
--- a/src/language/validation/other/argumentLists.ts
+++ b/src/language/validation/other/argumentLists.ts
@@ -104,9 +104,13 @@ export const argumentListMustSetAllRequiredParameters = (services: SafeDsService
     const nodeMapper = services.helpers.NodeMapper;
 
     return (node: SdsAbstractCall, accept: ValidationAcceptor): void => {
-        const callable = nodeMapper.callToCallableOrUndefined(node);
+        // We already report other errors in this case
+        if (!node.argumentList) {
+            return;
+        }
 
         // We already report other errors in those cases
+        const callable = nodeMapper.callToCallableOrUndefined(node);
         if (!callable || (isSdsCall(node) && isSdsAnnotation(callable))) {
             return;
         }

--- a/tests/resources/validation/other/argument lists/missing required parameter/dont show this error if the argument list is missing altogether.sdstest
+++ b/tests/resources/validation/other/argument lists/missing required parameter/dont show this error if the argument list is missing altogether.sdstest
@@ -1,0 +1,21 @@
+package tests.validation.other.argumentLists.missingRequiredParameter
+
+// $TEST$ no error r"The parameters? .* must be set here\."
+
+@MyAnnotation
+segment mySegment2(
+    myCallableType: (a: Int, b: Int, c: Int = 0) -> ()
+) {
+    val myBlockLambda = (a: Int, b: Int, c: Int = 0) {};
+    val myExpressionLambda = (a: Int, b: Int, c: Int = 0) -> 1;
+
+    MyAnnotation;
+    MyClass;
+    MyEnum.MyEnumVariant;
+    myFunction;
+    mySegment1;
+    myCallableType;
+    myBlockLambda;
+    myExpressionLambda;
+    myPipeline;
+}


### PR DESCRIPTION
### Summary of Changes

If an annotation call had no argument list and did not set some required parameters, two separate errors were shown in the same place. This PR hides one of them.