### PR TITLE
fix: mark map literals as experimental

### DIFF
--- a/src/language/validation/experimentalLanguageFeatures.ts
+++ b/src/language/validation/experimentalLanguageFeatures.ts
@@ -1,10 +1,17 @@
-import { SdsIndexedAccess } from '../generated/ast.js';
+import { SdsIndexedAccess, SdsMap } from '../generated/ast.js';
 import { ValidationAcceptor } from 'langium';
 
 export const CODE_EXPERIMENTAL_LANGUAGE_FEATURE = 'experimental/language-feature';
 
 export const indexedAccessesShouldBeUsedWithCaution = (node: SdsIndexedAccess, accept: ValidationAcceptor): void => {
     accept('warning', 'Indexed accesses are experimental and may change without prior notice.', {
+        node,
+        code: CODE_EXPERIMENTAL_LANGUAGE_FEATURE,
+    });
+};
+
+export const mapsShouldBeUsedWithCaution = (node: SdsMap, accept: ValidationAcceptor): void => {
+    accept('warning', 'Map literals are experimental and may change without prior notice.', {
         node,
         code: CODE_EXPERIMENTAL_LANGUAGE_FEATURE,
     });

--- a/src/language/validation/safe-ds-validator.ts
+++ b/src/language/validation/safe-ds-validator.ts
@@ -90,7 +90,10 @@ import {
     lambdaMustBeAssignedToTypedParameter,
     lambdaParameterMustNotHaveConstModifier,
 } from './other/expressions/lambdas.js';
-import { indexedAccessesShouldBeUsedWithCaution } from './experimentalLanguageFeatures.js';
+import {
+    indexedAccessesShouldBeUsedWithCaution,
+    mapsShouldBeUsedWithCaution
+} from './experimentalLanguageFeatures.js';
 import { requiredParameterMustNotBeExpert } from './builtins/expert.js';
 import {
     annotationCallArgumentsMustBeConstant,
@@ -197,6 +200,7 @@ export const registerValidationChecks = function (services: SafeDsServices) {
             lambdaParametersMustNotBeAnnotated,
             lambdaParameterMustNotHaveConstModifier,
         ],
+        SdsMap: [mapsShouldBeUsedWithCaution],
         SdsMemberAccess: [
             memberAccessMustBeNullSafeIfReceiverIsNullable(services),
             memberAccessNullSafetyShouldBeNeeded(services),

--- a/src/language/validation/safe-ds-validator.ts
+++ b/src/language/validation/safe-ds-validator.ts
@@ -90,10 +90,7 @@ import {
     lambdaMustBeAssignedToTypedParameter,
     lambdaParameterMustNotHaveConstModifier,
 } from './other/expressions/lambdas.js';
-import {
-    indexedAccessesShouldBeUsedWithCaution,
-    mapsShouldBeUsedWithCaution
-} from './experimentalLanguageFeatures.js';
+import { indexedAccessesShouldBeUsedWithCaution, mapsShouldBeUsedWithCaution } from './experimentalLanguageFeatures.js';
 import { requiredParameterMustNotBeExpert } from './builtins/expert.js';
 import {
     annotationCallArgumentsMustBeConstant,

--- a/tests/resources/scoping/member accesses/skip-main.sdstest
+++ b/tests/resources/scoping/member accesses/skip-main.sdstest
@@ -500,13 +500,6 @@ class SubClassForHiding sub SuperClassForHiding {
     static fun staticMethodForHiding()
 }
 
-class ClassForResultMemberAccess() {
-    attr result: Int
-}
-enum EnumForResultMemberAccess {
-    result
-}
-
 
 // Access to own members -------------------------------------------------------
 

--- a/tests/resources/validation/experimental language feature/maps/main.sdstest
+++ b/tests/resources/validation/experimental language feature/maps/main.sdstest
@@ -1,0 +1,6 @@
+package tests.validation.experimentalLanguageFeature.maps
+
+pipeline myPipeline {
+    // $TEST$ warning "Map literals are experimental and may change without prior notice."
+    »{"a": "b"}«;
+}


### PR DESCRIPTION
### Summary of Changes

Our map literals are fairly new and need to be tested for some time. Because of this, they are now marked as experimental.