### PR TITLE
feat: mark union types as experimental

### DIFF
--- a/src/language/validation/experimentalLanguageFeatures.ts
+++ b/src/language/validation/experimentalLanguageFeatures.ts
@@ -1,4 +1,4 @@
-import { SdsIndexedAccess, SdsLiteralType, SdsMap } from '../generated/ast.js';
+import { SdsIndexedAccess, SdsLiteralType, SdsMap, SdsUnionType } from '../generated/ast.js';
 import { ValidationAcceptor } from 'langium';
 
 export const CODE_EXPERIMENTAL_LANGUAGE_FEATURE = 'experimental/language-feature';
@@ -19,6 +19,13 @@ export const literalTypesShouldBeUsedWithCaution = (node: SdsLiteralType, accept
 
 export const mapsShouldBeUsedWithCaution = (node: SdsMap, accept: ValidationAcceptor): void => {
     accept('warning', 'Map literals are experimental and may change without prior notice.', {
+        node,
+        code: CODE_EXPERIMENTAL_LANGUAGE_FEATURE,
+    });
+};
+
+export const unionTypesShouldBeUsedWithCaution = (node: SdsUnionType, accept: ValidationAcceptor): void => {
+    accept('warning', 'Union types are experimental and may change without prior notice.', {
         node,
         code: CODE_EXPERIMENTAL_LANGUAGE_FEATURE,
     });

--- a/src/language/validation/safe-ds-validator.ts
+++ b/src/language/validation/safe-ds-validator.ts
@@ -98,6 +98,7 @@ import {
     indexedAccessesShouldBeUsedWithCaution,
     literalTypesShouldBeUsedWithCaution,
     mapsShouldBeUsedWithCaution,
+    unionTypesShouldBeUsedWithCaution,
 } from './experimentalLanguageFeatures.js';
 import { requiredParameterMustNotBeExpert } from './builtins/expert.js';
 import {
@@ -273,6 +274,7 @@ export const registerValidationChecks = function (services: SafeDsServices) {
         SdsTypeParameterList: [typeParameterListShouldNotBeEmpty],
         SdsUnionType: [
             unionTypeMustHaveTypes,
+            unionTypesShouldBeUsedWithCaution,
             unionTypeShouldNotHaveDuplicateTypes(services),
             unionTypeShouldNotHaveASingularTypeArgument,
         ],

--- a/tests/resources/validation/experimental language feature/union types/main.sdstest
+++ b/tests/resources/validation/experimental language feature/union types/main.sdstest
@@ -1,0 +1,6 @@
+package tests.validation.experimentalLanguageFeature.unionTypes
+
+fun myFunction(
+    // $TEST$ warning "Union types are experimental and may change without prior notice."
+    p: »union<>«
+)


### PR DESCRIPTION
Closes #674

### Summary of Changes

Using a union type now shows a warning that this language feature is experimental.