### PR TITLE
docs: syntax highlighting in documentation

### DIFF
--- a/.github/linters/.ruff.toml
+++ b/.github/linters/.ruff.toml
@@ -71,6 +71,8 @@ ignore = [
     "RET507",
     # superfluous-else-break (sometimes it's more readable)
     "RET508",
+    # mutable-class-default (not helpful for the lexer)
+    "RUF012",
     # private-member-access (we cannot always avoid it if we want a clean API)
     "SLF001",
     # if-else-block-instead-of-if-exp (an if-else block can be more readable)

--- a/docs/development/formatting-testing.md
+++ b/docs/development/formatting-testing.md
@@ -14,7 +14,7 @@ formatting test.
 
 2. Add the original unformatted Safe-DS code to the top of the file. The code must be syntactically valid.
 3. Add the following separator to the file:
-    ```txt
+    ```sds
     // -----------------------------------------------------------------------------
     ```
 4. Add the expected formatted Safe-DS code to the file below the separator.

--- a/docs/language/common/comments.md
+++ b/docs/language/common/comments.md
@@ -8,7 +8,7 @@ Safe-DS has two types of comments, namely _line comments_, which end at a linebr
 
 Line comments stop at the end of a line:
 
-```txt
+```sds
 // This is a comment.
 ```
 
@@ -18,7 +18,7 @@ As we can see here, they start with two slashes. There must be no space between 
 
 Block comments have a start and end delimiter, which allows them to cover multiple lines:
 
-```txt
+```sds
 /*
 This
 is

--- a/docs/language/common/imports.md
+++ b/docs/language/common/imports.md
@@ -8,7 +8,7 @@ Safe-DS has two kinds of imports, namely a _qualified import_, which imports a s
 
 A _qualified import_ makes a single declaration available. Here is an example that imports the [class][classes] `DecisionTree` in the [package][packages] `safeds.model.regression`:
 
-```txt
+```sds
 from safeds.model.regression import DecisionTree
 ```
 
@@ -21,13 +21,13 @@ The syntax consists of the following parts:
 
 Once the declaration is imported, we can refer to it by its name. Here is, for example, a [call][calls] to the constructor of the `DecisionTree` class:
 
-```txt
+```sds
 DecisionTree()
 ```
 
 Multiple declarations can be imported from the same package in a single import statement by separating them with commas:
 
-```txt
+```sds
 from safeds.model.regression import DecisionTree, RandomForest
 ```
 
@@ -35,7 +35,7 @@ from safeds.model.regression import DecisionTree, RandomForest
 
 Sometimes the name of the imported declaration can conflict with other declarations that are imported or that are contained in the importing file. To counter this, declarations can be imported under an alias:
 
-```txt
+```sds
 from safeds.model.regression import DecisionTree as StdlibDecisionTree
 ```
 
@@ -50,13 +50,13 @@ Let us take apart the syntax:
 
 Afterwards, the declaration can **only** be accessed using the alias. The next example shows how to create a new instance of the class now by invoking its constructor:
 
-```txt
+```sds
 StdlibDecisionTree()
 ```
 
 Multiple declarations can be imported with or without an alias in a single import statement by separating them with commas:
 
-```txt
+```sds
 from safeds.model.regression import DecisionTree as StdlibDecisionTree, RandomForest
 ```
 
@@ -66,7 +66,7 @@ We can also import all declarations in a [package][packages] with a single impor
 
 Nevertheless, let us look at an example, which imports all declarations from the [package][packages] `safeds.model.regression`:
 
-```txt
+```sds
 from safeds.model.regression import *
 ```
 
@@ -79,7 +79,7 @@ Here is the breakdown of the syntax:
 
 Afterwards, we can again access declarations by their simple name, such as the [class][classes] `DecisionTree`:
 
-```txt
+```sds
 DecisionTree()
 ```
 

--- a/docs/language/common/packages.md
+++ b/docs/language/common/packages.md
@@ -2,7 +2,7 @@
 
 _Packages_ are used to prevent conflicts when multiple files have declarations with the same name. They accomplish this by grouping all declarations in a file into a namespace. Here is an example for a package declaration:
 
-```txt
+```sds
 package de.unibonn.speedPrediction
 ```
 
@@ -35,7 +35,7 @@ class DecisionTree:
 
 This file contains the actual implementation of the Python class `DecisionTree`. We now want to make this Python class available in Safe-DS, which requires the following Safe-DS stub file:
 
-```txt
+```sds
 // Safe-DS file "safeds/model/regression/_decision_tree/DecisionTree.sdsstub"
 
 package safeds.model.regression._decision_tree
@@ -85,7 +85,7 @@ from safeds.model.regression import DecisionTree
 
 Note the omission of the suffix `._decision_tree` after `safeds.model.regression`. Likewise, we can now update the Safe-DS stub code. We again just take everything between `from` and `import` and use this as the Safe-DS package name:
 
-```txt
+```sds
 // Safe-DS file "safeds/model/regression/DecisionTree.sdsstub"
 
 package safeds.model.regression
@@ -115,7 +115,7 @@ class DecisionTree:
 
 Our original solution leads to a warning because the Safe-DS package name contains the segment `_decision_tree`, which is not `lowerCamelCase` due to the underscores:
 
-```txt
+```sds
 // Safe-DS file "safeds/model/regression/_decision_tree/DecisionTree.sdsstub"
 
 package safeds.model.regression._decision_tree
@@ -125,7 +125,7 @@ class DecisionTree()
 
 By [calling][annotation-calls] the [annotation][annotations] `@PythonModule`, we can also specify the corresponding [Python module][python-modules], however. If this [annotation][annotations] is [called][annotation-calls], it takes precedence over the Safe-DS package name. This allows us to pick an arbitrary Safe-DS package that respects the Safe-DS naming convention. We can even group multiple [Python modules][python-modules] together in one Safe-DS package without relying on Python's `__init__.py` files:
 
-```txt
+```sds
 // Safe-DS file "safeds/model/regression/DecisionTree.sdsstub"
 
 @PythonModule("safeds.model.regression._decision_tree")
@@ -140,7 +140,7 @@ Here is a breakdown of this:
 - We [call][annotation-calls] the `@PythonModule` [annotation][annotations] before we declare the Safe-DS package. The [Python module][python-modules] that exports the Python declarations that correspond to the Safe-DS declarations in this stub file is passed as a [string literal][string-literals] (here `safeds.model.regression._decision_tree`). This is used only for code generation and does not affect users of Safe-DS.
 - We specify the Safe-DS package as usual. This must be used when we [import][imports] the declaration in another Safe-DS file:
 
-    ```txt
+    ```sds
     // Safe-DS
 
     from safeds.model.regression import DecisionTree

--- a/docs/language/common/parameters.md
+++ b/docs/language/common/parameters.md
@@ -9,7 +9,7 @@ _Parameters_ define the expected inputs of some declaration that can be [called]
 
 _Required parameters_ must always be passed when the declaration is [called][calls]. Let us look at an example:
 
-```txt
+```sds
 requiredParameter: Int
 ```
 
@@ -23,7 +23,7 @@ Here are the pieces of syntax:
 
 _Optional parameters_ have a default value and, thus, need not be passed as an [argument][calls] unless the default value does not fit. Here is an example:
 
-```txt
+```sds
 optionalParameter: Int = 1
 ```
 
@@ -39,7 +39,7 @@ These are the syntactic elements:
 
 Let us now look at a full example of a [segment][segments] called `doSomething` with one [required parameter](#required-parameters) and one [optional parameter](#optional-parameters):
 
-```txt
+```sds
 segment doSomething(requiredParameter: Int, optionalParameter: Boolean = false) {
     // ...
 }
@@ -81,7 +81,7 @@ def accuracy(x_pred: Dataset, x_test: Dataset) -> float:
     pass
 ```
 
-```txt
+```sds
 // Safe-DS code
 
 fun accuracy(
@@ -121,7 +121,7 @@ def required(a: int):
     pass
 ```
 
-```txt
+```sds
 // Safe-DS code
 
 fun required(a: Int)
@@ -136,7 +136,7 @@ def optional(a: int = 1):
     pass
 ```
 
-```txt
+```sds
 // Safe-DS code
 
 fun optional(a: Int = 1)

--- a/docs/language/common/results.md
+++ b/docs/language/common/results.md
@@ -2,7 +2,7 @@
 
 _Results_ define the outputs of some declaration when it is [called][calls]. Here is an example:
 
-```txt
+```sds
 result: Int
 ```
 
@@ -16,7 +16,7 @@ Here is a breakdown of the syntax:
 
 Let us now look at a full example of a [segment][segments] called `doSomething` with two results:
 
-```txt
+```sds
 segment doSomething() -> (result1: Int, result2: Boolean) {
     // ...
 }
@@ -33,11 +33,11 @@ The interesting part is the list of results, which uses the following syntactic 
 
 In case that the callable produces only a single result, we can omit the parentheses. The following two declarations are, hence, equivalent:
 
-```txt
+```sds
 segment doSomething1() -> (result: Int) {}
 ```
 
-```txt
+```sds
 segment doSomething2() -> result: Int {}
 ```
 
@@ -45,11 +45,11 @@ segment doSomething2() -> result: Int {}
 
 In case that the callable produces no results, we can usually omit the entire results list. The following two declarations are, hence equivalent:
 
-```txt
+```sds
 segment doSomething1() -> () {}
 ```
 
-```txt
+```sds
 segment doSomething2() {}
 ```
 

--- a/docs/language/common/results.md
+++ b/docs/language/common/results.md
@@ -66,6 +66,6 @@ Since Python results do not have a name, the names of Safe-DS results can be arb
 [stub-language]: ../stub-language/README.md
 [types]: types.md
 [types-python]: types.md#corresponding-python-code
-[callable-types]: types.md#callable-type
+[callable-types]: types.md#callable-types
 [segments]: ../pipeline-language/segments.md
 [calls]: ../pipeline-language/expressions.md#calls

--- a/docs/language/common/types.md
+++ b/docs/language/common/types.md
@@ -12,7 +12,7 @@ _Named types_ either denote that a declaration must be an instance of a [class][
 
 A declaration with a _class type_ must be an instance of a [class][classes] or one of its [subclasses][subclassing]. Let us use the following [classes][classes] for our example:
 
-```txt
+```sds
 class SomeClass
 
 class SomeSubclass sub SomeClass
@@ -20,7 +20,7 @@ class SomeSubclass sub SomeClass
 
 To denote that a declaration accepts instances of `SomeClass` and its [subclass][subclassing] `SomeSubclass`, we write the name of the class as the type:
 
-```txt
+```sds
 SomeClass
 ```
 
@@ -30,7 +30,7 @@ The value `null` (see [null][null-literal]) deserves special treatment since it 
 
 To specifically allow `null` as a value, simply add a question mark to the named type:
 
-```txt
+```sds
 SomeClass?
 ```
 
@@ -38,7 +38,7 @@ SomeClass?
 
 A declaration with an _enum type_ must be one of the [variants][variants] of the [enum][enums]. Let us use the following [enum][enums] for our example:
 
-```txt
+```sds
 enum SomeEnum {
     SomeEnumVariant,
     SomeOtherEnumVariant(count: Int)
@@ -47,7 +47,7 @@ enum SomeEnum {
 
 To denote that a declaration accepts instances of any [variant][variants] of `SomeEnum`, use the name of the enum as the type:
 
-```txt
+```sds
 SomeEnum
 ```
 
@@ -59,7 +59,7 @@ This type expects either the value `SomeEnum.SomeEnumVariant` (see [member acces
 
 If a declaration has [type parameters][type-parameters] we need to assign all of them when we use the declaration as a named type. This assignment happens in the form of _type arguments_. We explain this using the following declaration:
 
-```txt
+```sds
 class SomeSpecialList<T>
 ```
 
@@ -71,7 +71,7 @@ If a positional type argument is used, we just write down its value, which is a 
 
 For example, if we expect a list of integers, we could use the following type:
 
-```txt
+```sds
 SomeSpecialList<Int>
 ```
 
@@ -84,7 +84,7 @@ Let us break down the syntax:
 
 When a named type argument is used, we explicitly specify the [type parameter][type-parameters] that we want to assign. This allows us to specify them in any order. It can also improve the clarity of the code since the meaning of the type argument becomes more apparent. Here is the type for our list of integers when a named argument is used:
 
-```txt
+```sds
 SomeSpecialList<T = Int>
 ```
 
@@ -102,7 +102,7 @@ Within a list of type arguments both positional and named type arguments can be 
 
 Let us finally look at how multiple type arguments are passed. For this we use the following declaration:
 
-```txt
+```sds
 class SomeSpecialMap<K, V>
 ```
 
@@ -110,7 +110,7 @@ This [class][classes] has to [type parameters][type-parameters], namely `K` and 
 
 Here is a valid use:
 
-```txt
+```sds
 SomeSpecialMap<String, V = Int>
 ```
 
@@ -127,7 +127,7 @@ We will now look at the values that we can pass within type arguments.
 
 The most basic case is that we pass a concrete type as the value. We have already seen this in the example above where we constructed the type for a list of integers:
 
-```txt
+```sds
 SomeSpecialList<Int>
 ```
 
@@ -141,7 +141,7 @@ A member type is essentially the same as a [named type](#named-types) with the d
 
 We begin with nested classes and use these declarations to illustrate the concept:
 
-```txt
+```sds
 class SomeOuterClass {
     class SomeInnerClass
 }
@@ -149,7 +149,7 @@ class SomeOuterClass {
 
 To specify that a declaration accepts instances of `SomeInnerClass` or its [subclasses][subclassing], use the following member type:
 
-```txt
+```sds
 SomeOuterClass.SomeInnerClass
 ```
 
@@ -161,7 +161,7 @@ This has the following syntactic elements:
 
 Classes can be nested multiple levels deep. In this case, use a member access for each level. Let us use the following declarations to explain this:
 
-```txt
+```sds
 class SomeOuterClass {
     class SomeMiddleClass {
         class SomeInnerClass
@@ -171,13 +171,13 @@ class SomeOuterClass {
 
 To specify that a declaration accepts instances of `SomeInnerClass`, or its [subclasses][subclassing], use the following member type:
 
-```txt
+```sds
 SomeOuterClass.SomeMiddleClass.SomeInnerClass
 ```
 
 If any referenced class has [type parameters][type-parameters] these must be specified by [type arguments](#type-arguments). For this we use these declarations:
 
-```txt
+```sds
 class SomeOuterClass<A> {
     class SomeInnerClass<B>
 }
@@ -185,13 +185,13 @@ class SomeOuterClass<A> {
 
 To specify that a declaration accepts instances of `SomeInnerClass` where all type parameters are set to `Int`, or its [subclasses][subclassing], use the following member type:
 
-```txt
+```sds
 SomeOuterClass<Int>.SomeInnerClass<Int>
 ```
 
 Finally, as with [named types](#named-types), `null` is not an allowed value by default. To allow it, add a question mark at the end of the member type. This can be used independently from [type arguments](#type-arguments):
 
-```txt
+```sds
 SomeOuterClass<Int>.SomeInnerClass<Int>?
 ```
 
@@ -199,7 +199,7 @@ SomeOuterClass<Int>.SomeInnerClass<Int>?
 
 Member types are also used to specify that a declaration is an instance of a single [variant][variants] of an [enum][enums]. For this, we use the following declarations:
 
-```txt
+```sds
 enum SomeEnum {
     SomeEnumVariant(count: Int),
     SomeOtherEnumVariant
@@ -208,7 +208,7 @@ enum SomeEnum {
 
 To allow only instances of the [variant][variants] `SomeEnumVariant`, use the following member type:
 
-```txt
+```sds
 SomeEnum.SomeEnumVariant
 ```
 
@@ -220,7 +220,7 @@ Let us take apart the syntax:
 
 Identical to [class member types](#class-member-types), all [type parameters][type-parameters] of the [enum variant][variants] must be assigned by [type arguments](#type-arguments). We use these declarations to explain the concept:
 
-```txt
+```sds
 enum SomeEnum {
     SomeEnumVariant<T>(value: T),
     SomeOtherEnumVariant
@@ -229,7 +229,7 @@ enum SomeEnum {
 
 To now allow only instances of the [variant][variants] `SomeEnumVariant` with `Int` values, use the following member type:
 
-```txt
+```sds
 SomeEnum.SomeEnumVariant<Int>
 ```
 
@@ -237,7 +237,7 @@ SomeEnum.SomeEnumVariant<Int>
 
 If a declaration can have one of multiple types you can denote that with a _union type_:
 
-```txt
+```sds
 union<String, Int>
 ```
 
@@ -263,7 +263,7 @@ A _callable type_ denotes that only values that can be [called][calls] are accep
 
 Additionally, a callable types specifies the names and types of parameters and results. Here is the most basic callable type that expects neither parameters nor results:
 
-```txt
+```sds
 () -> ()
 ```
 
@@ -275,7 +275,7 @@ Let us break down the syntax:
 
 We can now add some expected [parameters][parameters]:
 
-```txt
+```sds
 (a: Int, b: Int) -> ()
 ```
 
@@ -290,7 +290,7 @@ These are the syntactic elements:
 
 Finally, we can add some expected [results][results]:
 
-```txt
+```sds
 (a: Int, b: Int) -> (r: Int, s: Int)
 ```
 
@@ -305,7 +305,7 @@ The syntax is reminiscent of the notation for [parameters][parameters]:
 
 If exactly one result is expected, the surrounding parentheses may be also removed:
 
-```txt
+```sds
 (a: Int, b: Int) -> r: Int
 ```
 
@@ -348,7 +348,7 @@ The following table shows how Safe-DS types can be written as Python [type hints
 
 Most of these are rather self-explanatory. We will, however, cover the translation of [callable types](#callable-types) in a little more detail: In Python, the type hint for a callable type has the following general syntax:
 
-```txt
+```sds
 Callable[<list of parameter types>, <result type>]
 ```
 

--- a/docs/language/common/variance.md
+++ b/docs/language/common/variance.md
@@ -4,7 +4,7 @@
 
 Variance deals with the question, which generic types are compatible with each other. We explain this concept using the following [class][classes]:
 
-```txt
+```sds
 class Stack<T>(initialElements: List<T>) {
     fun push(element: T)
 
@@ -42,7 +42,7 @@ As outlined above, we can only allow covariance if we forbid writing access. Thi
 
 In the `Stack` example, we can make the [class][classes] covariant by adding the keyword `out` to the [type parameter][type-parameters] `T` and removing the writing [method][methods] `push`:
 
-```txt
+```sds
 class Stack<out T> {
     fun pop() -> element: T
 }
@@ -56,7 +56,7 @@ As outlined above, we can only allow contravariance if we forbid reading access.
 
 In the `Stack` example, we can make the [class][classes] contravariant by adding the keyword `in` to the [type parameter][type-parameters] `T` and removing the reading [method][methods] `pop`:
 
-```txt
+```sds
 class Stack<in T> {
     fun push(element: T)
 }

--- a/docs/language/pipeline-language/expressions.md
+++ b/docs/language/pipeline-language/expressions.md
@@ -36,7 +36,7 @@ String literals describe text. Their syntax is simply text enclosed by double qu
 
 String literals can contain also contain raw line breaks:
 
-```txt
+```sds
 "Hello,
 
 world!"
@@ -120,7 +120,7 @@ Safe-DS also has shorthand versions for negated equality checks which should be 
 
 The elvis operator `?:` (given its name because it resembles Elvis's haircut) is used to specify a default value that should be used instead if the left operand is `null`. This operator is not short-circuited, so both operand are always evaluated. In the following example the whole expression evaluates to `nullableExpression` if this value is not `null` and to `42` if it is:
 
-```txt
+```sds
 nullableExpression ?: 42
 ```
 
@@ -128,7 +128,7 @@ nullableExpression ?: 42
 
 [String literals](#string-literals) can only be used to denote a fixed string. Sometimes, however, parts of the string have to be computed and then interpolated into the remaining text. This is done with template strings. Here is an example:
 
-```txt
+```sds
 "1 + 2 = {{ 1 + 2 }}"
 ```
 
@@ -140,7 +140,7 @@ These template expressions are evaluated, converted to a string and inserted int
 
 References are used to refer to a declaration, such as a [class][classes] or a [placeholder][placeholders]. The syntax is simply the name of the declaration, as shown in the next snippet where we first declare a [placeholder][placeholders] called `one` and then refer to it when computing the value for the [placeholder][placeholders] called `two`:
 
-```txt
+```sds
 val one = 1;
 val two = one + one;
 ```
@@ -153,7 +153,7 @@ Calls are used to trigger the execution of a specific action, which can, for exa
 
 First, we show the code of the [segment][segments] that we want to call.
 
-```txt
+```sds
 segment createDecisionTree(maxDepth: Int = 10) {
     // ... do something ...
 }
@@ -161,7 +161,7 @@ segment createDecisionTree(maxDepth: Int = 10) {
 
 This [segment][segments] has a single [parameter][parameters] `maxDepth`, which must have [type][types] `Int`, and has the default value `10`. Since it has a default value, we are not required to specify a value when we call this [segment][segments]. The most basic legal call of the [segment][segments] is, thus, this:
 
-```txt
+```sds
 createDecisionTree()
 ```
 
@@ -176,7 +176,7 @@ If we want to override the default value of an optional [parameter][parameters] 
 
 In the case of positional arguments, they are mapped to parameters by position, i.e. the first argument is assigned to the first parameter, the second argument is assigned to the second parameter and so forth. We do this in the following example to set `maxDepth` to 5:
 
-```txt
+```sds
 createDecisionTree(5)
 ```
 
@@ -184,7 +184,7 @@ The syntax for positional argument is simply the expression we want to pass as v
 
 Named arguments, however, are mapped to parameters by name. On the one hand, this can improve readability of the code, since the meaning of a value becomes obvious. On the other hand, it allows to override only specific optional parameters and keep the rest unchanged. Here is how to set `maxDepth` to 5 using a named argument:
 
-```txt
+```sds
 createDecisionTree(maxDepth = 5)
 ```
 
@@ -198,7 +198,7 @@ These are the syntactic elements:
 
 We now add another parameter to the `createDecisionTree` [segment][segments]:
 
-```txt
+```sds
 segment createDecisionTree(isBinary: Boolean, maxDepth: Int = 10) {
     // ... do something ...
 }
@@ -206,7 +206,7 @@ segment createDecisionTree(isBinary: Boolean, maxDepth: Int = 10) {
 
 This allows us to show how multiple arguments can be passed:
 
-```txt
+```sds
 createDecisionTree(isBinary = true, maxDepth = 5)
 ```
 
@@ -258,7 +258,7 @@ A member access is used to refer to members of a complex data structure such as
 
 The general syntax of a member access is this:
 
-```txt
+```sds
 <receiver>.<member>
 ```
 
@@ -268,7 +268,7 @@ Here, the receiver is some expression (the legal choices are explained below), w
 
 To understand how we can access members of a [class][classes] we must first look briefly at a declaration of the [class][classes] we use in the following examples:
 
-```txt
+```sds
 class DecisionTree() {
     static attr verboseTraining: Boolean
 
@@ -284,7 +284,7 @@ Moreover, the class has an instance [attribute][attributes]`maxDepth`, which is 
 
 Let us look at how to access the static [attribute][attributes] `verboseTraining` to retrieve its value:
 
-```txt
+```sds
 DecisionTree.verboseTraining
 ```
 
@@ -300,7 +300,7 @@ Note that we cannot access a static member from an instance of the class. We mus
 
 Contrary to static member accesses, we can only access instance members on an instance of a class:
 
-```txt
+```sds
 DecisionTree().maxDepth
 ```
 
@@ -318,7 +318,7 @@ If an expression could be `null` it cannot be used as the receiver of a regular 
 
 The syntax is identical to a normal member access except that we replace the dot with the operator `?.`:
 
-```txt
+```sds
 nullableExpression?.member
 ```
 
@@ -326,7 +326,7 @@ nullableExpression?.member
 
 A member access can also be used to access the [variants][enum-variants] of an [enum][enums]. Here is the declaration of the [enum][enums] that we use in the example:
 
-```txt
+```sds
 enum SvmKernel {
     Linear,
     RBF
@@ -337,7 +337,7 @@ This [enum][enums] is called `SvmKernel` and has the two [variants][enum-variant
 
 We can access the [variant][enum-variants] `Linear` using this member access:
 
-```txt
+```sds
 SvmKernel.Linear
 ```
 
@@ -353,7 +353,7 @@ This syntax is identical to the [member access of static class members](#member-
 
 If the [result record](#result-record) that is produced by a [call](#calls) has multiple results, we can use a member access to select a single one. Here is the [global function][global-functions] we use to explain this concept:
 
-```txt
+```sds
 fun divideWithRemainder(dividend: Int, divisor: Int) -> (quotient: Int, remainder: Int)
 ```
 
@@ -361,7 +361,7 @@ The [global function][global-functions] `divideWithRemainder` has two [parameter
 
 If we are only interested in the remainder of `12` divided by `5`, we can use a member access:
 
-```txt
+```sds
 divideWithRemainder(12, 5).remainder
 ```
 
@@ -375,7 +375,7 @@ While it is also possible to access the result by name if the [result record](#r
 
 To explain this concept further, we need the following declarations:
 
-```txt
+```sds
 class ValueWrapper {
     attr value: Int
 }
@@ -387,7 +387,7 @@ We first declare a [class][classes] called `ValueWrapper`, which has an [attribu
 
 Let us now look at this member access:
 
-```txt
+```sds
 createValueWrapper().value
 ```
 
@@ -395,7 +395,7 @@ This evaluates to the [attribute][attributes], i.e. an integer, rather than the 
 
 If you want the result instead, simply omit the member access:
 
-```txt
+```sds
 createValueWrapper()
 ```
 
@@ -403,7 +403,7 @@ createValueWrapper()
 
 An indexed access is currently only used to access elements of a list or values of a map by their key. In the following example, we use an index access to retrieve the first element of the `values` list:
 
-```txt
+```sds
 segment printFirst(values: List<Int>) {
     print(values[0]);
 }
@@ -422,7 +422,7 @@ Note that accessing a value at an index outside the bounds of the value list cur
 
 Multiple [calls](#calls), [member accesses](#member-accesses), and [indexed accesses](#member-accesses) can be chained together. Let us first look at the declaration of the [class][classes] we need for the example:
 
-```txt
+```sds
 class LinearRegression() {
     fun drawAsGraph()
 }
@@ -432,7 +432,7 @@ This is a [class][classes] `LinearRegression`, which has a constructor and an in
 
 We can then use those declarations in a [segment][segments]:
 
-```txt
+```sds
 segment mySegment(regressions: List<LinearRegression>) {
     regressions[0].drawAsGraph();
 }
@@ -450,7 +450,7 @@ In the body of the segment we then
 
 If you want to write reusable blocks of code, use a [segment][segments]. However, sometimes you need to create a highly application-specific callable that can be passed as argument to some function or returned as the result of a [segment][segments]. We will explain this concept by filtering a list. Here are the relevant declarations:
 
-```txt
+```sds
 class IntList {
     fun filter(filterFunction: (element: Int) -> shouldKeep: Boolean) -> filteredList: IntList
 }
@@ -464,7 +464,7 @@ Second, we declare a [global function][global-functions] `intListOf` that is sup
 
 Say, we now want to keep only the elements in the list that are less than `10`. We can do this by declaring a [segment][segments]:
 
-```txt
+```sds
 segment keepLessThan10(a: Int) -> shouldKeep: Boolean {
     yield shouldKeep = a < 10;
 }
@@ -472,7 +472,7 @@ segment keepLessThan10(a: Int) -> shouldKeep: Boolean {
 
 Here is how to solve the task of keeping only elements below `10` with this [segment][segments]:
 
-```txt
+```sds
 intListOf(1, 4, 11).filter(keepLessThan10)
 ```
 
@@ -484,7 +484,7 @@ The problem here is that this solution is very cumbersome and verbose. We need t
 
 We will first rewrite the above solution using a _block lambda_, which is essentially a [segment][segments] without a name and more concise syntax that can be declared where it is needed:
 
-```txt
+```sds
 intListOf(1, 4, 11).filter(
     (a) { yield shouldKeep = a < 10; }
 )
@@ -503,7 +503,7 @@ The results of a block lambda are [declared in its body using assignments][assig
 
 Often, the body of a [block lambda](#block-lambdas) only consists of yielding a single result, as is the case in the example above. The syntax of [block lambdas](#block-lambdas) is quite verbose for such a common use-case, which is why Safe-DS has _expression lambdas_ as a shorter but less flexible alternative. Using an expression lambda we can rewrite the example above as
 
-```txt
+```sds
 intListOf(1, 4, 11).filter(
     (a) -> a < 10
 )
@@ -521,7 +521,7 @@ These are the syntactic elements:
 
 Both [block lambdas](#block-lambdas) and [expression lambdas](#expression-lambdas) are closures, which means they remember the values of [placeholders][placeholders] and [parameters][parameters] that can be accessed within their body at the time of their creation. Here is an example:
 
-```txt
+```sds
 segment lazyValue(value: Int) -> result: () -> storedValue: Int {
     yield result = () -> value
 }

--- a/docs/language/pipeline-language/pipelines.md
+++ b/docs/language/pipeline-language/pipelines.md
@@ -8,7 +8,7 @@ Pipelines are data science programs designed to solve a specific task. They act 
 
 Let's look at a minimal example of a pipeline:
 
-```txt
+```sds
 pipeline predictSpeed {}
 ```
 
@@ -22,7 +22,7 @@ This declaration of a pipeline has the following syntactic elements:
 
 In order to describe what should be done when the pipeline is executed, we need to add [statements][statements] to its body, as shown in this example:
 
-```txt
+```sds
 pipeline predictSpeed {
     val adac = loadDataset("ADAC");
     val adacSample = adac.sample(1000);

--- a/docs/language/pipeline-language/segments.md
+++ b/docs/language/pipeline-language/segments.md
@@ -8,7 +8,7 @@ Segments are used to extract a sequence of [statements][statements] from a data 
 
 Let's look at a minimal example of a segment:
 
-```txt
+```sds
 segment loadMovieRatingsSample() {}
 ```
 
@@ -29,7 +29,7 @@ Parameters must be declared in the header of the segment so [callers](#calling-a
 
 In the following example, we give the segment a single parameters with name `nInstances` and [type][types] `Int`.
 
-```txt
+```sds
 segment loadMovieRatingsSample(nInstances: Int) {}
 ```
 
@@ -39,7 +39,7 @@ More information about parameters can be found in the [linked document][paramete
 
 Within the segment we can access the value of a parameter using a [reference][references]. Here is a basic example where we print the value of the `nInstances` parameter to the console:
 
-```txt
+```sds
 segment loadMovieRatingsSample(nInstances: Int) {
     print(nInstances);
 }
@@ -51,7 +51,7 @@ More information about references can be found in the [linked document][referenc
 
 In order to describe what should be done when the segment is executed, we need to add [statements][statements] to its body. The previous example in the section ["References to Parameters"](#references-to-parameters) already contained a statement - an [expression statement][expression-statements] to be precise. Here is another example, this time showing an [assignment][assignments]:
 
-```txt
+```sds
 segment loadMovieRatingsSample(nInstances: Int) {
     val movieRatingsSample = loadDataset("movieRatings").sample(nInstances = 1000);
 }
@@ -67,7 +67,7 @@ More information about statements can be found in the [linked document][statemen
 
 As with [parameters](#parameters) we first need to declare the available results in the headed. This tells [callers](#calling-a-segment) that they can use these results and reminds us to [assign a value to them](#assigning-to-results) in the body of the segment. Let's look at an example:
 
-```txt
+```sds
 segment loadMovieRatingsSample(nInstances: Int) -> (features: Dataset, target: Dataset) {
     val movieRatingsSample = loadDataset("movieRatings").sample(nInstances = 1000);
 }
@@ -81,7 +81,7 @@ More information about the declaration of results can be found in the [linked do
 
 Currently, the program will not compile since we never assigned a value to these results. This can be done with an [assignment][assignments] and the `yield` keyword:
 
-```txt
+```sds
 segment loadMovieRatingsSample(nInstances: Int) -> (features: Dataset, target: Dataset) {
     val movieRatingsSample = loadDataset("movieRatings").sample(nInstances = 1000);
     yield features = movieRatingsSample.keepAttributes(
@@ -103,7 +103,7 @@ The order of the [result declarations](#result-declaration) does not need to mat
 
 By default, a segment can be [imported][imports] in any other file and reused there. We say they have `public` visibility. However, it is possible to restrict the visibility of a segment with modifiers:
 
-```txt
+```sds
 internal segment internalSegment() {}
 
 private segment privateSegment() {}
@@ -115,7 +115,7 @@ The segment `internalSegment` is only visible in files with the same [package][p
 
 Inside a [pipeline][pipelines], another segment, or a [lambda][lambdas] we can then [call][calls] a segment, which means the segment is executed when the call is reached: The results of a segment can then be used as needed. In the following example, where we call the segment `loadMovieRatingsSample` that we defined above, we [assign the results to placeholders][assignments-to-placeholders]:
 
-```txt
+```sds
 val features, val target = loadMovieRatingsSample(nInstances = 1000);
 ```
 

--- a/docs/language/pipeline-language/segments.md
+++ b/docs/language/pipeline-language/segments.md
@@ -128,7 +128,7 @@ More information about calls can be found in the [linked document][calls].
 [packages]: ../common/packages.md
 [statements]: statements.md
 [assignments]: statements.md#assignments
-[assignments-to-placeholders]: statements.md#assigning-placeholders
+[assignments-to-placeholders]: statements.md#declaring-placeholders
 [expression-statements]: statements.md#expression-statements
 [calls]: expressions.md#calls
 [lambdas]: expressions.md#lambdas

--- a/docs/language/pipeline-language/statements.md
+++ b/docs/language/pipeline-language/statements.md
@@ -16,7 +16,7 @@ are not planned since we want to keep the language small and easy to learn. More
 
 Expression statements are used to evaluate an [expression][expressions] exactly once. The results of this expression are ignored. Therefore, expression statements are only useful if the expression has side effects. The following snippet demonstrates this by [calling][calls] the `print` function that prints the given string to the console:
 
-```txt
+```sds
 print("Hello, world!");
 ```
 
@@ -35,7 +35,7 @@ Placeholders are used to provide a name for a fixed value. This later allows us 
 
 The next snippet shows how the singular result of an expression (the integer `1`) can be assigned to a placeholder called `one`:
 
-```txt
+```sds
 val one = 1;
 ```
 
@@ -51,7 +51,7 @@ This assignment to a placeholder has the following syntactic elements:
 
 We can access the value of a placeholder in any statement that follows the assignment of that placeholder in the closest containing [pipeline][pipelines], [segment][segments], or [block lambda][block-lambdas] using a [reference][references]. Here is a basic example, where we print the value of the `one` placeholder (here `1`) to the console:
 
-```txt
+```sds
 segment loadMovieRatingsSample(nInstances: Int) {
     val one = 1;
     print(one);
@@ -68,7 +68,7 @@ In addition to the [declaration of placeholders](#declaring-placeholders), assig
 
 The following snippet shows how we can assign a value to a declared [result][results] of a [segment][segments]:
 
-```txt
+```sds
 segment trulyRandomInt() -> result: Int {
     yield result = 1;
 }
@@ -86,7 +86,7 @@ The assignment here has the following syntactic elements:
 
 Similar syntax is used to yield results of [block lambdas][block-lambdas]. The difference to segments is that block lambdas do not declare their results in their header. Instead the results are declared within the assignments, just like [placeholders](#declaring-placeholders). The block lambda in the following snippet has a single result called `greeting`, which gets the value `"Hello, world!"`:
 
-```txt
+```sds
 () -> {
     yield greeting = "Hello, world!";
 }
@@ -104,7 +104,7 @@ The assignment here has the following syntactic elements:
 
 In case we want to ignore a result of the expression on the right-hand side of the assignment we can inserting an underscore (called _wildcard_). The following snippet is equivalent to the [expression statement](#expression-statements) `1;`:
 
-```txt
+```sds
 _ = 1;
 ```
 
@@ -114,7 +114,7 @@ So far, the left-hand side of the assignment always had a single assignee. Howev
 
 For example, the `split` method in the next example splits a large dataset into two datasets according to a given ratio. We then ignore the first dataset using a [wildcard](#ignoring-results) and [assign the second result to a placeholder](#declaring-placeholders) called `trainingDataset`. Afterwards, we train a `DecisionTree` using the `trainingDataset` and yield the trained model as a result:
 
-```txt
+```sds
 segment createModel(fullDataset: Dataset) -> trainedModel: Model {
     _, val trainingDataset = fullDataset.split(0.2);
     yield trainedModel = DecisionTree().fit(trainingDataset);

--- a/docs/language/stub-language/annotations.md
+++ b/docs/language/stub-language/annotations.md
@@ -8,7 +8,7 @@ Annotations attach additional metainformation to declarations. Annotations must 
 
 Let's look at a minimal example of an annotation:
 
-```txt
+```sds
 annotation OnlyForExperts
 ```
 
@@ -21,7 +21,7 @@ This declaration of an annotation has the following syntactic elements:
 
 For the annotation `OnlyForExperts`, no more inputs are required. It is only used to mark declarations. However, say we want to assign a category to a declaration. We could define individual annotations for each category, such as:
 
-```txt
+```sds
 annotation Model
 annotation Data
 ```
@@ -30,7 +30,7 @@ However, these annotations are difficult to process since we need to maintain a 
 
 In the following example, we define the complete `Category` annotation with a single parameter with name `category` and [type][types] `String`.
 
-```txt
+```sds
 annotation Category(category: String)
 ```
 
@@ -57,7 +57,7 @@ The valid targets of an annotation can be restricted with the [`Target`][safeds-
 
 Annotation calls are always located right in front of their target. Exception: In the case of compilations units they are located at the very top of the file. Here is an example that demonstrates how to call the annotation `OnlyForExperts` that we defined above on a [class][classes]:
 
-```txt
+```sds
 @OnlyForExperts
 class VerySpecificMLModel
 ```
@@ -71,14 +71,14 @@ The code `class VerySpecificMLModel` is **not** part of the annotation call but 
 
 For an annotation with parameters, such as the `Category` annotation that we defined above, we must pass arguments. The same syntax is used for arguments of annotation calls as for normal [calls][calls]. We can use positional arguments:
 
-```txt
+```sds
 @Category("model")
 class VerySpecificMLModel
 ```
 
 Or we can use named arguments:
 
-```txt
+```sds
 @Category(category="model")
 class VerySpecificMLModel
 ```

--- a/docs/language/stub-language/classes.md
+++ b/docs/language/stub-language/classes.md
@@ -11,7 +11,7 @@ To define a class we use the following syntax:
 * To define the constructor of the class we list the _parameters_ (inputs) necessary to create an instance. This list is enclosed in parentheses and separated by commas, `(regularizationStrength: Float)` in the following snippet. For each parameter, we list the name of the parameter followed by a colon and its type.
 * Finally, we have the _body_ of the class, which lists the members ([attributes](#defining-attributes) for data and [methods](#defining-methods) for operations on this data, as explained in the following sections) of the class enclosed by curly braces.
 
-```txt
+```sds
 class Lasso(regularizationStrength: Float) {
     // ...
 }
@@ -26,7 +26,7 @@ The data of a class is called _attributes_. We differentiate _static attributes_
 * The name of the attribute ("regularizationStrength" in the following example).
 * A colon followed by the type of the attribute ("Float" in the next example).
 
-```txt
+```sds
 class Lasso(regularizationStrength: Float) {
     attr regularizationStrength: Float
 
@@ -44,7 +44,7 @@ _Methods_ represent operations on the attributes of a class. As with attributes 
 * The list of _parameters_ (inputs) enclosed in parentheses and separated by commas (`(features: Table, target: Table)` in the following snippet). For each parameter we list the name of the parameter followed by a colon and its type.
 * Optionally, we can list the _results_ (outputs) after the symbol `->`. If this section is missing it means the method does not produce results. The list of results is again enclosed in parentheses and we use commas to separate the entries. If there is exactly one result we can omit the parentheses (see `-> trainedModel: Lasso` in the following example). For each result we specify its name followed by a colon and its type.
 
-```txt
+```sds
 class Lasso(regularizationStrength: Float) {
     attr regularizationStrength: Float
 
@@ -64,6 +64,6 @@ class Lasso(regularizationStrength: Float) {
 
 To express that the type of a declaration is some class we simply write the name of the class as the type. For example, we could declare a function that plots the line learned by a ridge regression model like this:
 
-```txt
+```sds
 fun plotRidge(model: Ridge)
 ```

--- a/docs/language/stub-language/enumerations.md
+++ b/docs/language/stub-language/enumerations.md
@@ -12,7 +12,7 @@ The syntax to declare an enumeration is as follows:
 
 Coming back to the ridge solver example from the introduction, we would implement this in Safe-DS as follows, so that only the seven specified values are valid instances of the datatype.
 
-```txt
+```sds
 enum RidgeSolver {
     AUTO,
     SVD,
@@ -36,7 +36,7 @@ enum RidgeSolver {
 
 To express that the type of a declaration is an enumeration we simply write the name of the enumeration as the type. For example, when declaring a [class][classes] called "Ridge" for the ridge regression model we can declare a parameter of type "RidgeSolver" like this:
 
-```txt
+```sds
 class Ridge(solver: RidgeSolver) {
     // ...
 }

--- a/docs/language/stub-language/global-functions.md
+++ b/docs/language/stub-language/global-functions.md
@@ -12,7 +12,7 @@ The syntax to define a global function is as follows:
 - Optionally we can list the _results_ (outputs) after the symbol `->`. If this section is missing it means the global function does not produce results. The list of results is again enclosed in parentheses and we use commas to separate the entries. If there is exactly one result we can omit the parentheses (see `-> dataset: Dataset` in the following example). For each result we specify its name followed by a colon and its type.
 - Note that global functions do **not** have a body since they are part of the [stub language][stub-language], which does not deal with implementation.
 
-```txt
+```sds
 fun loadDataset(name: String) -> dataset: Dataset
 ```
 

--- a/docs/lexer/pyproject.toml
+++ b/docs/lexer/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "safe-ds-lexer"
+version = "0.1.0"
+
+[project.entry-points."pygments.lexers"]
+sds = "safe_ds_lexer:SafeDsLexer"
+safe-ds = "safe_ds_lexer:SafeDsLexer"

--- a/docs/lexer/pyproject.toml
+++ b/docs/lexer/pyproject.toml
@@ -4,4 +4,3 @@ version = "0.1.0"
 
 [project.entry-points."pygments.lexers"]
 sds = "safe_ds_lexer:SafeDsLexer"
-safe-ds = "safe_ds_lexer:SafeDsLexer"

--- a/docs/lexer/safe_ds_lexer/__init__.py
+++ b/docs/lexer/safe_ds_lexer/__init__.py
@@ -1,3 +1,5 @@
+"""Pygments lexer for Safe-DS markup."""
+
 from ._safe_ds_lexer import SafeDsLexer
 
 __all__ = [

--- a/docs/lexer/safe_ds_lexer/__init__.py
+++ b/docs/lexer/safe_ds_lexer/__init__.py
@@ -3,5 +3,5 @@
 from ._safe_ds_lexer import SafeDsLexer
 
 __all__ = [
-    'SafeDsLexer',
+    "SafeDsLexer",
 ]

--- a/docs/lexer/safe_ds_lexer/__init__.py
+++ b/docs/lexer/safe_ds_lexer/__init__.py
@@ -1,0 +1,5 @@
+from ._safe_ds_lexer import SafeDsLexer
+
+__all__ = [
+    'SafeDsLexer',
+]

--- a/docs/lexer/safe_ds_lexer/_safe_ds_lexer.py
+++ b/docs/lexer/safe_ds_lexer/_safe_ds_lexer.py
@@ -1,78 +1,78 @@
-from typing import ClassVar
+
 from pygments.lexer import RegexLexer, words
 from pygments.token import Comment, Keyword, Name, Number, Operator, String, Whitespace
 
 constants = (
-    'false',
-    'null',
-    'true'
+    "false",
+    "null",
+    "true",
 )
 
 keywords = (
-    'annotation',
-    'as',
-    'attr',
-    'class',
-    'const',
-    'enum',
-    'fun',
-    'in',
-    'internal',
-    'literal',
-    'out',
-    'pipeline',
-    'private',
-    'schema',
-    'segment',
-    'static',
-    'union',
-    'val',
-    'where',
-    'yield',
+    "annotation",
+    "as",
+    "attr",
+    "class",
+    "const",
+    "enum",
+    "fun",
+    "in",
+    "internal",
+    "literal",
+    "out",
+    "pipeline",
+    "private",
+    "schema",
+    "segment",
+    "static",
+    "union",
+    "val",
+    "where",
+    "yield",
 )
 
 namespace = (
-    'from',
-    'import',
-    'package',
+    "from",
+    "import",
+    "package",
 )
 
 operators = (
-    'and',
-    'not',
-    'or',
-    'sub',
-    'super'
+    "and",
+    "not",
+    "or",
+    "sub",
+    "super",
 )
 
 
 class SafeDsLexer(RegexLexer):
-    name: ClassVar[str] = 'safe-ds'
-    aliases: ClassVar[list[str]] = [
-        'Safe-DS',
-        'safe-ds',
-        'SafeDS',
-        'safeds',
-        'SDS',
-        'sds'
+    name = "safe-ds"
+    aliases = [
+        "Safe-DS",
+        "safe-ds",
+        "SafeDS",
+        "safeds",
+        "SDS",
+        "sds",
     ]
-    filenames: ClassVar[list[str]] = ['*.sdspipe', '*.sdsstub', '*.sdstest']
+    filenames = ["*.sdspipe", "*.sdsstub", "*.sdstest"]
 
     tokens = {
-        'root': [
-            (r'\b([0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?)\b', Number),
-            (r'"|}}', String, 'string'),
-            (words(constants, prefix=r'\b', suffix=r'\b'), Keyword.Constant),
-            (words(keywords, prefix=r'\b', suffix=r'\b'), Keyword),
-            (words(namespace, prefix=r'\b', suffix=r'\b'), Keyword.Namespace),
-            (words(operators, prefix=r'\b', suffix=r'\b'), Operator.Word),
-            (r'`[_a-zA-Z][_a-zA-Z0-9]*`', Name),
-            (r'//.+?$', Comment.Single),
-            (r'/\*[\s\S]*?\*/', Comment.Multiline),
-            (r'\s+', Whitespace),
+        "root": [
+            (r"\b([0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?)\b", Number),
+            (r'"|}}', String, "string"),
+            (words(constants, prefix=r"\b", suffix=r"\b"), Keyword.Constant),
+            (words(keywords, prefix=r"\b", suffix=r"\b"), Keyword),
+            (words(namespace, prefix=r"\b", suffix=r"\b"), Keyword.Namespace),
+            (words(operators, prefix=r"\b", suffix=r"\b"), Operator.Word),
+            (r"`[_a-zA-Z][_a-zA-Z0-9]*`", Name),
+            (r"//.+?$", Comment.Single),
+            (r"/\*[\s\S]*?\*/", Comment.Multiline),
+            (r"\s+", Whitespace),
         ],
-        'string': [
+        "string": [
             (r'([^"{]|\{(?!\{))+', String),
-            (r'\{\{|"', String, '#pop'),
+            (r'\{\{|"', String, "#pop"),
         ],
     }

--- a/docs/lexer/safe_ds_lexer/_safe_ds_lexer.py
+++ b/docs/lexer/safe_ds_lexer/_safe_ds_lexer.py
@@ -1,5 +1,4 @@
-"""Pygments lexer for Safe-DS markup."""
-
+from typing import ClassVar
 from pygments.lexer import RegexLexer, words
 from pygments.token import Comment, Keyword, Name, Number, Operator, String, Whitespace
 
@@ -48,8 +47,8 @@ operators = (
 
 
 class SafeDsLexer(RegexLexer):
-    name = 'safe-ds'
-    aliases = [
+    name: ClassVar[str] = 'safe-ds'
+    aliases: ClassVar[list[str]] = [
         'Safe-DS',
         'safe-ds',
         'SafeDS',
@@ -57,7 +56,7 @@ class SafeDsLexer(RegexLexer):
         'SDS',
         'sds'
     ]
-    filenames = ['*.sdspipe', '*.sdsstub', '*.sdstest']
+    filenames: ClassVar[list[str]] = ['*.sdspipe', '*.sdsstub', '*.sdstest']
 
     tokens = {
         'root': [

--- a/docs/lexer/safe_ds_lexer/_safe_ds_lexer.py
+++ b/docs/lexer/safe_ds_lexer/_safe_ds_lexer.py
@@ -1,7 +1,50 @@
 """Pygments lexer for Safe-DS markup."""
 
 from pygments.lexer import RegexLexer, words
-from pygments.token import *
+from pygments.token import Comment, Keyword, Name, Number, Operator, String, Whitespace
+
+constants = (
+    'false',
+    'null',
+    'true'
+)
+
+keywords = (
+    'annotation',
+    'as',
+    'attr',
+    'class',
+    'const',
+    'enum',
+    'fun',
+    'in',
+    'internal',
+    'literal',
+    'out',
+    'pipeline',
+    'private',
+    'schema',
+    'segment',
+    'static',
+    'union',
+    'val',
+    'where',
+    'yield',
+)
+
+namespace = (
+    'from',
+    'import',
+    'package',
+)
+
+operators = (
+    'and',
+    'not',
+    'or',
+    'sub',
+    'super'
+)
 
 
 class SafeDsLexer(RegexLexer):
@@ -15,49 +58,6 @@ class SafeDsLexer(RegexLexer):
         'sds'
     ]
     filenames = ['*.sdspipe', '*.sdsstub', '*.sdstest']
-
-    constants = (
-        'false',
-        'null',
-        'true'
-    )
-
-    keywords = (
-        'annotation',
-        'as',
-        'attr',
-        'class',
-        'const',
-        'enum',
-        'fun',
-        'in',
-        'internal',
-        'literal',
-        'out',
-        'pipeline',
-        'private',
-        'schema',
-        'segment',
-        'static',
-        'union',
-        'val',
-        'where',
-        'yield',
-    )
-
-    namespace = (
-        'from',
-        'import',
-        'package',
-    )
-
-    operators = (
-        'and',
-        'not',
-        'or',
-        'sub',
-        'super'
-    )
 
     tokens = {
         'root': [

--- a/docs/lexer/safe_ds_lexer/_safe_ds_lexer.py
+++ b/docs/lexer/safe_ds_lexer/_safe_ds_lexer.py
@@ -52,6 +52,7 @@ class SafeDsLexer(RegexLexer):
     tokens = {
         'root': [
             (words(keywords, suffix=r'\b'), Name.Builtin),
+            (r'[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?', Number),
             (r'//.+?$', Comment.Single),
             (r'/\*[\s\S]*?\*/', Comment.Multiline),
             (r'\s+', Whitespace),

--- a/docs/lexer/safe_ds_lexer/_safe_ds_lexer.py
+++ b/docs/lexer/safe_ds_lexer/_safe_ds_lexer.py
@@ -1,4 +1,3 @@
-
 from pygments.lexer import RegexLexer, words
 from pygments.token import Comment, Keyword, Name, Number, Operator, String, Whitespace
 

--- a/docs/lexer/safe_ds_lexer/_safe_ds_lexer.py
+++ b/docs/lexer/safe_ds_lexer/_safe_ds_lexer.py
@@ -1,0 +1,25 @@
+"""Pygments lexer for Safe-DS markup."""
+
+from pygments.lexer import RegexLexer, words
+from pygments.token import *
+
+class SafeDsLexer(RegexLexer):
+    name = 'safe-ds'
+    aliases = [
+        'Safe-DS',
+        'safe-ds',
+        'SafeDS',
+        'safeds',
+        'SDS',
+        'sds'
+    ]
+    filenames = ['*.sdspipe', '*.sdsstub', '*.sdstest']
+
+    tokens = {
+        'root': [
+            (words(('pipeline', 'segment'), suffix=r'\b'), Name.Builtin),
+            (r'//.+?$', Comment.Single),
+            (r'/\*[\s\S]*?\*/', Comment.Multiline),
+            (r'\s+', Whitespace),
+        ],
+    }

--- a/docs/lexer/safe_ds_lexer/_safe_ds_lexer.py
+++ b/docs/lexer/safe_ds_lexer/_safe_ds_lexer.py
@@ -3,6 +3,7 @@
 from pygments.lexer import RegexLexer, words
 from pygments.token import *
 
+
 class SafeDsLexer(RegexLexer):
     name = 'safe-ds'
     aliases = [
@@ -15,46 +16,64 @@ class SafeDsLexer(RegexLexer):
     ]
     filenames = ['*.sdspipe', '*.sdsstub', '*.sdstest']
 
+    constants = (
+        'false',
+        'null',
+        'true'
+    )
+
     keywords = (
-        'and',
         'annotation',
         'as',
         'attr',
         'class',
         'const',
         'enum',
-        'false',
-        'from',
         'fun',
-        'import',
         'in',
         'internal',
         'literal',
-        'not',
-        'null',
-        'or',
         'out',
-        'package',
         'pipeline',
         'private',
         'schema',
         'segment',
         'static',
-        'sub',
-        'super',
-        'true',
         'union',
         'val',
         'where',
         'yield',
     )
 
+    namespace = (
+        'from',
+        'import',
+        'package',
+    )
+
+    operators = (
+        'and',
+        'not',
+        'or',
+        'sub',
+        'super'
+    )
+
     tokens = {
         'root': [
-            (words(keywords, suffix=r'\b'), Name.Builtin),
-            (r'[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?', Number),
+            (r'\b([0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?)\b', Number),
+            (r'"|}}', String, 'string'),
+            (words(constants, prefix=r'\b', suffix=r'\b'), Keyword.Constant),
+            (words(keywords, prefix=r'\b', suffix=r'\b'), Keyword),
+            (words(namespace, prefix=r'\b', suffix=r'\b'), Keyword.Namespace),
+            (words(operators, prefix=r'\b', suffix=r'\b'), Operator.Word),
+            (r'`[_a-zA-Z][_a-zA-Z0-9]*`', Name),
             (r'//.+?$', Comment.Single),
             (r'/\*[\s\S]*?\*/', Comment.Multiline),
             (r'\s+', Whitespace),
+        ],
+        'string': [
+            (r'([^"{]|\{(?!\{))+', String),
+            (r'\{\{|"', String, '#pop'),
         ],
     }

--- a/docs/lexer/safe_ds_lexer/_safe_ds_lexer.py
+++ b/docs/lexer/safe_ds_lexer/_safe_ds_lexer.py
@@ -15,9 +15,43 @@ class SafeDsLexer(RegexLexer):
     ]
     filenames = ['*.sdspipe', '*.sdsstub', '*.sdstest']
 
+    keywords = (
+        'and',
+        'annotation',
+        'as',
+        'attr',
+        'class',
+        'const',
+        'enum',
+        'false',
+        'from',
+        'fun',
+        'import',
+        'in',
+        'internal',
+        'literal',
+        'not',
+        'null',
+        'or',
+        'out',
+        'package',
+        'pipeline',
+        'private',
+        'schema',
+        'segment',
+        'static',
+        'sub',
+        'super',
+        'true',
+        'union',
+        'val',
+        'where',
+        'yield',
+    )
+
     tokens = {
         'root': [
-            (words(('pipeline', 'segment'), suffix=r'\b'), Name.Builtin),
+            (words(keywords, suffix=r'\b'), Name.Builtin),
             (r'//.+?$', Comment.Single),
             (r'/\*[\s\S]*?\*/', Comment.Multiline),
             (r'\s+', Whitespace),

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
 mkdocs==1.5.3
 mkdocs-glightbox==0.3.4
 mkdocs-material==9.4.2
+pygments==2.16.1
+file:./docs/lexer

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,8 +95,9 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_code_format # Footnotes
+          format: !!python/name:pymdownx.superfences.fence_code_format
 
+  # Footnotes
   - footnotes
 
   # Keys
@@ -104,9 +105,10 @@ markdown_extensions:
 
   # Icons & emojis
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg # Images
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
+  # Images
   - attr_list
   - md_in_html
 


### PR DESCRIPTION
Closes #439

### Summary of Changes

Add syntax highlighting for Safe-DS code in the generated documentation.