### PR TITLE
feat: document symbol provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,7 @@
                 "radash": "^11.0.0",
                 "true-myth": "^7.1.0",
                 "vscode-languageclient": "^9.0.1",
-                "vscode-languageserver": "^9.0.1",
-                "vscode-languageserver-types": "^3.17.5",
-                "vscode-uri": "^3.0.7"
+                "vscode-languageserver": "^9.0.1"
             },
             "bin": {
                 "safe-ds-cli": "bin/cli"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "chalk": "^5.3.0",
                 "chevrotain": "^11.0.3",
-                "commander": "^11.0.0",
+                "commander": "^11.1.0",
                 "glob": "^10.3.10",
                 "langium": "^2.0.2",
                 "radash": "^11.0.0",
@@ -23,21 +23,21 @@
                 "safe-ds-cli": "bin/cli"
             },
             "devDependencies": {
-                "@lars-reimann/eslint-config": "^5.1.3",
+                "@lars-reimann/eslint-config": "^5.1.4",
                 "@lars-reimann/prettier-config": "^5.0.0",
-                "@types/node": "^18.18.1",
-                "@types/vscode": "^1.82.0",
+                "@types/node": "^18.18.6",
+                "@types/vscode": "^1.83.1",
                 "@vitest/coverage-v8": "^0.34.6",
                 "@vitest/ui": "^0.34.6",
-                "concurrently": "^8.2.1",
-                "esbuild": "^0.19.4",
+                "concurrently": "^8.2.2",
+                "esbuild": "^0.19.5",
                 "esbuild-plugin-copy": "^2.1.1",
                 "langium-cli": "^2.0.1",
                 "typescript": "^5.2.2",
                 "vitest": "^0.34.6"
             },
             "engines": {
-                "vscode": "^1.82.0"
+                "vscode": "^1.83.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -116,9 +116,9 @@
             "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.4.tgz",
-            "integrity": "sha512-uBIbiYMeSsy2U0XQoOGVVcpIktjLMEKa7ryz2RLr7L/vTnANNEsPVAh4xOv7ondGz6ac1zVb0F8Jx20rQikffQ==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.5.tgz",
+            "integrity": "sha512-bhvbzWFF3CwMs5tbjf3ObfGqbl/17ict2/uwOSfr3wmxDE6VdS2GqY/FuzIPe0q0bdhj65zQsvqfArI9MY6+AA==",
             "cpu": [
                 "arm"
             ],
@@ -132,9 +132,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.4.tgz",
-            "integrity": "sha512-mRsi2vJsk4Bx/AFsNBqOH2fqedxn5L/moT58xgg51DjX1la64Z3Npicut2VbhvDFO26qjWtPMsVxCd80YTFVeg==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.5.tgz",
+            "integrity": "sha512-5d1OkoJxnYQfmC+Zd8NBFjkhyCNYwM4n9ODrycTFY6Jk1IGiZ+tjVJDDSwDt77nK+tfpGP4T50iMtVi4dEGzhQ==",
             "cpu": [
                 "arm64"
             ],
@@ -148,9 +148,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.4.tgz",
-            "integrity": "sha512-4iPufZ1TMOD3oBlGFqHXBpa3KFT46aLl6Vy7gwed0ZSYgHaZ/mihbYb4t7Z9etjkC9Al3ZYIoOaHrU60gcMy7g==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.5.tgz",
+            "integrity": "sha512-9t+28jHGL7uBdkBjL90QFxe7DVA+KGqWlHCF8ChTKyaKO//VLuoBricQCgwhOjA1/qOczsw843Fy4cbs4H3DVA==",
             "cpu": [
                 "x64"
             ],
@@ -164,9 +164,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.4.tgz",
-            "integrity": "sha512-Lviw8EzxsVQKpbS+rSt6/6zjn9ashUZ7Tbuvc2YENgRl0yZTktGlachZ9KMJUsVjZEGFVu336kl5lBgDN6PmpA==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.5.tgz",
+            "integrity": "sha512-mvXGcKqqIqyKoxq26qEDPHJuBYUA5KizJncKOAf9eJQez+L9O+KfvNFu6nl7SCZ/gFb2QPaRqqmG0doSWlgkqw==",
             "cpu": [
                 "arm64"
             ],
@@ -180,9 +180,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.4.tgz",
-            "integrity": "sha512-YHbSFlLgDwglFn0lAO3Zsdrife9jcQXQhgRp77YiTDja23FrC2uwnhXMNkAucthsf+Psr7sTwYEryxz6FPAVqw==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.5.tgz",
+            "integrity": "sha512-Ly8cn6fGLNet19s0X4unjcniX24I0RqjPv+kurpXabZYSXGM4Pwpmf85WHJN3lAgB8GSth7s5A0r856S+4DyiA==",
             "cpu": [
                 "x64"
             ],
@@ -196,9 +196,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.4.tgz",
-            "integrity": "sha512-vz59ijyrTG22Hshaj620e5yhs2dU1WJy723ofc+KUgxVCM6zxQESmWdMuVmUzxtGqtj5heHyB44PjV/HKsEmuQ==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.5.tgz",
+            "integrity": "sha512-GGDNnPWTmWE+DMchq1W8Sd0mUkL+APvJg3b11klSGUDvRXh70JqLAO56tubmq1s2cgpVCSKYywEiKBfju8JztQ==",
             "cpu": [
                 "arm64"
             ],
@@ -212,9 +212,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.4.tgz",
-            "integrity": "sha512-3sRbQ6W5kAiVQRBWREGJNd1YE7OgzS0AmOGjDmX/qZZecq8NFlQsQH0IfXjjmD0XtUYqr64e0EKNFjMUlPL3Cw==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.5.tgz",
+            "integrity": "sha512-1CCwDHnSSoA0HNwdfoNY0jLfJpd7ygaLAp5EHFos3VWJCRX9DMwWODf96s9TSse39Br7oOTLryRVmBoFwXbuuQ==",
             "cpu": [
                 "x64"
             ],
@@ -228,9 +228,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.4.tgz",
-            "integrity": "sha512-z/4ArqOo9EImzTi4b6Vq+pthLnepFzJ92BnofU1jgNlcVb+UqynVFdoXMCFreTK7FdhqAzH0vmdwW5373Hm9pg==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.5.tgz",
+            "integrity": "sha512-lrWXLY/vJBzCPC51QN0HM71uWgIEpGSjSZZADQhq7DKhPcI6NH1IdzjfHkDQws2oNpJKpR13kv7/pFHBbDQDwQ==",
             "cpu": [
                 "arm"
             ],
@@ -244,9 +244,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.4.tgz",
-            "integrity": "sha512-ZWmWORaPbsPwmyu7eIEATFlaqm0QGt+joRE9sKcnVUG3oBbr/KYdNE2TnkzdQwX6EDRdg/x8Q4EZQTXoClUqqA==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.5.tgz",
+            "integrity": "sha512-o3vYippBmSrjjQUCEEiTZ2l+4yC0pVJD/Dl57WfPwwlvFkrxoSO7rmBZFii6kQB3Wrn/6GwJUPLU5t52eq2meA==",
             "cpu": [
                 "arm64"
             ],
@@ -260,9 +260,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.4.tgz",
-            "integrity": "sha512-EGc4vYM7i1GRUIMqRZNCTzJh25MHePYsnQfKDexD8uPTCm9mK56NIL04LUfX2aaJ+C9vyEp2fJ7jbqFEYgO9lQ==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.5.tgz",
+            "integrity": "sha512-MkjHXS03AXAkNp1KKkhSKPOCYztRtK+KXDNkBa6P78F8Bw0ynknCSClO/ztGszILZtyO/lVKpa7MolbBZ6oJtQ==",
             "cpu": [
                 "ia32"
             ],
@@ -276,9 +276,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.4.tgz",
-            "integrity": "sha512-WVhIKO26kmm8lPmNrUikxSpXcgd6HDog0cx12BUfA2PkmURHSgx9G6vA19lrlQOMw+UjMZ+l3PpbtzffCxFDRg==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.5.tgz",
+            "integrity": "sha512-42GwZMm5oYOD/JHqHska3Jg0r+XFb/fdZRX+WjADm3nLWLcIsN27YKtqxzQmGNJgu0AyXg4HtcSK9HuOk3v1Dw==",
             "cpu": [
                 "loong64"
             ],
@@ -292,9 +292,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.4.tgz",
-            "integrity": "sha512-keYY+Hlj5w86hNp5JJPuZNbvW4jql7c1eXdBUHIJGTeN/+0QFutU3GrS+c27L+NTmzi73yhtojHk+lr2+502Mw==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.5.tgz",
+            "integrity": "sha512-kcjndCSMitUuPJobWCnwQ9lLjiLZUR3QLQmlgaBfMX23UEa7ZOrtufnRds+6WZtIS9HdTXqND4yH8NLoVVIkcg==",
             "cpu": [
                 "mips64el"
             ],
@@ -308,9 +308,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.4.tgz",
-            "integrity": "sha512-tQ92n0WMXyEsCH4m32S21fND8VxNiVazUbU4IUGVXQpWiaAxOBvtOtbEt3cXIV3GEBydYsY8pyeRMJx9kn3rvw==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.5.tgz",
+            "integrity": "sha512-yJAxJfHVm0ZbsiljbtFFP1BQKLc8kUF6+17tjQ78QjqjAQDnhULWiTA6u0FCDmYT1oOKS9PzZ2z0aBI+Mcyj7Q==",
             "cpu": [
                 "ppc64"
             ],
@@ -324,9 +324,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.4.tgz",
-            "integrity": "sha512-tRRBey6fG9tqGH6V75xH3lFPpj9E8BH+N+zjSUCnFOX93kEzqS0WdyJHkta/mmJHn7MBaa++9P4ARiU4ykjhig==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.5.tgz",
+            "integrity": "sha512-5u8cIR/t3gaD6ad3wNt1MNRstAZO+aNyBxu2We8X31bA8XUNyamTVQwLDA1SLoPCUehNCymhBhK3Qim1433Zag==",
             "cpu": [
                 "riscv64"
             ],
@@ -340,9 +340,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.4.tgz",
-            "integrity": "sha512-152aLpQqKZYhThiJ+uAM4PcuLCAOxDsCekIbnGzPKVBRUDlgaaAfaUl5NYkB1hgY6WN4sPkejxKlANgVcGl9Qg==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.5.tgz",
+            "integrity": "sha512-Z6JrMyEw/EmZBD/OFEFpb+gao9xJ59ATsoTNlj39jVBbXqoZm4Xntu6wVmGPB/OATi1uk/DB+yeDPv2E8PqZGw==",
             "cpu": [
                 "s390x"
             ],
@@ -356,9 +356,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.4.tgz",
-            "integrity": "sha512-Mi4aNA3rz1BNFtB7aGadMD0MavmzuuXNTaYL6/uiYIs08U7YMPETpgNn5oue3ICr+inKwItOwSsJDYkrE9ekVg==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.5.tgz",
+            "integrity": "sha512-psagl+2RlK1z8zWZOmVdImisMtrUxvwereIdyJTmtmHahJTKb64pAcqoPlx6CewPdvGvUKe2Jw+0Z/0qhSbG1A==",
             "cpu": [
                 "x64"
             ],
@@ -372,9 +372,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.4.tgz",
-            "integrity": "sha512-9+Wxx1i5N/CYo505CTT7T+ix4lVzEdz0uCoYGxM5JDVlP2YdDC1Bdz+Khv6IbqmisT0Si928eAxbmGkcbiuM/A==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.5.tgz",
+            "integrity": "sha512-kL2l+xScnAy/E/3119OggX8SrWyBEcqAh8aOY1gr4gPvw76la2GlD4Ymf832UCVbmuWeTf2adkZDK+h0Z/fB4g==",
             "cpu": [
                 "x64"
             ],
@@ -388,9 +388,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.4.tgz",
-            "integrity": "sha512-MFsHleM5/rWRW9EivFssop+OulYVUoVcqkyOkjiynKBCGBj9Lihl7kh9IzrreDyXa4sNkquei5/DTP4uCk25xw==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.5.tgz",
+            "integrity": "sha512-sPOfhtzFufQfTBgRnE1DIJjzsXukKSvZxloZbkJDG383q0awVAq600pc1nfqBcl0ice/WN9p4qLc39WhBShRTA==",
             "cpu": [
                 "x64"
             ],
@@ -404,9 +404,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.4.tgz",
-            "integrity": "sha512-6Xq8SpK46yLvrGxjp6HftkDwPP49puU4OF0hEL4dTxqCbfx09LyrbUj/D7tmIRMj5D5FCUPksBbxyQhp8tmHzw==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.5.tgz",
+            "integrity": "sha512-dGZkBXaafuKLpDSjKcB0ax0FL36YXCvJNnztjKV+6CO82tTYVDSH2lifitJ29jxRMoUhgkg9a+VA/B03WK5lcg==",
             "cpu": [
                 "x64"
             ],
@@ -420,9 +420,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.4.tgz",
-            "integrity": "sha512-PkIl7Jq4mP6ke7QKwyg4fD4Xvn8PXisagV/+HntWoDEdmerB2LTukRZg728Yd1Fj+LuEX75t/hKXE2Ppk8Hh1w==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.5.tgz",
+            "integrity": "sha512-dWVjD9y03ilhdRQ6Xig1NWNgfLtf2o/STKTS+eZuF90fI2BhbwD6WlaiCGKptlqXlURVB5AUOxUj09LuwKGDTg==",
             "cpu": [
                 "arm64"
             ],
@@ -436,9 +436,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.4.tgz",
-            "integrity": "sha512-ga676Hnvw7/ycdKB53qPusvsKdwrWzEyJ+AtItHGoARszIqvjffTwaaW3b2L6l90i7MO9i+dlAW415INuRhSGg==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.5.tgz",
+            "integrity": "sha512-4liggWIA4oDgUxqpZwrDhmEfAH4d0iljanDOK7AnVU89T6CzHon/ony8C5LeOdfgx60x5cnQJFZwEydVlYx4iw==",
             "cpu": [
                 "ia32"
             ],
@@ -452,9 +452,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.4.tgz",
-            "integrity": "sha512-HP0GDNla1T3ZL8Ko/SHAS2GgtjOg+VmWnnYLhuTksr++EnduYB0f3Y2LzHsUwb2iQ13JGoY6G3R8h6Du/WG6uA==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.5.tgz",
+            "integrity": "sha512-czTrygUsB/jlM8qEW5MD8bgYU2Xg14lo6kBDXW6HdxKjh8M5PzETGiSHaz9MtbXBYDloHNUAUW2tMiKW4KM9Mw==",
             "cpu": [
                 "x64"
             ],
@@ -717,9 +717,9 @@
             }
         },
         "node_modules/@lars-reimann/eslint-config": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/@lars-reimann/eslint-config/-/eslint-config-5.1.3.tgz",
-            "integrity": "sha512-Kzw8ksILtRzwXgWAdOuJ+06c5RuuBetqCxj2xIUYohvPSvpXPusuJzoEnXwiQcjCs6MNhaf6ZlmccB7JBe8fMw==",
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/@lars-reimann/eslint-config/-/eslint-config-5.1.4.tgz",
+            "integrity": "sha512-OtPNeiHJKK/sAAhdiTzd4j2Likv32RxEcxVmC8T0WIXVQKyaUVgr+bJlnxCJ+n9LPx986Ah/8o9Ac8JNmHYm9Q==",
             "dev": true,
             "dependencies": {
                 "eslint-config-airbnb": "^19.0.4",
@@ -838,9 +838,9 @@
             "peer": true
         },
         "node_modules/@types/node": {
-            "version": "18.18.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.1.tgz",
-            "integrity": "sha512-3G42sxmm0fF2+Vtb9TJQpnjmP+uKlWvFa8KoEGquh4gqRmoUG/N0ufuhikw6HEsdG2G2oIKhog1GCTfz9v5NdQ==",
+            "version": "18.18.6",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.6.tgz",
+            "integrity": "sha512-wf3Vz+jCmOQ2HV1YUJuCWdL64adYxumkrxtc+H1VUQlnQI04+5HtH+qZCOE21lBE7gIrt+CwX2Wv8Acrw5Ak6w==",
             "dev": true
         },
         "node_modules/@types/semver": {
@@ -851,9 +851,9 @@
             "peer": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.82.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
-            "integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
+            "version": "1.83.1",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.83.1.tgz",
+            "integrity": "sha512-BHu51NaNKOtDf3BOonY3sKFFmZKEpRkzqkZVpSYxowLbs5JqjOQemYFob7Gs5rpxE5tiGhfpnMpcdF/oKrLg4w==",
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1675,9 +1675,9 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "node_modules/commander": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-            "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+            "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
             "engines": {
                 "node": ">=16"
             }
@@ -1689,9 +1689,9 @@
             "dev": true
         },
         "node_modules/concurrently": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.1.tgz",
-            "integrity": "sha512-nVraf3aXOpIcNud5pB9M82p1tynmZkrSGQ1p6X/VY8cJ+2LMVqAgXsJxYYefACSHbTYlm92O1xuhdGTjwoEvbQ==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
+            "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
             "dev": true,
             "dependencies": {
                 "chalk": "^4.1.2",
@@ -2007,9 +2007,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.4.tgz",
-            "integrity": "sha512-x7jL0tbRRpv4QUyuDMjONtWFciygUxWaUM1kMX2zWxI0X2YWOt7MSA0g4UdeSiHM8fcYVzpQhKYOycZwxTdZkA==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.5.tgz",
+            "integrity": "sha512-bUxalY7b1g8vNhQKdB24QDmHeY4V4tw/s6Ak5z+jJX9laP5MoQseTOMemAr0gxssjNcH0MCViG8ONI2kksvfFQ==",
             "dev": true,
             "hasInstallScript": true,
             "bin": {
@@ -2019,28 +2019,28 @@
                 "node": ">=12"
             },
             "optionalDependencies": {
-                "@esbuild/android-arm": "0.19.4",
-                "@esbuild/android-arm64": "0.19.4",
-                "@esbuild/android-x64": "0.19.4",
-                "@esbuild/darwin-arm64": "0.19.4",
-                "@esbuild/darwin-x64": "0.19.4",
-                "@esbuild/freebsd-arm64": "0.19.4",
-                "@esbuild/freebsd-x64": "0.19.4",
-                "@esbuild/linux-arm": "0.19.4",
-                "@esbuild/linux-arm64": "0.19.4",
-                "@esbuild/linux-ia32": "0.19.4",
-                "@esbuild/linux-loong64": "0.19.4",
-                "@esbuild/linux-mips64el": "0.19.4",
-                "@esbuild/linux-ppc64": "0.19.4",
-                "@esbuild/linux-riscv64": "0.19.4",
-                "@esbuild/linux-s390x": "0.19.4",
-                "@esbuild/linux-x64": "0.19.4",
-                "@esbuild/netbsd-x64": "0.19.4",
-                "@esbuild/openbsd-x64": "0.19.4",
-                "@esbuild/sunos-x64": "0.19.4",
-                "@esbuild/win32-arm64": "0.19.4",
-                "@esbuild/win32-ia32": "0.19.4",
-                "@esbuild/win32-x64": "0.19.4"
+                "@esbuild/android-arm": "0.19.5",
+                "@esbuild/android-arm64": "0.19.5",
+                "@esbuild/android-x64": "0.19.5",
+                "@esbuild/darwin-arm64": "0.19.5",
+                "@esbuild/darwin-x64": "0.19.5",
+                "@esbuild/freebsd-arm64": "0.19.5",
+                "@esbuild/freebsd-x64": "0.19.5",
+                "@esbuild/linux-arm": "0.19.5",
+                "@esbuild/linux-arm64": "0.19.5",
+                "@esbuild/linux-ia32": "0.19.5",
+                "@esbuild/linux-loong64": "0.19.5",
+                "@esbuild/linux-mips64el": "0.19.5",
+                "@esbuild/linux-ppc64": "0.19.5",
+                "@esbuild/linux-riscv64": "0.19.5",
+                "@esbuild/linux-s390x": "0.19.5",
+                "@esbuild/linux-x64": "0.19.5",
+                "@esbuild/netbsd-x64": "0.19.5",
+                "@esbuild/openbsd-x64": "0.19.5",
+                "@esbuild/sunos-x64": "0.19.5",
+                "@esbuild/win32-arm64": "0.19.5",
+                "@esbuild/win32-ia32": "0.19.5",
+                "@esbuild/win32-x64": "0.19.5"
             }
         },
         "node_modules/esbuild-plugin-copy": {
@@ -6268,156 +6268,156 @@
             "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="
         },
         "@esbuild/android-arm": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.4.tgz",
-            "integrity": "sha512-uBIbiYMeSsy2U0XQoOGVVcpIktjLMEKa7ryz2RLr7L/vTnANNEsPVAh4xOv7ondGz6ac1zVb0F8Jx20rQikffQ==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.5.tgz",
+            "integrity": "sha512-bhvbzWFF3CwMs5tbjf3ObfGqbl/17ict2/uwOSfr3wmxDE6VdS2GqY/FuzIPe0q0bdhj65zQsvqfArI9MY6+AA==",
             "dev": true,
             "optional": true
         },
         "@esbuild/android-arm64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.4.tgz",
-            "integrity": "sha512-mRsi2vJsk4Bx/AFsNBqOH2fqedxn5L/moT58xgg51DjX1la64Z3Npicut2VbhvDFO26qjWtPMsVxCd80YTFVeg==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.5.tgz",
+            "integrity": "sha512-5d1OkoJxnYQfmC+Zd8NBFjkhyCNYwM4n9ODrycTFY6Jk1IGiZ+tjVJDDSwDt77nK+tfpGP4T50iMtVi4dEGzhQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/android-x64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.4.tgz",
-            "integrity": "sha512-4iPufZ1TMOD3oBlGFqHXBpa3KFT46aLl6Vy7gwed0ZSYgHaZ/mihbYb4t7Z9etjkC9Al3ZYIoOaHrU60gcMy7g==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.5.tgz",
+            "integrity": "sha512-9t+28jHGL7uBdkBjL90QFxe7DVA+KGqWlHCF8ChTKyaKO//VLuoBricQCgwhOjA1/qOczsw843Fy4cbs4H3DVA==",
             "dev": true,
             "optional": true
         },
         "@esbuild/darwin-arm64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.4.tgz",
-            "integrity": "sha512-Lviw8EzxsVQKpbS+rSt6/6zjn9ashUZ7Tbuvc2YENgRl0yZTktGlachZ9KMJUsVjZEGFVu336kl5lBgDN6PmpA==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.5.tgz",
+            "integrity": "sha512-mvXGcKqqIqyKoxq26qEDPHJuBYUA5KizJncKOAf9eJQez+L9O+KfvNFu6nl7SCZ/gFb2QPaRqqmG0doSWlgkqw==",
             "dev": true,
             "optional": true
         },
         "@esbuild/darwin-x64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.4.tgz",
-            "integrity": "sha512-YHbSFlLgDwglFn0lAO3Zsdrife9jcQXQhgRp77YiTDja23FrC2uwnhXMNkAucthsf+Psr7sTwYEryxz6FPAVqw==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.5.tgz",
+            "integrity": "sha512-Ly8cn6fGLNet19s0X4unjcniX24I0RqjPv+kurpXabZYSXGM4Pwpmf85WHJN3lAgB8GSth7s5A0r856S+4DyiA==",
             "dev": true,
             "optional": true
         },
         "@esbuild/freebsd-arm64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.4.tgz",
-            "integrity": "sha512-vz59ijyrTG22Hshaj620e5yhs2dU1WJy723ofc+KUgxVCM6zxQESmWdMuVmUzxtGqtj5heHyB44PjV/HKsEmuQ==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.5.tgz",
+            "integrity": "sha512-GGDNnPWTmWE+DMchq1W8Sd0mUkL+APvJg3b11klSGUDvRXh70JqLAO56tubmq1s2cgpVCSKYywEiKBfju8JztQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/freebsd-x64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.4.tgz",
-            "integrity": "sha512-3sRbQ6W5kAiVQRBWREGJNd1YE7OgzS0AmOGjDmX/qZZecq8NFlQsQH0IfXjjmD0XtUYqr64e0EKNFjMUlPL3Cw==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.5.tgz",
+            "integrity": "sha512-1CCwDHnSSoA0HNwdfoNY0jLfJpd7ygaLAp5EHFos3VWJCRX9DMwWODf96s9TSse39Br7oOTLryRVmBoFwXbuuQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-arm": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.4.tgz",
-            "integrity": "sha512-z/4ArqOo9EImzTi4b6Vq+pthLnepFzJ92BnofU1jgNlcVb+UqynVFdoXMCFreTK7FdhqAzH0vmdwW5373Hm9pg==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.5.tgz",
+            "integrity": "sha512-lrWXLY/vJBzCPC51QN0HM71uWgIEpGSjSZZADQhq7DKhPcI6NH1IdzjfHkDQws2oNpJKpR13kv7/pFHBbDQDwQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-arm64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.4.tgz",
-            "integrity": "sha512-ZWmWORaPbsPwmyu7eIEATFlaqm0QGt+joRE9sKcnVUG3oBbr/KYdNE2TnkzdQwX6EDRdg/x8Q4EZQTXoClUqqA==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.5.tgz",
+            "integrity": "sha512-o3vYippBmSrjjQUCEEiTZ2l+4yC0pVJD/Dl57WfPwwlvFkrxoSO7rmBZFii6kQB3Wrn/6GwJUPLU5t52eq2meA==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-ia32": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.4.tgz",
-            "integrity": "sha512-EGc4vYM7i1GRUIMqRZNCTzJh25MHePYsnQfKDexD8uPTCm9mK56NIL04LUfX2aaJ+C9vyEp2fJ7jbqFEYgO9lQ==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.5.tgz",
+            "integrity": "sha512-MkjHXS03AXAkNp1KKkhSKPOCYztRtK+KXDNkBa6P78F8Bw0ynknCSClO/ztGszILZtyO/lVKpa7MolbBZ6oJtQ==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-loong64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.4.tgz",
-            "integrity": "sha512-WVhIKO26kmm8lPmNrUikxSpXcgd6HDog0cx12BUfA2PkmURHSgx9G6vA19lrlQOMw+UjMZ+l3PpbtzffCxFDRg==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.5.tgz",
+            "integrity": "sha512-42GwZMm5oYOD/JHqHska3Jg0r+XFb/fdZRX+WjADm3nLWLcIsN27YKtqxzQmGNJgu0AyXg4HtcSK9HuOk3v1Dw==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-mips64el": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.4.tgz",
-            "integrity": "sha512-keYY+Hlj5w86hNp5JJPuZNbvW4jql7c1eXdBUHIJGTeN/+0QFutU3GrS+c27L+NTmzi73yhtojHk+lr2+502Mw==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.5.tgz",
+            "integrity": "sha512-kcjndCSMitUuPJobWCnwQ9lLjiLZUR3QLQmlgaBfMX23UEa7ZOrtufnRds+6WZtIS9HdTXqND4yH8NLoVVIkcg==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-ppc64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.4.tgz",
-            "integrity": "sha512-tQ92n0WMXyEsCH4m32S21fND8VxNiVazUbU4IUGVXQpWiaAxOBvtOtbEt3cXIV3GEBydYsY8pyeRMJx9kn3rvw==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.5.tgz",
+            "integrity": "sha512-yJAxJfHVm0ZbsiljbtFFP1BQKLc8kUF6+17tjQ78QjqjAQDnhULWiTA6u0FCDmYT1oOKS9PzZ2z0aBI+Mcyj7Q==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-riscv64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.4.tgz",
-            "integrity": "sha512-tRRBey6fG9tqGH6V75xH3lFPpj9E8BH+N+zjSUCnFOX93kEzqS0WdyJHkta/mmJHn7MBaa++9P4ARiU4ykjhig==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.5.tgz",
+            "integrity": "sha512-5u8cIR/t3gaD6ad3wNt1MNRstAZO+aNyBxu2We8X31bA8XUNyamTVQwLDA1SLoPCUehNCymhBhK3Qim1433Zag==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-s390x": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.4.tgz",
-            "integrity": "sha512-152aLpQqKZYhThiJ+uAM4PcuLCAOxDsCekIbnGzPKVBRUDlgaaAfaUl5NYkB1hgY6WN4sPkejxKlANgVcGl9Qg==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.5.tgz",
+            "integrity": "sha512-Z6JrMyEw/EmZBD/OFEFpb+gao9xJ59ATsoTNlj39jVBbXqoZm4Xntu6wVmGPB/OATi1uk/DB+yeDPv2E8PqZGw==",
             "dev": true,
             "optional": true
         },
         "@esbuild/linux-x64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.4.tgz",
-            "integrity": "sha512-Mi4aNA3rz1BNFtB7aGadMD0MavmzuuXNTaYL6/uiYIs08U7YMPETpgNn5oue3ICr+inKwItOwSsJDYkrE9ekVg==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.5.tgz",
+            "integrity": "sha512-psagl+2RlK1z8zWZOmVdImisMtrUxvwereIdyJTmtmHahJTKb64pAcqoPlx6CewPdvGvUKe2Jw+0Z/0qhSbG1A==",
             "dev": true,
             "optional": true
         },
         "@esbuild/netbsd-x64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.4.tgz",
-            "integrity": "sha512-9+Wxx1i5N/CYo505CTT7T+ix4lVzEdz0uCoYGxM5JDVlP2YdDC1Bdz+Khv6IbqmisT0Si928eAxbmGkcbiuM/A==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.5.tgz",
+            "integrity": "sha512-kL2l+xScnAy/E/3119OggX8SrWyBEcqAh8aOY1gr4gPvw76la2GlD4Ymf832UCVbmuWeTf2adkZDK+h0Z/fB4g==",
             "dev": true,
             "optional": true
         },
         "@esbuild/openbsd-x64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.4.tgz",
-            "integrity": "sha512-MFsHleM5/rWRW9EivFssop+OulYVUoVcqkyOkjiynKBCGBj9Lihl7kh9IzrreDyXa4sNkquei5/DTP4uCk25xw==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.5.tgz",
+            "integrity": "sha512-sPOfhtzFufQfTBgRnE1DIJjzsXukKSvZxloZbkJDG383q0awVAq600pc1nfqBcl0ice/WN9p4qLc39WhBShRTA==",
             "dev": true,
             "optional": true
         },
         "@esbuild/sunos-x64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.4.tgz",
-            "integrity": "sha512-6Xq8SpK46yLvrGxjp6HftkDwPP49puU4OF0hEL4dTxqCbfx09LyrbUj/D7tmIRMj5D5FCUPksBbxyQhp8tmHzw==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.5.tgz",
+            "integrity": "sha512-dGZkBXaafuKLpDSjKcB0ax0FL36YXCvJNnztjKV+6CO82tTYVDSH2lifitJ29jxRMoUhgkg9a+VA/B03WK5lcg==",
             "dev": true,
             "optional": true
         },
         "@esbuild/win32-arm64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.4.tgz",
-            "integrity": "sha512-PkIl7Jq4mP6ke7QKwyg4fD4Xvn8PXisagV/+HntWoDEdmerB2LTukRZg728Yd1Fj+LuEX75t/hKXE2Ppk8Hh1w==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.5.tgz",
+            "integrity": "sha512-dWVjD9y03ilhdRQ6Xig1NWNgfLtf2o/STKTS+eZuF90fI2BhbwD6WlaiCGKptlqXlURVB5AUOxUj09LuwKGDTg==",
             "dev": true,
             "optional": true
         },
         "@esbuild/win32-ia32": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.4.tgz",
-            "integrity": "sha512-ga676Hnvw7/ycdKB53qPusvsKdwrWzEyJ+AtItHGoARszIqvjffTwaaW3b2L6l90i7MO9i+dlAW415INuRhSGg==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.5.tgz",
+            "integrity": "sha512-4liggWIA4oDgUxqpZwrDhmEfAH4d0iljanDOK7AnVU89T6CzHon/ony8C5LeOdfgx60x5cnQJFZwEydVlYx4iw==",
             "dev": true,
             "optional": true
         },
         "@esbuild/win32-x64": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.4.tgz",
-            "integrity": "sha512-HP0GDNla1T3ZL8Ko/SHAS2GgtjOg+VmWnnYLhuTksr++EnduYB0f3Y2LzHsUwb2iQ13JGoY6G3R8h6Du/WG6uA==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.5.tgz",
+            "integrity": "sha512-czTrygUsB/jlM8qEW5MD8bgYU2Xg14lo6kBDXW6HdxKjh8M5PzETGiSHaz9MtbXBYDloHNUAUW2tMiKW4KM9Mw==",
             "dev": true,
             "optional": true
         },
@@ -6597,9 +6597,9 @@
             }
         },
         "@lars-reimann/eslint-config": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/@lars-reimann/eslint-config/-/eslint-config-5.1.3.tgz",
-            "integrity": "sha512-Kzw8ksILtRzwXgWAdOuJ+06c5RuuBetqCxj2xIUYohvPSvpXPusuJzoEnXwiQcjCs6MNhaf6ZlmccB7JBe8fMw==",
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/@lars-reimann/eslint-config/-/eslint-config-5.1.4.tgz",
+            "integrity": "sha512-OtPNeiHJKK/sAAhdiTzd4j2Likv32RxEcxVmC8T0WIXVQKyaUVgr+bJlnxCJ+n9LPx986Ah/8o9Ac8JNmHYm9Q==",
             "dev": true,
             "requires": {
                 "eslint-config-airbnb": "^19.0.4",
@@ -6694,9 +6694,9 @@
             "peer": true
         },
         "@types/node": {
-            "version": "18.18.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.1.tgz",
-            "integrity": "sha512-3G42sxmm0fF2+Vtb9TJQpnjmP+uKlWvFa8KoEGquh4gqRmoUG/N0ufuhikw6HEsdG2G2oIKhog1GCTfz9v5NdQ==",
+            "version": "18.18.6",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.6.tgz",
+            "integrity": "sha512-wf3Vz+jCmOQ2HV1YUJuCWdL64adYxumkrxtc+H1VUQlnQI04+5HtH+qZCOE21lBE7gIrt+CwX2Wv8Acrw5Ak6w==",
             "dev": true
         },
         "@types/semver": {
@@ -6707,9 +6707,9 @@
             "peer": true
         },
         "@types/vscode": {
-            "version": "1.82.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
-            "integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
+            "version": "1.83.1",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.83.1.tgz",
+            "integrity": "sha512-BHu51NaNKOtDf3BOonY3sKFFmZKEpRkzqkZVpSYxowLbs5JqjOQemYFob7Gs5rpxE5tiGhfpnMpcdF/oKrLg4w==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
@@ -7284,9 +7284,9 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "commander": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-            "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ=="
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+            "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="
         },
         "concat-map": {
             "version": "0.0.1",
@@ -7295,9 +7295,9 @@
             "dev": true
         },
         "concurrently": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.1.tgz",
-            "integrity": "sha512-nVraf3aXOpIcNud5pB9M82p1tynmZkrSGQ1p6X/VY8cJ+2LMVqAgXsJxYYefACSHbTYlm92O1xuhdGTjwoEvbQ==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
+            "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
             "dev": true,
             "requires": {
                 "chalk": "^4.1.2",
@@ -7538,33 +7538,33 @@
             }
         },
         "esbuild": {
-            "version": "0.19.4",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.4.tgz",
-            "integrity": "sha512-x7jL0tbRRpv4QUyuDMjONtWFciygUxWaUM1kMX2zWxI0X2YWOt7MSA0g4UdeSiHM8fcYVzpQhKYOycZwxTdZkA==",
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.5.tgz",
+            "integrity": "sha512-bUxalY7b1g8vNhQKdB24QDmHeY4V4tw/s6Ak5z+jJX9laP5MoQseTOMemAr0gxssjNcH0MCViG8ONI2kksvfFQ==",
             "dev": true,
             "requires": {
-                "@esbuild/android-arm": "0.19.4",
-                "@esbuild/android-arm64": "0.19.4",
-                "@esbuild/android-x64": "0.19.4",
-                "@esbuild/darwin-arm64": "0.19.4",
-                "@esbuild/darwin-x64": "0.19.4",
-                "@esbuild/freebsd-arm64": "0.19.4",
-                "@esbuild/freebsd-x64": "0.19.4",
-                "@esbuild/linux-arm": "0.19.4",
-                "@esbuild/linux-arm64": "0.19.4",
-                "@esbuild/linux-ia32": "0.19.4",
-                "@esbuild/linux-loong64": "0.19.4",
-                "@esbuild/linux-mips64el": "0.19.4",
-                "@esbuild/linux-ppc64": "0.19.4",
-                "@esbuild/linux-riscv64": "0.19.4",
-                "@esbuild/linux-s390x": "0.19.4",
-                "@esbuild/linux-x64": "0.19.4",
-                "@esbuild/netbsd-x64": "0.19.4",
-                "@esbuild/openbsd-x64": "0.19.4",
-                "@esbuild/sunos-x64": "0.19.4",
-                "@esbuild/win32-arm64": "0.19.4",
-                "@esbuild/win32-ia32": "0.19.4",
-                "@esbuild/win32-x64": "0.19.4"
+                "@esbuild/android-arm": "0.19.5",
+                "@esbuild/android-arm64": "0.19.5",
+                "@esbuild/android-x64": "0.19.5",
+                "@esbuild/darwin-arm64": "0.19.5",
+                "@esbuild/darwin-x64": "0.19.5",
+                "@esbuild/freebsd-arm64": "0.19.5",
+                "@esbuild/freebsd-x64": "0.19.5",
+                "@esbuild/linux-arm": "0.19.5",
+                "@esbuild/linux-arm64": "0.19.5",
+                "@esbuild/linux-ia32": "0.19.5",
+                "@esbuild/linux-loong64": "0.19.5",
+                "@esbuild/linux-mips64el": "0.19.5",
+                "@esbuild/linux-ppc64": "0.19.5",
+                "@esbuild/linux-riscv64": "0.19.5",
+                "@esbuild/linux-s390x": "0.19.5",
+                "@esbuild/linux-x64": "0.19.5",
+                "@esbuild/netbsd-x64": "0.19.5",
+                "@esbuild/openbsd-x64": "0.19.5",
+                "@esbuild/sunos-x64": "0.19.5",
+                "@esbuild/win32-arm64": "0.19.5",
+                "@esbuild/win32-ia32": "0.19.5",
+                "@esbuild/win32-x64": "0.19.5"
             }
         },
         "esbuild-plugin-copy": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         }
     ],
     "engines": {
-        "vscode": "^1.82.0"
+        "vscode": "^1.83.0"
     },
     "contributes": {
         "languages": [
@@ -103,7 +103,7 @@
     "dependencies": {
         "chalk": "^5.3.0",
         "chevrotain": "^11.0.3",
-        "commander": "^11.0.0",
+        "commander": "^11.1.0",
         "glob": "^10.3.10",
         "langium": "^2.0.2",
         "radash": "^11.0.0",
@@ -112,14 +112,14 @@
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {
-        "@lars-reimann/eslint-config": "^5.1.3",
+        "@lars-reimann/eslint-config": "^5.1.4",
         "@lars-reimann/prettier-config": "^5.0.0",
-        "@types/node": "^18.18.1",
-        "@types/vscode": "^1.82.0",
+        "@types/node": "^18.18.6",
+        "@types/vscode": "^1.83.1",
         "@vitest/coverage-v8": "^0.34.6",
         "@vitest/ui": "^0.34.6",
-        "concurrently": "^8.2.1",
-        "esbuild": "^0.19.4",
+        "concurrently": "^8.2.2",
+        "esbuild": "^0.19.5",
         "esbuild-plugin-copy": "^2.1.1",
         "langium-cli": "^2.0.1",
         "typescript": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -109,9 +109,7 @@
         "radash": "^11.0.0",
         "true-myth": "^7.1.0",
         "vscode-languageclient": "^9.0.1",
-        "vscode-languageserver": "^9.0.1",
-        "vscode-languageserver-types": "^3.17.5",
-        "vscode-uri": "^3.0.7"
+        "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {
         "@lars-reimann/eslint-config": "^5.1.3",

--- a/src/language/lsp/safe-ds-document-symbol-provider.ts
+++ b/src/language/lsp/safe-ds-document-symbol-provider.ts
@@ -1,8 +1,17 @@
-import {AstNode, DefaultDocumentSymbolProvider, LangiumDocument} from 'langium';
-import {DocumentSymbol, SymbolTag} from 'vscode-languageserver';
-import {SafeDsServices} from "../safe-ds-module.js";
-import {SafeDsAnnotations} from "../builtins/safe-ds-annotations.js";
-import {isSdsAnnotatedObject} from "../generated/ast.js";
+import { AstNode, DefaultDocumentSymbolProvider, LangiumDocument } from 'langium';
+import { DocumentSymbol, SymbolTag } from 'vscode-languageserver';
+import { SafeDsServices } from '../safe-ds-module.js';
+import { SafeDsAnnotations } from '../builtins/safe-ds-annotations.js';
+import {
+    isSdsAnnotatedObject,
+    isSdsAnnotation,
+    isSdsAttribute,
+    isSdsClass,
+    isSdsEnumVariant,
+    isSdsFunction,
+    isSdsPipeline,
+    isSdsSegment,
+} from '../generated/ast.js';
 
 export class SafeDsDocumentSymbolProvider extends DefaultDocumentSymbolProvider {
     private readonly builtinAnnotations: SafeDsAnnotations;
@@ -10,28 +19,53 @@ export class SafeDsDocumentSymbolProvider extends DefaultDocumentSymbolProvider 
     constructor(services: SafeDsServices) {
         super(services);
 
-        this.builtinAnnotations = services.builtins.Annotations
+        this.builtinAnnotations = services.builtins.Annotations;
     }
 
-    protected override getSymbol(document: LangiumDocument, astNode: AstNode): DocumentSymbol[] {
-        const node = astNode.$cstNode;
-        const nameNode = this.nameProvider.getNameNode(astNode);
-        if (nameNode && node) {
-            const name = this.nameProvider.getName(astNode);
-            const isDeprecated = isSdsAnnotatedObject(astNode) && this.builtinAnnotations.isDeprecated(astNode);
+    protected override getSymbol(document: LangiumDocument, node: AstNode): DocumentSymbol[] {
+        const cstNode = node.$cstNode;
+        const nameNode = this.nameProvider.getNameNode(node);
+        if (nameNode && cstNode) {
+            const name = this.nameProvider.getName(node);
+            const isDeprecated = isSdsAnnotatedObject(node) && this.builtinAnnotations.isDeprecated(node);
 
             return [
                 {
                     name: name ?? nameNode.text,
-                    kind: this.nodeKindProvider.getSymbolKind(astNode),
-                    tags: isDeprecated ? [ SymbolTag.Deprecated ] : undefined,
-                    range: node.range,
+                    kind: this.nodeKindProvider.getSymbolKind(node),
+                    tags: isDeprecated ? [SymbolTag.Deprecated] : undefined,
+                    range: cstNode.range,
                     selectionRange: nameNode.range,
-                    children: this.getChildSymbols(document, astNode),
+                    children: this.getChildSymbols(document, node),
                 },
             ];
         } else {
-            return this.getChildSymbols(document, astNode) || [];
+            return this.getChildSymbols(document, node) || [];
         }
+    }
+
+    protected override getChildSymbols(document: LangiumDocument, node: AstNode): DocumentSymbol[] | undefined {
+        if (this.isLeaf(node)) {
+            return undefined;
+        } else if (isSdsClass(node)) {
+            if (node.body) {
+                return super.getChildSymbols(document, node.body);
+            } else {
+                return undefined;
+            }
+        } else {
+            return super.getChildSymbols(document, node);
+        }
+    }
+
+    private isLeaf(node: AstNode): boolean {
+        return (
+            isSdsAnnotation(node) ||
+            isSdsAttribute(node) ||
+            isSdsEnumVariant(node) ||
+            isSdsFunction(node) ||
+            isSdsPipeline(node) ||
+            isSdsSegment(node)
+        );
     }
 }

--- a/src/language/lsp/safe-ds-document-symbol-provider.ts
+++ b/src/language/lsp/safe-ds-document-symbol-provider.ts
@@ -5,14 +5,14 @@ import { SafeDsAnnotations } from '../builtins/safe-ds-annotations.js';
 import {
     isSdsAnnotatedObject,
     isSdsAnnotation,
-    isSdsAttribute, isSdsCallable,
+    isSdsAttribute,
     isSdsClass,
     isSdsEnumVariant,
     isSdsFunction,
     isSdsPipeline,
     isSdsSegment,
 } from '../generated/ast.js';
-import {SafeDsTypeComputer} from "../typing/safe-ds-type-computer.js";
+import { SafeDsTypeComputer } from '../typing/safe-ds-type-computer.js';
 
 export class SafeDsDocumentSymbolProvider extends DefaultDocumentSymbolProvider {
     private readonly builtinAnnotations: SafeDsAnnotations;
@@ -65,12 +65,12 @@ export class SafeDsDocumentSymbolProvider extends DefaultDocumentSymbolProvider 
             const type = this.typeComputer.computeType(node);
             return type?.toString();
         }
-        return undefined
+        return undefined;
     }
 
     private getTags(node: AstNode): SymbolTag[] | undefined {
         if (isSdsAnnotatedObject(node) && this.builtinAnnotations.isDeprecated(node)) {
-            return [SymbolTag.Deprecated]
+            return [SymbolTag.Deprecated];
         } else {
             return undefined;
         }

--- a/src/language/lsp/safe-ds-document-symbol-provider.ts
+++ b/src/language/lsp/safe-ds-document-symbol-provider.ts
@@ -1,0 +1,3 @@
+import { DefaultDocumentSymbolProvider } from 'langium';
+
+export class SafeDsDocumentSymbolProvider extends DefaultDocumentSymbolProvider {}

--- a/src/language/lsp/safe-ds-document-symbol-provider.ts
+++ b/src/language/lsp/safe-ds-document-symbol-provider.ts
@@ -1,3 +1,37 @@
-import { DefaultDocumentSymbolProvider } from 'langium';
+import {AstNode, DefaultDocumentSymbolProvider, LangiumDocument} from 'langium';
+import {DocumentSymbol, SymbolTag} from 'vscode-languageserver';
+import {SafeDsServices} from "../safe-ds-module.js";
+import {SafeDsAnnotations} from "../builtins/safe-ds-annotations.js";
+import {isSdsAnnotatedObject} from "../generated/ast.js";
 
-export class SafeDsDocumentSymbolProvider extends DefaultDocumentSymbolProvider {}
+export class SafeDsDocumentSymbolProvider extends DefaultDocumentSymbolProvider {
+    private readonly builtinAnnotations: SafeDsAnnotations;
+
+    constructor(services: SafeDsServices) {
+        super(services);
+
+        this.builtinAnnotations = services.builtins.Annotations
+    }
+
+    protected override getSymbol(document: LangiumDocument, astNode: AstNode): DocumentSymbol[] {
+        const node = astNode.$cstNode;
+        const nameNode = this.nameProvider.getNameNode(astNode);
+        if (nameNode && node) {
+            const name = this.nameProvider.getName(astNode);
+            const isDeprecated = isSdsAnnotatedObject(astNode) && this.builtinAnnotations.isDeprecated(astNode);
+
+            return [
+                {
+                    name: name ?? nameNode.text,
+                    kind: this.nodeKindProvider.getSymbolKind(astNode),
+                    tags: isDeprecated ? [ SymbolTag.Deprecated ] : undefined,
+                    range: node.range,
+                    selectionRange: nameNode.range,
+                    children: this.getChildSymbols(document, astNode),
+                },
+            ];
+        } else {
+            return this.getChildSymbols(document, astNode) || [];
+        }
+    }
+}

--- a/src/language/lsp/safe-ds-node-kind-provider.ts
+++ b/src/language/lsp/safe-ds-node-kind-provider.ts
@@ -1,6 +1,23 @@
 import { AstNode, AstNodeDescription, hasContainerOfType, isAstNode, NodeKindProvider } from 'langium';
 import { CompletionItemKind, SymbolKind } from 'vscode-languageserver';
-import { isSdsClass, isSdsFunction, SdsAnnotation } from '../generated/ast.js';
+import {
+    isSdsClass,
+    isSdsFunction,
+    SdsAnnotation,
+    SdsAttribute,
+    SdsBlockLambdaResult,
+    SdsClass,
+    SdsEnum,
+    SdsEnumVariant,
+    SdsFunction,
+    SdsModule,
+    SdsParameter,
+    SdsPipeline,
+    SdsPlaceholder,
+    SdsResult,
+    SdsSegment,
+    SdsTypeParameter,
+} from '../generated/ast.js';
 
 export class SafeDsNodeKindProvider implements NodeKindProvider {
     getSymbolKind(nodeOrDescription: AstNode | AstNodeDescription): SymbolKind {
@@ -14,29 +31,37 @@ export class SafeDsNodeKindProvider implements NodeKindProvider {
         switch (type) {
             case SdsAnnotation:
                 return SymbolKind.Interface;
-            case 'SdsAttribute':
+            case SdsAttribute:
                 return SymbolKind.Property;
-            case 'SdsClass':
+            /* c8 ignore next 2 */
+            case SdsBlockLambdaResult:
+                return SymbolKind.Variable;
+            case SdsClass:
                 return SymbolKind.Class;
-            case 'SdsEnum':
+            case SdsEnum:
                 return SymbolKind.Enum;
-            case 'SdsEnumVariant':
+            case SdsEnumVariant:
                 return SymbolKind.EnumMember;
-            case 'SdsFunction':
+            case SdsFunction:
                 return SymbolKind.Function;
-            case 'SdsModule':
+            case SdsModule:
                 return SymbolKind.Package;
-            case 'SdsParameter':
+            /* c8 ignore next 2 */
+            case SdsParameter:
                 return SymbolKind.Variable;
-            case 'SdsPipeline':
+            case SdsPipeline:
                 return SymbolKind.Function;
-            case 'SdsPlaceholder':
+            /* c8 ignore next 2 */
+            case SdsPlaceholder:
                 return SymbolKind.Variable;
-            case 'SdsSegment':
+            /* c8 ignore next 2 */
+            case SdsResult:
+                return SymbolKind.Variable;
+            case SdsSegment:
                 return SymbolKind.Function;
-            case 'SdsTypeParameter':
+            /* c8 ignore next 2 */
+            case SdsTypeParameter:
                 return SymbolKind.TypeParameter;
-
             /* c8 ignore next 2 */
             default:
                 return SymbolKind.Null;

--- a/src/language/lsp/safe-ds-node-kind-provider.ts
+++ b/src/language/lsp/safe-ds-node-kind-provider.ts
@@ -1,0 +1,12 @@
+import { NodeKindProvider } from 'langium';
+import { CompletionItemKind, SymbolKind } from 'vscode-languageserver-types';
+
+export class SafeDsNodeKindProvider implements NodeKindProvider {
+    getSymbolKind(): SymbolKind {
+        return SymbolKind.Constant;
+    }
+
+    getCompletionItemKind(): CompletionItemKind {
+        return CompletionItemKind.Reference;
+    }
+}

--- a/src/language/lsp/safe-ds-node-kind-provider.ts
+++ b/src/language/lsp/safe-ds-node-kind-provider.ts
@@ -1,12 +1,69 @@
-import { NodeKindProvider } from 'langium';
+import { AstNode, AstNodeDescription, hasContainerOfType, isAstNode, NodeKindProvider } from 'langium';
 import { CompletionItemKind, SymbolKind } from 'vscode-languageserver';
+import {
+    isSdsAnnotation,
+    isSdsAttribute,
+    isSdsClass,
+    isSdsEnum,
+    isSdsEnumVariant,
+    isSdsFunction,
+    isSdsModule,
+    isSdsParameter,
+    isSdsPipeline,
+    isSdsPlaceholder,
+    isSdsSegment,
+    isSdsTypeParameter,
+} from '../generated/ast.js';
 
 export class SafeDsNodeKindProvider implements NodeKindProvider {
-    getSymbolKind(): SymbolKind {
-        return SymbolKind.Constant;
+    getSymbolKind(nodeOrDescription: AstNode | AstNodeDescription): SymbolKind {
+        const node = this.getNode(nodeOrDescription);
+
+        if (isSdsAnnotation(node)) {
+            return SymbolKind.Interface;
+        } else if (isSdsAttribute(node)) {
+            return SymbolKind.Property;
+        } else if (isSdsClass(node)) {
+            return SymbolKind.Class;
+        } else if (isSdsEnum(node)) {
+            return SymbolKind.Enum;
+        } else if (isSdsEnumVariant(node)) {
+            return SymbolKind.EnumMember;
+        } else if (isSdsFunction(node)) {
+            if (hasContainerOfType(node, isSdsClass)) {
+                return SymbolKind.Method;
+            } else {
+                return SymbolKind.Function;
+            }
+        } else if (isSdsModule(node)) {
+            return SymbolKind.Package;
+        } else if (isSdsParameter(node)) {
+            return SymbolKind.Variable;
+        } else if (isSdsPipeline(node)) {
+            return SymbolKind.Function;
+        } else if (isSdsPlaceholder(node)) {
+            return SymbolKind.Variable;
+        } else if (isSdsSegment(node)) {
+            return SymbolKind.Function;
+        } else if (isSdsTypeParameter(node)) {
+            return SymbolKind.TypeParameter;
+        } /* c8 ignore start */ else {
+            return SymbolKind.Null;
+        } /* c8 ignore stop */
     }
 
-    getCompletionItemKind(): CompletionItemKind {
+    /* c8 ignore start */
+    getCompletionItemKind(_nodeOrDescription: AstNode | AstNodeDescription) {
         return CompletionItemKind.Reference;
+    }
+
+    /* c8 ignore stop */
+
+    private getNode(nodeOrDescription: AstNode | AstNodeDescription): AstNode | undefined {
+        if (isAstNode(nodeOrDescription)) {
+            return nodeOrDescription;
+        } /* c8 ignore start */ else {
+            return nodeOrDescription.node;
+        } /* c8 ignore stop */
     }
 }

--- a/src/language/lsp/safe-ds-node-kind-provider.ts
+++ b/src/language/lsp/safe-ds-node-kind-provider.ts
@@ -1,5 +1,5 @@
 import { NodeKindProvider } from 'langium';
-import { CompletionItemKind, SymbolKind } from 'vscode-languageserver-types';
+import { CompletionItemKind, SymbolKind } from 'vscode-languageserver';
 
 export class SafeDsNodeKindProvider implements NodeKindProvider {
     getSymbolKind(): SymbolKind {

--- a/src/language/lsp/safe-ds-semantic-token-provider.ts
+++ b/src/language/lsp/safe-ds-semantic-token-provider.ts
@@ -29,7 +29,7 @@ import {
     isSdsTypeParameter,
     isSdsTypeParameterConstraint,
 } from '../generated/ast.js';
-import { SemanticTokenModifiers, SemanticTokenTypes } from 'vscode-languageserver-types';
+import { SemanticTokenModifiers, SemanticTokenTypes } from 'vscode-languageserver';
 import { SafeDsServices } from '../safe-ds-module.js';
 import { SafeDsClasses } from '../builtins/safe-ds-classes.js';
 

--- a/src/language/lsp/safe-ds-semantic-token-provider.ts
+++ b/src/language/lsp/safe-ds-semantic-token-provider.ts
@@ -2,9 +2,9 @@ import {
     AbstractSemanticTokenProvider,
     AllSemanticTokenTypes,
     AstNode,
+    DefaultSemanticTokenOptions,
     hasContainerOfType,
     SemanticTokenAcceptor,
-    DefaultSemanticTokenOptions,
 } from 'langium';
 import {
     isSdsAnnotation,

--- a/src/language/partialEvaluation/model.ts
+++ b/src/language/partialEvaluation/model.ts
@@ -371,7 +371,7 @@ class UnknownEvaluatedNodeClass extends EvaluatedNode {
     }
 
     override toString(): string {
-        return '$unknown';
+        return '?';
     }
 }
 

--- a/src/language/safe-ds-module.ts
+++ b/src/language/safe-ds-module.ts
@@ -27,7 +27,7 @@ import { SafeDsSemanticTokenProvider } from './lsp/safe-ds-semantic-token-provid
 import { SafeDsTypeChecker } from './typing/safe-ds-type-checker.js';
 import { SafeDsCoreTypes } from './typing/safe-ds-core-types.js';
 import { SafeDsNodeKindProvider } from './lsp/safe-ds-node-kind-provider.js';
-import {SafeDsDocumentSymbolProvider} from "./lsp/safe-ds-document-symbol-provider.js";
+import { SafeDsDocumentSymbolProvider } from './lsp/safe-ds-document-symbol-provider.js';
 
 /**
  * Declaration of custom services - add your own service classes here.

--- a/src/language/safe-ds-module.ts
+++ b/src/language/safe-ds-module.ts
@@ -26,6 +26,7 @@ import { SafeDsPartialEvaluator } from './partialEvaluation/safe-ds-partial-eval
 import { SafeDsSemanticTokenProvider } from './lsp/safe-ds-semantic-token-provider.js';
 import { SafeDsTypeChecker } from './typing/safe-ds-type-checker.js';
 import { SafeDsCoreTypes } from './typing/safe-ds-core-types.js';
+import { SafeDsNodeKindProvider } from './lsp/safe-ds-node-kind-provider.js';
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -99,6 +100,9 @@ export const SafeDsModule: Module<SafeDsServices, PartialLangiumServices & SafeD
 export type SafeDsSharedServices = LangiumSharedServices;
 
 export const SafeDsSharedModule: Module<SafeDsSharedServices, DeepPartial<SafeDsSharedServices>> = {
+    lsp: {
+        NodeKindProvider: () => new SafeDsNodeKindProvider(),
+    },
     workspace: {
         WorkspaceManager: (services) => new SafeDsWorkspaceManager(services),
     },

--- a/src/language/safe-ds-module.ts
+++ b/src/language/safe-ds-module.ts
@@ -27,6 +27,7 @@ import { SafeDsSemanticTokenProvider } from './lsp/safe-ds-semantic-token-provid
 import { SafeDsTypeChecker } from './typing/safe-ds-type-checker.js';
 import { SafeDsCoreTypes } from './typing/safe-ds-core-types.js';
 import { SafeDsNodeKindProvider } from './lsp/safe-ds-node-kind-provider.js';
+import {SafeDsDocumentSymbolProvider} from "./lsp/safe-ds-document-symbol-provider.js";
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -76,6 +77,7 @@ export const SafeDsModule: Module<SafeDsServices, PartialLangiumServices & SafeD
         NodeMapper: (services) => new SafeDsNodeMapper(services),
     },
     lsp: {
+        DocumentSymbolProvider: (services) => new SafeDsDocumentSymbolProvider(services),
         Formatter: () => new SafeDsFormatter(),
         SemanticTokenProvider: (services) => new SafeDsSemanticTokenProvider(services),
     },

--- a/src/language/typing/model.ts
+++ b/src/language/typing/model.ts
@@ -350,7 +350,7 @@ class UnknownTypeClass extends Type {
     }
 
     toString(): string {
-        return '$Unknown';
+        return '?';
     }
 }
 

--- a/src/language/validation/builtins/deprecated.ts
+++ b/src/language/validation/builtins/deprecated.ts
@@ -13,7 +13,7 @@ import {
 import { SafeDsServices } from '../../safe-ds-module.js';
 import { isRequiredParameter } from '../../helpers/nodeProperties.js';
 import { parameterCanBeAnnotated } from '../other/declarations/annotationCalls.js';
-import { DiagnosticTag } from 'vscode-languageserver-types';
+import { DiagnosticTag } from 'vscode-languageserver';
 
 export const CODE_DEPRECATED_ASSIGNED_RESULT = 'deprecated/assigned-result';
 export const CODE_DEPRECATED_CALLED_ANNOTATION = 'deprecated/called-annotation';

--- a/src/language/validation/other/declarations/placeholders.ts
+++ b/src/language/validation/other/declarations/placeholders.ts
@@ -11,7 +11,7 @@ import { getContainerOfType, ValidationAcceptor } from 'langium';
 import { SafeDsServices } from '../../../safe-ds-module.js';
 import { statementsOrEmpty } from '../../../helpers/nodeProperties.js';
 import { last } from 'radash';
-import { DiagnosticTag } from 'vscode-languageserver-types';
+import { DiagnosticTag } from 'vscode-languageserver';
 
 export const CODE_PLACEHOLDER_ALIAS = 'placeholder/alias';
 export const CODE_PLACEHOLDER_UNUSED = 'placeholder/unused';

--- a/src/language/validation/other/declarations/segments.ts
+++ b/src/language/validation/other/declarations/segments.ts
@@ -2,7 +2,7 @@ import { SdsSegment } from '../../../generated/ast.js';
 import { ValidationAcceptor } from 'langium';
 import { parametersOrEmpty, resultsOrEmpty } from '../../../helpers/nodeProperties.js';
 import { SafeDsServices } from '../../../safe-ds-module.js';
-import { DiagnosticTag } from 'vscode-languageserver-types';
+import { DiagnosticTag } from 'vscode-languageserver';
 
 export const CODE_SEGMENT_DUPLICATE_YIELD = 'segment/duplicate-yield';
 export const CODE_SEGMENT_UNASSIGNED_RESULT = 'segment/unassigned-result';

--- a/tests/helpers/diagnostics.ts
+++ b/tests/helpers/diagnostics.ts
@@ -1,6 +1,6 @@
 import { parseHelper } from 'langium/test';
 import { LangiumServices, URI } from 'langium';
-import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver-types';
+import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
 import { TestDescriptionError } from './testDescription.js';
 
 let nextId = 0;

--- a/tests/language/builtins/builtinFilesCorrectness.test.ts
+++ b/tests/language/builtins/builtinFilesCorrectness.test.ts
@@ -3,7 +3,7 @@ import { listBuiltinFiles } from '../../../src/language/builtins/fileFinder.js';
 import { uriToShortenedResourceName } from '../../../src/helpers/resources.js';
 import { createSafeDsServices } from '../../../src/language/safe-ds-module.js';
 import { NodeFileSystem } from 'langium/node';
-import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver-types';
+import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
 import { isEmpty } from 'radash';
 import { URI } from 'langium';
 import { locationToString } from '../../helpers/location.js';

--- a/tests/language/lsp/formatting/creator.ts
+++ b/tests/language/lsp/formatting/creator.ts
@@ -1,6 +1,6 @@
 import { listTestSafeDsFiles, uriToShortenedTestResourceName } from '../../../helpers/testResources.js';
 import fs from 'fs';
-import { Diagnostic } from 'vscode-languageserver-types';
+import { Diagnostic } from 'vscode-languageserver';
 import { createSafeDsServices } from '../../../../src/language/safe-ds-module.js';
 import { EmptyFileSystem, URI } from 'langium';
 import { getSyntaxErrors } from '../../../helpers/diagnostics.js';

--- a/tests/language/lsp/safe-ds-document-symbol-provider.test.ts
+++ b/tests/language/lsp/safe-ds-document-symbol-provider.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { clearDocuments, parseDocument, textDocumentParams } from 'langium/test';
+import { createSafeDsServices } from '../../../src/language/safe-ds-module.js';
+import { DocumentSymbol, SymbolKind, SymbolTag } from 'vscode-languageserver';
+import { NodeFileSystem } from 'langium/node';
+
+const services = createSafeDsServices(NodeFileSystem).SafeDs;
+const symbolProvider = services.lsp.DocumentSymbolProvider!;
+
+describe('SafeDsSemanticTokenProvider', async () => {
+    beforeEach(async () => {
+        // Load the builtin library
+        await services.shared.workspace.WorkspaceManager.initializeWorkspace([]);
+    });
+
+    afterEach(async () => {
+        await clearDocuments(services);
+    });
+
+    const testCases: DocumentSymbolProviderTest[] = [
+        {
+            testName: 'annotation declaration',
+            code: 'annotation A',
+            expectedSymbols: [
+                {
+                    name: 'A',
+                    kind: SymbolKind.Interface,
+                },
+            ],
+        },
+        {
+            testName: 'attribute declaration',
+            code: `
+                class C {
+                    attr a
+                    static attr b
+                }
+            `,
+            expectedSymbols: [
+                {
+                    name: 'C',
+                    kind: SymbolKind.Class,
+                    children: [
+                        {
+                            name: 'a',
+                            kind: SymbolKind.Property,
+                        },
+                        {
+                            name: 'b',
+                            kind: SymbolKind.Property,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            testName: 'class declaration',
+            code: 'class C',
+            expectedSymbols: [
+                {
+                    name: 'C',
+                    kind: SymbolKind.Class,
+                },
+            ],
+        },
+        {
+            testName: 'enum declaration',
+            code: 'enum E',
+            expectedSymbols: [
+                {
+                    name: 'E',
+                    kind: SymbolKind.Enum,
+                },
+            ],
+        },
+        {
+            testName: 'enum variant declaration',
+            code: 'enum E { V }',
+            expectedSymbols: [
+                {
+                    name: 'E',
+                    kind: SymbolKind.Enum,
+                    children: [
+                        {
+                            name: 'V',
+                            kind: SymbolKind.EnumMember,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            testName: 'function declaration',
+            code: `
+                class C {
+                    fun f()
+                    static fun g()
+                }
+
+                fun f()
+            `,
+            expectedSymbols: [
+                {
+                    name: 'C',
+                    kind: SymbolKind.Class,
+                    children: [
+                        {
+                            name: 'f',
+                            kind: SymbolKind.Method,
+                        },
+                        {
+                            name: 'g',
+                            kind: SymbolKind.Method,
+                        },
+                    ],
+                },
+                {
+                    name: 'f',
+                    kind: SymbolKind.Function,
+                },
+            ],
+        },
+        {
+            testName: 'module',
+            code: 'package a.b.c',
+            expectedSymbols: [
+                {
+                    name: 'a.b.c',
+                    kind: SymbolKind.Package,
+                },
+            ],
+        },
+        {
+            testName: 'parameter declaration',
+            code: 'fun f(p: String)',
+            expectedSymbols: [
+                {
+                    name: 'f',
+                    kind: SymbolKind.Function,
+                    // TODO: omit parameter?
+                    children: [
+                        {
+                            name: 'p',
+                            kind: SymbolKind.Variable,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            testName: 'pipeline declaration',
+            code: 'pipeline p {}',
+            expectedSymbols: [
+                {
+                    name: 'p',
+                    kind: SymbolKind.Function,
+                },
+            ],
+        },
+        {
+            testName: 'placeholder declaration',
+            code: `
+                pipeline p {
+                    val a = 1;
+                }
+            `,
+            expectedSymbols: [
+                {
+                    name: 'p',
+                    kind: SymbolKind.Function,
+                    children: [
+                        {
+                            name: 'a',
+                            kind: SymbolKind.Variable,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            testName: 'segment declaration',
+            code: 'segment s() {}',
+            expectedSymbols: [
+                {
+                    name: 's',
+                    kind: SymbolKind.Function,
+                },
+            ],
+        },
+        {
+            testName: 'type parameter declaration',
+            code: 'class C<T>',
+            expectedSymbols: [
+                {
+                    name: 'C',
+                    kind: SymbolKind.Class,
+                    children: [
+                        {
+                            name: 'T',
+                            kind: SymbolKind.TypeParameter,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            testName: 'deprecated declaration',
+            code: `
+                package test
+
+                @Deprecated
+                class C
+            `,
+            expectedSymbols: [
+                {
+                    name: 'test',
+                    kind: SymbolKind.Package,
+                    children: [
+                        {
+                            name: 'C',
+                            kind: SymbolKind.Class,
+                            tags: [SymbolTag.Deprecated],
+                        },
+                    ],
+                },
+            ],
+        },
+    ];
+
+    it.each(testCases)('should assign the correct token types ($testName)', async ({ code, expectedSymbols }) => {
+        await checkDocumentSymbols(code, expectedSymbols);
+    });
+});
+
+const checkDocumentSymbols = async (code: string, expectedSymbols: SimpleDocumentSymbol[]) => {
+    const document = await parseDocument(services, code);
+    const symbols = (await symbolProvider.getSymbols(document, textDocumentParams(document))) ?? [];
+    const simpleSymbols = symbols.map(simplifyDocumentSymbol);
+
+    // eslint-disable-next-line vitest/prefer-strict-equal
+    expect(simpleSymbols).toEqual(expectedSymbols);
+};
+
+const simplifyDocumentSymbol = (symbol: DocumentSymbol): SimpleDocumentSymbol => {
+    return {
+        name: symbol.name,
+        kind: symbol.kind,
+        tags: symbol.tags,
+        detail: symbol.detail,
+        children: symbol.children?.map(simplifyDocumentSymbol),
+    };
+};
+
+// => Promise < void > {
+// return async input => {
+//     const document = await parseDocument(services, input.text);
+//     const symbolProvider = services.lsp.DocumentSymbolProvider;
+//     const symbols = await symbolProvider?.getSymbols(document, textDocumentParams(document)) ?? [];
+//
+//     if ('assert' in input && typeof input.assert === 'function') {
+//         input.assert(symbols);
+//     } else if ('expectedSymbols' in input) {
+//         const symbolToString = input.symbolToString ?? (symbol => symbol.name);
+//         const expectedSymbols = input.expectedSymbols;
+//
+//         if (symbols.length === expectedSymbols.length) {
+//             for (let i = 0; i < expectedSymbols.length; i++) {
+//                 const expected = expectedSymbols[i];
+//                 const item = symbols[i];
+//                 if (typeof expected === 'string') {
+//                     expectedFunction(symbolToString(item), expected);
+//                 } else {
+//                     expectedFunction(item, expected);
+//                 }
+//             }
+//         } else {
+//             const symbolsMapped = symbols.map((s, i) => expectedSymbols[i] === undefined || typeof expectedSymbols[i] === 'string' ? symbolToString(s) : s);
+//             expectedFunction(symbolsMapped, expectedSymbols, `Expected ${expectedSymbols.length} but found ${symbols.length} symbols in document`);
+//         }
+//     }
+// };
+// }
+
+/**
+ * A description of a test case for the document symbol provider.
+ */
+interface DocumentSymbolProviderTest {
+    /**
+     * A short description of the test case.
+     */
+    testName: string;
+
+    /**
+     * The code to parse.
+     */
+    code: string;
+
+    /**
+     * The expected symbols.
+     */
+    expectedSymbols: SimpleDocumentSymbol[];
+}
+
+/**
+ * A document symbol without range information.
+ */
+interface SimpleDocumentSymbol {
+    name: string;
+    kind: SymbolKind;
+    tags?: SymbolTag[];
+    detail?: string;
+    children?: SimpleDocumentSymbol[];
+}

--- a/tests/language/lsp/safe-ds-document-symbol-provider.test.ts
+++ b/tests/language/lsp/safe-ds-document-symbol-provider.test.ts
@@ -111,16 +111,19 @@ describe('SafeDsSemanticTokenProvider', async () => {
                         {
                             name: 'f',
                             kind: SymbolKind.Method,
+                            detail: '(p: Int) -> (r: Int)',
                         },
                         {
                             name: 'g',
                             kind: SymbolKind.Method,
+                            detail: '(p: Int) -> (r: Int)',
                         },
                     ],
                 },
                 {
                     name: 'f',
                     kind: SymbolKind.Function,
+                    detail: '(p: Int) -> (r: Int)',
                 },
             ],
         },
@@ -167,6 +170,7 @@ describe('SafeDsSemanticTokenProvider', async () => {
                 {
                     name: 's',
                     kind: SymbolKind.Function,
+                    detail: '(p: Int) -> (r: Int)',
                 },
             ],
         },

--- a/tests/language/lsp/safe-ds-semantic-token-provider.test.ts
+++ b/tests/language/lsp/safe-ds-semantic-token-provider.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, it } from 'vitest';
 import { clearDocuments, highlightHelper } from 'langium/test';
 import { createSafeDsServices } from '../../../src/language/safe-ds-module.js';
-import { SemanticTokenTypes } from 'vscode-languageserver-types';
+import { SemanticTokenTypes } from 'vscode-languageserver';
 import { AssertionError } from 'assert';
 import { NodeFileSystem } from 'langium/node';
 

--- a/tests/language/scoping/testScoping.test.ts
+++ b/tests/language/scoping/testScoping.test.ts
@@ -1,12 +1,11 @@
 import { afterEach, beforeEach, describe, it } from 'vitest';
 import { createSafeDsServices } from '../../../src/language/safe-ds-module.js';
-import { URI } from 'vscode-uri';
+import { LangiumDocument, Reference, URI } from 'langium';
 import { NodeFileSystem } from 'langium/node';
 import { clearDocuments, isRangeEqual } from 'langium/test';
 import { AssertionError } from 'assert';
 import { isLocationEqual, locationToString } from '../../helpers/location.js';
 import { createScopingTests, ExpectedReference } from './creator.js';
-import { LangiumDocument, Reference } from 'langium';
 import { Location } from 'vscode-languageserver';
 
 const services = createSafeDsServices(NodeFileSystem).SafeDs;

--- a/tests/language/validation/creator.ts
+++ b/tests/language/validation/creator.ts
@@ -7,7 +7,7 @@ import { findTestChecks } from '../../helpers/testChecks.js';
 import { getSyntaxErrors, SyntaxErrorsInCodeError } from '../../helpers/diagnostics.js';
 import { EmptyFileSystem, URI } from 'langium';
 import { createSafeDsServices } from '../../../src/language/safe-ds-module.js';
-import { Range } from 'vscode-languageserver-types';
+import { Range } from 'vscode-languageserver';
 import { TestDescription, TestDescriptionError } from '../../helpers/testDescription.js';
 
 const services = createSafeDsServices(EmptyFileSystem).SafeDs;

--- a/tests/language/validation/testValidation.test.ts
+++ b/tests/language/validation/testValidation.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, it } from 'vitest';
 import { createSafeDsServices } from '../../../src/language/safe-ds-module.js';
 import { NodeFileSystem } from 'langium/node';
 import { createValidationTests, ExpectedIssue } from './creator.js';
-import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver-types';
+import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
 import { AssertionError } from 'assert';
 import { clearDocuments, isRangeEqual } from 'langium/test';
 import { locationToString } from '../../helpers/location.js';

--- a/tests/resources/partial evaluation/recursive cases/calls/of enum variants/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/calls/of enum variants/main.sdstest
@@ -11,7 +11,7 @@ pipeline test {
     // $TEST$ serialization MyEnumVariantWithoutParameters()
     »MyEnum.MyEnumVariantWithoutParameters()«;
 
-    // $TEST$ serialization MyEnumVariantWithParameters($unknown, 3)
+    // $TEST$ serialization MyEnumVariantWithParameters(?, 3)
     »MyEnum.MyEnumVariantWithParameters()«;
 
         // $TEST$ serialization MyEnumVariantWithParameters(1, 3)
@@ -23,15 +23,15 @@ pipeline test {
     // $TEST$ serialization MyEnumVariantWithParameters(1, 2)
     »MyEnum.MyEnumVariantWithParameters(q = 2, p = 1)«;
 
-    // $TEST$ serialization MyEnumVariantWithParameters(1, $unknown)
+    // $TEST$ serialization MyEnumVariantWithParameters(1, ?)
     »MyEnum.MyEnumVariantWithParameters(1, f())«;
 
-    // $TEST$ serialization MyEnumVariantWithParameters(1, $unknown)
+    // $TEST$ serialization MyEnumVariantWithParameters(1, ?)
     »MyEnum.MyEnumVariantWithParameters(1, f(), 3)«;
 
-    // $TEST$ serialization MyEnumVariantWithParameters(1, $unknown)
+    // $TEST$ serialization MyEnumVariantWithParameters(1, ?)
     »MyEnum.MyEnumVariantWithParameters(1, f(), r = 3)«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »MyEnum.MyEnumVariantWithParameters(q = 2, p = 1)()«;
 }

--- a/tests/resources/partial evaluation/recursive cases/calls/unresolved/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/calls/unresolved/main.sdstest
@@ -5,9 +5,9 @@ enum MyEnum {
 }
 
 pipeline test {
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »unresolved.MyEnumVariant()«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »MyEnum.unresolved()«;
 }

--- a/tests/resources/partial evaluation/recursive cases/indexed access/on lists/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/indexed access/on lists/main.sdstest
@@ -7,18 +7,18 @@ pipeline test {
     // $TEST$ serialization 1
     »[1, 2, unresolved][0]«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »[1, 2, unresolved][2]«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »[][-1]«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »[][1]«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »[][""]«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »[][unresolved]«;
 }

--- a/tests/resources/partial evaluation/recursive cases/indexed access/on maps/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/indexed access/on maps/main.sdstest
@@ -10,12 +10,12 @@ pipeline test {
     // $TEST$ serialization 2
     »{"1": 1, "2": 2, "3": unresolved}["2"]«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »{"1": 1, "2": 2, "3": unresolved}["3"]«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »{}[1]«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »{}[unresolved]«;
 }

--- a/tests/resources/partial evaluation/recursive cases/indexed access/on other/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/indexed access/on other/main.sdstest
@@ -1,9 +1,9 @@
 package tests.partialValidation.recursiveCases.indexedAccess.onOther
 
 pipeline test {
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1[1]«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »unresolved[1]«;
 }

--- a/tests/resources/partial evaluation/recursive cases/infix operations/and/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/infix operations/and/main.sdstest
@@ -13,15 +13,15 @@ pipeline test {
     // $TEST$ serialization true
     »true and true«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 and true«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »false and 0«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »unresolved and false«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »true and unresolved«;
 }

--- a/tests/resources/partial evaluation/recursive cases/infix operations/divided by/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/infix operations/divided by/main.sdstest
@@ -14,25 +14,25 @@ pipeline test {
     »1 / 1«;
 
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 / 0«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 / 0.0«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 / -0.0«;
 
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »true / 1«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 / true«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »unresolved / 1«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 / unresolved«;
 }

--- a/tests/resources/partial evaluation/recursive cases/infix operations/elvis/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/infix operations/elvis/main.sdstest
@@ -7,9 +7,9 @@ pipeline test {
     // $TEST$ serialization false
     »null ?: false«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »unresolved ?: true«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »true ?: unresolved«;
 }

--- a/tests/resources/partial evaluation/recursive cases/infix operations/equals/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/infix operations/equals/main.sdstest
@@ -7,9 +7,9 @@ pipeline test {
     // $TEST$ serialization false
     »false == 1«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 == unresolved«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »unresolved == 1.25«;
 }

--- a/tests/resources/partial evaluation/recursive cases/infix operations/greater than or equals/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/infix operations/greater than or equals/main.sdstest
@@ -27,15 +27,15 @@ pipeline test {
     »0 >= 1«;
 
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 >= true«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »false >= 0«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »unresolved >= false«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »true >= unresolved«;
 }

--- a/tests/resources/partial evaluation/recursive cases/infix operations/greater than/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/infix operations/greater than/main.sdstest
@@ -27,15 +27,15 @@ pipeline test {
     »0 > 1«;
 
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 > true«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »false > 0«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »unresolved > false«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »true > unresolved«;
 }

--- a/tests/resources/partial evaluation/recursive cases/infix operations/identical to/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/infix operations/identical to/main.sdstest
@@ -7,9 +7,9 @@ pipeline test {
     // $TEST$ serialization false
     »false === 1«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 === unresolved«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »unresolved === 1.25«;
 }

--- a/tests/resources/partial evaluation/recursive cases/infix operations/less than or equals/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/infix operations/less than or equals/main.sdstest
@@ -27,15 +27,15 @@ pipeline test {
     »1 <= 0«;
 
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 <= true«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »false <= 0«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »unresolved <= false«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »true <= unresolved«;
 }

--- a/tests/resources/partial evaluation/recursive cases/infix operations/less than/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/infix operations/less than/main.sdstest
@@ -27,15 +27,15 @@ pipeline test {
     »1 < 1«;
 
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 < true«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »false < 0«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »unresolved < false«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »true < unresolved«;
 }

--- a/tests/resources/partial evaluation/recursive cases/infix operations/minus/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/infix operations/minus/main.sdstest
@@ -14,15 +14,15 @@ pipeline test {
     »1 - 1«;
 
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »true - 1«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 - true«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »unresolved - 1«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 - unresolved«;
 }

--- a/tests/resources/partial evaluation/recursive cases/infix operations/not equals/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/infix operations/not equals/main.sdstest
@@ -7,9 +7,9 @@ pipeline test {
     // $TEST$ serialization true
     »false != 1«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 != unresolved«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »unresolved != 1.25«;
 }

--- a/tests/resources/partial evaluation/recursive cases/infix operations/not identical to/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/infix operations/not identical to/main.sdstest
@@ -7,9 +7,9 @@ pipeline test {
     // $TEST$ serialization true
     »false !== 1«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 !== unresolved«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »unresolved !== 1.25«;
 }

--- a/tests/resources/partial evaluation/recursive cases/infix operations/or/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/infix operations/or/main.sdstest
@@ -13,15 +13,15 @@ pipeline test {
     // $TEST$ serialization true
     »true or true«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 or true«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »false or 0«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »unresolved or false«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »true or unresolved«;
 }

--- a/tests/resources/partial evaluation/recursive cases/infix operations/plus/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/infix operations/plus/main.sdstest
@@ -14,15 +14,15 @@ pipeline test {
     »1 + 1«;
 
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »true + 1«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 + true«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »unresolved + 1«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 + unresolved«;
 }

--- a/tests/resources/partial evaluation/recursive cases/infix operations/times/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/infix operations/times/main.sdstest
@@ -14,15 +14,15 @@ pipeline test {
     »1 * 1«;
 
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »true * 1«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 * true«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »unresolved * 1«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »1 * unresolved«;
 }

--- a/tests/resources/partial evaluation/recursive cases/lists/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/lists/main.sdstest
@@ -4,6 +4,6 @@ pipeline test {
     // $TEST$ serialization []
     »[]«;
 
-    // $TEST$ serialization [1, 2.5, null, $unknown]
+    // $TEST$ serialization [1, 2.5, null, ?]
     »[1, 2.5, null, unresolved]«;
 }

--- a/tests/resources/partial evaluation/recursive cases/maps/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/maps/main.sdstest
@@ -4,7 +4,7 @@ pipeline test {
     // $TEST$ serialization {}
     »{}«;
 
-    // $TEST$ serialization {"a": 1, "b": 2.5, "c": null, "d": $unknown, $unknown: true}
+    // $TEST$ serialization {"a": 1, "b": 2.5, "c": null, "d": ?, ?: true}
     »{
         "a": 1,
         "b": 2.5,

--- a/tests/resources/partial evaluation/recursive cases/member accesses/unresolved/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/member accesses/unresolved/main.sdstest
@@ -5,9 +5,9 @@ enum MyEnum {
 }
 
 pipeline test {
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »unresolved.MyEnumVariant«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »MyEnum.unresolved«;
 }

--- a/tests/resources/partial evaluation/recursive cases/prefix operations/minus/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/prefix operations/minus/main.sdstest
@@ -7,9 +7,9 @@ pipeline test {
     // $TEST$ serialization -1
     »-1«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »-true«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »-unresolved«;
 }

--- a/tests/resources/partial evaluation/recursive cases/prefix operations/not/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/prefix operations/not/main.sdstest
@@ -7,9 +7,9 @@ pipeline test {
     // $TEST$ serialization false
     »not true«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »not 0«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »not unresolved«;
 }

--- a/tests/resources/partial evaluation/recursive cases/template strings/main.sdstest
+++ b/tests/resources/partial evaluation/recursive cases/template strings/main.sdstest
@@ -7,6 +7,6 @@ pipeline test {
     // $TEST$ serialization "start	1 inner1	true inner2	test end	"
     »"start\t{{ 1 }} inner1\t{{ true }} inner2\t{{ "test" }} end\t"«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization ?
     »"start {{ call() }} end"«;
 }

--- a/tests/resources/typing/assignees/block lambda results/main.sdstest
+++ b/tests/resources/typing/assignees/block lambda results/main.sdstest
@@ -11,7 +11,7 @@ segment mySegment() -> (r: Int) {
 
     () {
         // $TEST$ serialization literal<1>
-        // $TEST$ serialization $Unknown
+        // $TEST$ serialization ?
         yield »r«, yield »s« = 1;
     };
 

--- a/tests/resources/typing/assignees/placeholders/main.sdstest
+++ b/tests/resources/typing/assignees/placeholders/main.sdstest
@@ -10,7 +10,7 @@ segment mySegment1() -> (r: Int) {
 
 segment mySegment2() -> (r: Int, s: String) {
     // $TEST$ serialization literal<1>
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     val »r«, val »s« = 1;
 }
 

--- a/tests/resources/typing/assignees/yields/main.sdstest
+++ b/tests/resources/typing/assignees/yields/main.sdstest
@@ -10,7 +10,7 @@ segment mySegment1() -> (r: Int) {
 
 segment mySegment2() -> (r: Int, s: String) {
     // $TEST$ serialization literal<1>
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     »yield r«, »yield s« = 1;
 }
 

--- a/tests/resources/typing/declarations/annotations/main.sdstest
+++ b/tests/resources/typing/declarations/annotations/main.sdstest
@@ -6,5 +6,5 @@ annotation »myAnnotation1«
 // $TEST$ serialization (p1: Int, p2: String) -> ()
 annotation »myAnnotation3«(p1: Int, p2: String)
 
-// $TEST$ serialization (p1: $Unknown) -> ()
+// $TEST$ serialization (p1: ?) -> ()
 annotation »myAnnotation5«(p1)

--- a/tests/resources/typing/declarations/attributes/main.sdstest
+++ b/tests/resources/typing/declarations/attributes/main.sdstest
@@ -1,14 +1,14 @@
 package tests.typing.declarations.attributes
 
 class C {
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     attr »a«
 
     // $TEST$ equivalence_class instanceAttribute
     // $TEST$ equivalence_class instanceAttribute
     attr »b«: »Int«
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     static attr »c«
 
     // $TEST$ equivalence_class staticAttribute

--- a/tests/resources/typing/declarations/functions/main.sdstest
+++ b/tests/resources/typing/declarations/functions/main.sdstest
@@ -12,5 +12,5 @@ fun »myFunction3«(p1: Int, p2: String)
 // $TEST$ serialization (p1: Int, p2: String) -> (r1: Int, r2: String)
 fun »myFunction4«(p1: Int, p2: String) -> (r1: Int, r2: String)
 
-// $TEST$ serialization (p1: $Unknown) -> (r1: $Unknown)
+// $TEST$ serialization (p1: ?) -> (r1: ?)
 fun »myFunction5«(p1) -> (r1)

--- a/tests/resources/typing/declarations/parameters/of annotations/main.sdstest
+++ b/tests/resources/typing/declarations/parameters/of annotations/main.sdstest
@@ -4,5 +4,5 @@ package tests.typing.declarations.parameters.ofAnnotations
 // $TEST$ equivalence_class parameterType
 annotation MyAnnotation1(»p«: »Int«)
 
-// $TEST$ serialization $Unknown
+// $TEST$ serialization ?
 annotation MyAnnotation2(»p«)

--- a/tests/resources/typing/declarations/parameters/of block lambdas/that are isolated/main.sdstest
+++ b/tests/resources/typing/declarations/parameters/of block lambdas/that are isolated/main.sdstest
@@ -1,6 +1,6 @@
 package tests.typing.declarations.parameters.ofBlockLambdas.thatAreIsolated
 
 segment mySegment() {
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     (»p«) {};
 }

--- a/tests/resources/typing/declarations/parameters/of block lambdas/that are passed as arguments/main.sdstest
+++ b/tests/resources/typing/declarations/parameters/of block lambdas/that are passed as arguments/main.sdstest
@@ -12,15 +12,15 @@ segment mySegment() {
     // $TEST$ equivalence_class parameterType1
     higherOrderFunction1(param = (»p«) {});
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     higherOrderFunction2((»p«) {});
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     higherOrderFunction2(param = (»p«) {});
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     normalFunction((»p«) {});
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     normalFunction(param = (»p«) {});
 }

--- a/tests/resources/typing/declarations/parameters/of block lambdas/that are yielded/main.sdstest
+++ b/tests/resources/typing/declarations/parameters/of block lambdas/that are yielded/main.sdstest
@@ -9,9 +9,9 @@ segment mySegment() -> (
     // $TEST$ equivalence_class parameterType2
     yield r = (»p«) {};
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     yield s = (»p«) {};
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     yield t = (»p«) {};
 }

--- a/tests/resources/typing/declarations/parameters/of callable types/main.sdstest
+++ b/tests/resources/typing/declarations/parameters/of callable types/main.sdstest
@@ -4,5 +4,5 @@ package tests.typing.declarations.parameters.ofCallableTypes
 // $TEST$ equivalence_class parameterType
 annotation MyAnnotation1(f: (»p«: »Int«) -> ())
 
-// $TEST$ serialization $Unknown
+// $TEST$ serialization ?
 annotation MyAnnotation2(f: (»p«) -> ())

--- a/tests/resources/typing/declarations/parameters/of classes/main.sdstest
+++ b/tests/resources/typing/declarations/parameters/of classes/main.sdstest
@@ -4,5 +4,5 @@ package tests.typing.declarations.parameters.ofClasses
 // $TEST$ equivalence_class parameterType
 class MyClass1(»p«: »Int«)
 
-// $TEST$ serialization $Unknown
+// $TEST$ serialization ?
 class MyClass2(»p«)

--- a/tests/resources/typing/declarations/parameters/of enum variants/main.sdstest
+++ b/tests/resources/typing/declarations/parameters/of enum variants/main.sdstest
@@ -5,6 +5,6 @@ enum MyEnum {
     // $TEST$ equivalence_class parameterType
     MyEnumVariant1(»p«: »Int«)
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     MyEnumVariant2(»p«)
 }

--- a/tests/resources/typing/declarations/parameters/of expression lambdas/that are isolated/main.sdstest
+++ b/tests/resources/typing/declarations/parameters/of expression lambdas/that are isolated/main.sdstest
@@ -1,6 +1,6 @@
 package tests.typing.declarations.parameters.ofExpressionLambdas.thatAreIsolated
 
 segment mySegment() {
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     (»p«) -> 1;
 }

--- a/tests/resources/typing/declarations/parameters/of expression lambdas/that are passed as arguments/main.sdstest
+++ b/tests/resources/typing/declarations/parameters/of expression lambdas/that are passed as arguments/main.sdstest
@@ -12,15 +12,15 @@ segment mySegment() {
     // $TEST$ equivalence_class parameterType1
     higherOrderFunction1(param = (»p«) -> "");
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     higherOrderFunction2((»p«) -> "");
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     higherOrderFunction2(param = (»p«) -> "");
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     normalFunction((»p«) -> "");
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     normalFunction(param = (»p«) -> "");
 }

--- a/tests/resources/typing/declarations/parameters/of expression lambdas/that are yielded/main.sdstest
+++ b/tests/resources/typing/declarations/parameters/of expression lambdas/that are yielded/main.sdstest
@@ -9,9 +9,9 @@ segment mySegment() -> (
     // $TEST$ equivalence_class parameterType2
     yield r = (»p«) -> true;
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     yield s = (»p«) -> true;
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     yield t = (»p«) -> true;
 }

--- a/tests/resources/typing/declarations/parameters/of functions/main.sdstest
+++ b/tests/resources/typing/declarations/parameters/of functions/main.sdstest
@@ -4,5 +4,5 @@ package tests.typing.declarations.parameters.ofFunctions
 // $TEST$ equivalence_class parameterType
 fun myFunction1(»p«: »Int«)
 
-// $TEST$ serialization $Unknown
+// $TEST$ serialization ?
 fun myFunction2(»p«)

--- a/tests/resources/typing/declarations/parameters/of segments/main.sdstest
+++ b/tests/resources/typing/declarations/parameters/of segments/main.sdstest
@@ -4,5 +4,5 @@ package tests.typing.declarations.parameters.ofSegments
 // $TEST$ equivalence_class parameterType
 segment mySegment1(»p«: »Int«) {}
 
-// $TEST$ serialization $Unknown
+// $TEST$ serialization ?
 segment mySegment2(»p«) {}

--- a/tests/resources/typing/declarations/pipelines/main.sdstest
+++ b/tests/resources/typing/declarations/pipelines/main.sdstest
@@ -1,4 +1,4 @@
 package tests.typing.declarations.pipelines
 
-// $TEST$ serialization $Unknown
+// $TEST$ serialization ?
 pipeline »myPipeline« {}

--- a/tests/resources/typing/declarations/segments/main.sdstest
+++ b/tests/resources/typing/declarations/segments/main.sdstest
@@ -12,5 +12,5 @@ segment »mySegment3«(p1: Int, p2: String) {}
 // $TEST$ serialization (p1: Int, p2: String) -> (r1: Int, r2: String)
 segment »mySegment4«(p1: Int, p2: String) -> (r1: Int, r2: String) {}
 
-// $TEST$ serialization (p1: $Unknown) -> (r1: $Unknown)
+// $TEST$ serialization (p1: ?) -> (r1: ?)
 segment »mySegment5«(p1) -> (r1) {}

--- a/tests/resources/typing/expressions/block lambdas/that are isolated/main.sdstest
+++ b/tests/resources/typing/expressions/block lambdas/that are isolated/main.sdstest
@@ -3,12 +3,12 @@ package tests.typing.expressions.blockLambdas.thatAreIsolated
 fun g() -> r: Int
 
 segment mySegment() {
-    // $TEST$ serialization (p: $Unknown) -> (r: literal<1>, s: $Unknown)
+    // $TEST$ serialization (p: ?) -> (r: literal<1>, s: ?)
     »(p) {
         yield r, yield s = 1;
     }«;
 
-    // $TEST$ serialization (p: $Unknown) -> (r: Int, s: $Unknown)
+    // $TEST$ serialization (p: ?) -> (r: Int, s: ?)
     val f = »(p) {
         yield r, yield s = g();
     }«;

--- a/tests/resources/typing/expressions/block lambdas/that are passed as arguments/main.sdstest
+++ b/tests/resources/typing/expressions/block lambdas/that are passed as arguments/main.sdstest
@@ -12,34 +12,34 @@ segment mySegment() {
         yield s = "";
     }«);
 
-    // $TEST$ serialization (p: String) -> (r: literal<1>, s: $Unknown)
+    // $TEST$ serialization (p: String) -> (r: literal<1>, s: ?)
     higherOrderFunction1(param = »(p) {
         yield r, yield s = 1;
     }«);
 
-    // $TEST$ serialization (p: $Unknown) -> (r: literal<1>, s: literal<"">)
+    // $TEST$ serialization (p: ?) -> (r: literal<1>, s: literal<"">)
     higherOrderFunction2(»(p) {
         yield r = 1;
         yield s = "";
     }«);
 
-    // $TEST$ serialization (p: $Unknown) -> (r: literal<1>, s: $Unknown)
+    // $TEST$ serialization (p: ?) -> (r: literal<1>, s: ?)
     higherOrderFunction2(param = »(p) {
         yield r, yield s = 1;
     }«);
 
-    // $TEST$ serialization (p: $Unknown) -> (r: literal<1>, s: literal<"">)
+    // $TEST$ serialization (p: ?) -> (r: literal<1>, s: literal<"">)
     normalFunction(»(p) {
         yield r = 1;
         yield s = "";
     }«);
 
-    // $TEST$ serialization (p: $Unknown) -> (r: literal<1>, s: $Unknown)
+    // $TEST$ serialization (p: ?) -> (r: literal<1>, s: ?)
     normalFunction(param = »(p) {
         yield r, yield s = 1;
     }«);
 
-    // $TEST$ serialization (p: $Unknown) -> (r: literal<1>, s: $Unknown)
+    // $TEST$ serialization (p: ?) -> (r: literal<1>, s: ?)
     parameterlessFunction(»(p) {
         yield r, yield s = 1;
     }«);

--- a/tests/resources/typing/expressions/block lambdas/that are yielded/main.sdstest
+++ b/tests/resources/typing/expressions/block lambdas/that are yielded/main.sdstest
@@ -11,13 +11,13 @@ segment mySegment() -> (
         yield s = "";
     }«;
 
-    // $TEST$ serialization (p: $Unknown) -> (r: literal<1>, s: literal<"">)
+    // $TEST$ serialization (p: ?) -> (r: literal<1>, s: literal<"">)
     yield s = »(p) {
         yield r = 1;
         yield s = "";
     }«;
 
-    // $TEST$ serialization (p: $Unknown) -> (r: literal<1>, s: $Unknown)
+    // $TEST$ serialization (p: ?) -> (r: literal<1>, s: ?)
     yield t = »(p) {
         yield r, yield s = 1;
     }«;

--- a/tests/resources/typing/expressions/block lambdas/with manifest types/main.sdstest
+++ b/tests/resources/typing/expressions/block lambdas/with manifest types/main.sdstest
@@ -7,7 +7,7 @@ segment mySegment() {
         yield s = "";
     }«;
 
-    // $TEST$ serialization (p: String) -> (r: literal<1>, s: $Unknown)
+    // $TEST$ serialization (p: String) -> (r: literal<1>, s: ?)
     »(p: String) {
         yield r, yield s = 1;
     }«;

--- a/tests/resources/typing/expressions/calls/of annotations/main.sdstest
+++ b/tests/resources/typing/expressions/calls/of annotations/main.sdstest
@@ -3,6 +3,6 @@ package tests.typing.expressions.calls.ofAnnotations
 annotation MyAnnotation
 
 pipeline myPipeline {
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     »MyAnnotation()«;
 }

--- a/tests/resources/typing/expressions/calls/of classes/main.sdstest
+++ b/tests/resources/typing/expressions/calls/of classes/main.sdstest
@@ -6,6 +6,6 @@ pipeline myPipeline {
     // $TEST$ serialization C
     »C()«;
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     »C()()«;
 }

--- a/tests/resources/typing/expressions/calls/of enum variants/main.sdstest
+++ b/tests/resources/typing/expressions/calls/of enum variants/main.sdstest
@@ -10,7 +10,7 @@ pipeline myPipeline {
     // $TEST$ serialization MyEnumVariantWithoutParameterList
     »MyEnum.MyEnumVariantWithoutParameterList()«;
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     val alias1 = MyEnum.MyEnumVariantWithoutParameterList;
     »alias1()«;
 
@@ -18,14 +18,14 @@ pipeline myPipeline {
     // $TEST$ serialization MyEnumVariantWithoutParameters
     »MyEnum.MyEnumVariantWithoutParameters()«;
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     val alias2 = MyEnum.MyEnumVariantWithoutParameters;
     »alias2()«;
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     »MyEnum.MyEnumVariantWithoutParameters()()«;
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     val alias3 = MyEnum.MyEnumVariantWithoutParameters();
     »alias3()«;
 
@@ -38,10 +38,10 @@ pipeline myPipeline {
     »alias4(1)«;
 
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     »MyEnum.MyEnumVariantWithParameters(1)()«;
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     val alias5 = MyEnum.MyEnumVariantWithParameters(1);
     »alias5()«;
 }

--- a/tests/resources/typing/expressions/calls/of non-callable/main.sdstest
+++ b/tests/resources/typing/expressions/calls/of non-callable/main.sdstest
@@ -3,6 +3,6 @@ package tests.typing.expressions.calls.ofNonCallables
 enum MyEnum
 
 pipeline myPipeline {
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     »MyEnum()«;
 }

--- a/tests/resources/typing/expressions/calls/unresolved/main.sdstest
+++ b/tests/resources/typing/expressions/calls/unresolved/main.sdstest
@@ -1,6 +1,6 @@
 package tests.typing.expressions.calls.ofUnresolved
 
 pipeline myPipeline {
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     »unresolved()«;
 }

--- a/tests/resources/typing/expressions/expression lambdas/that are isolated/main.sdstest
+++ b/tests/resources/typing/expressions/expression lambdas/that are isolated/main.sdstest
@@ -3,9 +3,9 @@ package tests.typing.expressions.expressionLambdas.thatAreIsolated
 fun g() -> r: Int
 
 segment mySegment() {
-    // $TEST$ serialization (p: $Unknown) -> (result: Int)
+    // $TEST$ serialization (p: ?) -> (result: Int)
     »(p) -> g()«;
 
-    // $TEST$ serialization (p: $Unknown) -> (result: literal<1>)
+    // $TEST$ serialization (p: ?) -> (result: literal<1>)
     val f = »(p) -> 1«;
 }

--- a/tests/resources/typing/expressions/expression lambdas/that are passed as arguments/main.sdstest
+++ b/tests/resources/typing/expressions/expression lambdas/that are passed as arguments/main.sdstest
@@ -12,18 +12,18 @@ segment mySegment() {
     // $TEST$ serialization (p: String) -> (result: literal<1>)
     higherOrderFunction1(param = »(p) -> 1«);
 
-    // $TEST$ serialization (p: $Unknown) -> (result: literal<1>)
+    // $TEST$ serialization (p: ?) -> (result: literal<1>)
     higherOrderFunction2(»(p) -> 1«);
 
-    // $TEST$ serialization (p: $Unknown) -> (result: literal<1>)
+    // $TEST$ serialization (p: ?) -> (result: literal<1>)
     higherOrderFunction2(param = »(p) -> 1«);
 
-    // $TEST$ serialization (p: $Unknown) -> (result: literal<1>)
+    // $TEST$ serialization (p: ?) -> (result: literal<1>)
     normalFunction(»(p) -> 1«);
 
-    // $TEST$ serialization (p: $Unknown) -> (result: literal<1>)
+    // $TEST$ serialization (p: ?) -> (result: literal<1>)
     normalFunction(param = »(p) -> 1«);
 
-    // $TEST$ serialization (p: $Unknown) -> (result: literal<1>)
+    // $TEST$ serialization (p: ?) -> (result: literal<1>)
     parameterlessFunction(»(p) -> 1«);
 }

--- a/tests/resources/typing/expressions/expression lambdas/that are yielded/main.sdstest
+++ b/tests/resources/typing/expressions/expression lambdas/that are yielded/main.sdstest
@@ -8,9 +8,9 @@ segment mySegment() -> (
     // $TEST$ serialization (p: String) -> (result: literal<1>)
     yield r = »(p) -> 1«;
 
-    // $TEST$ serialization (p: $Unknown) -> (result: literal<1>)
+    // $TEST$ serialization (p: ?) -> (result: literal<1>)
     yield s = »(p) -> 1«;
 
-    // $TEST$ serialization (p: $Unknown) -> (result: literal<1>)
+    // $TEST$ serialization (p: ?) -> (result: literal<1>)
     yield t = »(p) -> 1«;
 }

--- a/tests/resources/typing/expressions/indexed accesses/main.sdstest
+++ b/tests/resources/typing/expressions/indexed accesses/main.sdstest
@@ -13,11 +13,11 @@ segment mySegment2(param: Map<String, Int>) {
 }
 
 segment mySegment3(param: String) {
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     »param[0]«;
 }
 
 segment mySegment4() {
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     »unresolved[0]«;
 }

--- a/tests/resources/typing/expressions/member accesses/unresolved/main.sdstest
+++ b/tests/resources/typing/expressions/member accesses/unresolved/main.sdstest
@@ -3,9 +3,9 @@ package tests.typing.expressions.memberAccesses.unresolved
 class C
 
 pipeline myPipeline {
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     »C.unresolved«;
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     »C?.unresolved«;
 }

--- a/tests/resources/typing/expressions/references/unresolved/main.sdstest
+++ b/tests/resources/typing/expressions/references/unresolved/main.sdstest
@@ -1,6 +1,6 @@
 package tests.typing.expressions.references.unresolved
 
 pipeline myPipeline {
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     »unresolved«;
 }

--- a/tests/resources/typing/types/callable types/main.sdstest
+++ b/tests/resources/typing/types/callable types/main.sdstest
@@ -12,5 +12,5 @@ fun myFunction3(f: »(p1: Int, p2: String) -> ()«)
 // $TEST$ serialization (p1: Int, p2: String) -> (r1: Int, r2: String)
 fun myFunction4(f: »(p1: Int, p2: String) -> (r1: Int, r2: String)«)
 
-// $TEST$ serialization (p1: $Unknown) -> (r1: $Unknown)
+// $TEST$ serialization (p1: ?) -> (r1: ?)
 fun myFunction5(f: »(p1) -> (r1)«)

--- a/tests/resources/typing/types/member types/main.sdstest
+++ b/tests/resources/typing/types/member types/main.sdstest
@@ -20,7 +20,7 @@ fun nonNullableMemberTypes(
     b: »MyClass.MyNestedEnum«,
     // $TEST$ equivalence_class myEnumVariant
     d: »MyEnum.MyEnumVariant«,
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     e: »MyEnum.unresolved«,
 )
 
@@ -31,6 +31,6 @@ fun nullableMemberTypes(
     b: »MyClass.MyNestedEnum?«,
     // $TEST$ serialization MyEnumVariant?
     d: »MyEnum.MyEnumVariant?«,
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     e: »MyEnum.unresolved?«,
 )

--- a/tests/resources/typing/types/named types/main.sdstest
+++ b/tests/resources/typing/types/named types/main.sdstest
@@ -9,7 +9,7 @@ fun nonNullableNamedTypes(
     a: »MyClass«,
     // $TEST$ serialization MyEnum
     b: »MyEnum«,
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     c: »unresolved«,
 )
 
@@ -18,6 +18,6 @@ fun nullableNamedTypes(
     a: »MyClass?«,
     // $TEST$ serialization MyEnum?
     b: »MyEnum?«,
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     c: »unresolved?«,
 )

--- a/tests/resources/typing/types/type arguments/main.sdstest
+++ b/tests/resources/typing/types/type arguments/main.sdstest
@@ -22,8 +22,8 @@ fun myFunction(
     // $TEST$ serialization Boolean
     f: unresolved<»T = Boolean«>,
 
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     g: MyClass<»unresolved«>,
-    // $TEST$ serialization $Unknown
+    // $TEST$ serialization ?
     h: MyClass<»T = unresolved«>,
 )


### PR DESCRIPTION
### Summary of Changes

Implement a document symbol provider. Compared to the default provider, it sets proper symbol kinds, adds details for functions and segments to show their signature, and marks symbols as deprecated.