### PR TITLE
feat: error if @PythonName and @PythonCall are set on a function

### DIFF
--- a/src/language/validation/builtins/pythonModule.ts
+++ b/src/language/validation/builtins/pythonModule.ts
@@ -20,6 +20,7 @@ export const pythonModuleShouldDifferFromSafeDsPackage = (services: SafeDsServic
             'The Python module is identical to the Safe-DS package, so the annotation call can be removed.',
             {
                 node: annotationCall,
+                property: 'annotation',
                 code: CODE_PYTHON_MODULE_SAME_AS_SAFE_DS_PACKAGE,
             },
         );

--- a/src/language/validation/builtins/pythonName.ts
+++ b/src/language/validation/builtins/pythonName.ts
@@ -17,6 +17,7 @@ export const pythonNameShouldDifferFromSafeDsName = (services: SafeDsServices) =
         const annotationCall = findFirstAnnotationCallOf(node, builtinAnnotations.PythonName)!;
         accept('info', 'The Python name is identical to the Safe-DS name, so the annotation call can be removed.', {
             node: annotationCall,
+            property: 'annotation',
             code: CODE_PYTHON_NAME_SAME_AS_SAFE_DS_NAME,
         });
     };

--- a/src/language/validation/builtins/pythonName.ts
+++ b/src/language/validation/builtins/pythonName.ts
@@ -1,9 +1,25 @@
 import { ValidationAcceptor } from 'langium';
-import { SdsDeclaration } from '../../generated/ast.js';
+import { SdsDeclaration, SdsFunction } from '../../generated/ast.js';
 import { SafeDsServices } from '../../safe-ds-module.js';
 import { findFirstAnnotationCallOf } from '../../helpers/nodeProperties.js';
 
+export const CODE_PYTHON_NAME_MUTUALLY_EXCLUSIVE_WITH_PYTHON_CALL = 'python-name/mutually-exclusive-with-python-call';
 export const CODE_PYTHON_NAME_SAME_AS_SAFE_DS_NAME = 'python-name/same-as-safe-ds-name';
+
+export const pythonNameMustNotBeSetIfPythonCallIsSet = (services: SafeDsServices) => {
+    const builtinAnnotations = services.builtins.Annotations;
+
+    return (node: SdsFunction, accept: ValidationAcceptor) => {
+        if (builtinAnnotations.getPythonCall(node)) {
+            const annotationCall = findFirstAnnotationCallOf(node, builtinAnnotations.PythonName)!;
+            accept('error', 'A Python name must not be set if a Python call is set.', {
+                node: annotationCall,
+                property: 'annotation',
+                code: CODE_PYTHON_NAME_MUTUALLY_EXCLUSIVE_WITH_PYTHON_CALL,
+            });
+        }
+    };
+};
 
 export const pythonNameShouldDifferFromSafeDsName = (services: SafeDsServices) => {
     const builtinAnnotations = services.builtins.Annotations;

--- a/src/language/validation/builtins/pythonName.ts
+++ b/src/language/validation/builtins/pythonName.ts
@@ -1,7 +1,7 @@
 import { ValidationAcceptor } from 'langium';
 import { SdsDeclaration, SdsFunction } from '../../generated/ast.js';
 import { SafeDsServices } from '../../safe-ds-module.js';
-import { findFirstAnnotationCallOf } from '../../helpers/nodeProperties.js';
+import { findFirstAnnotationCallOf, hasAnnotationCallOf } from '../../helpers/nodeProperties.js';
 
 export const CODE_PYTHON_NAME_MUTUALLY_EXCLUSIVE_WITH_PYTHON_CALL = 'python-name/mutually-exclusive-with-python-call';
 export const CODE_PYTHON_NAME_SAME_AS_SAFE_DS_NAME = 'python-name/same-as-safe-ds-name';
@@ -10,14 +10,20 @@ export const pythonNameMustNotBeSetIfPythonCallIsSet = (services: SafeDsServices
     const builtinAnnotations = services.builtins.Annotations;
 
     return (node: SdsFunction, accept: ValidationAcceptor) => {
-        if (builtinAnnotations.getPythonCall(node)) {
-            const annotationCall = findFirstAnnotationCallOf(node, builtinAnnotations.PythonName)!;
-            accept('error', 'A Python name must not be set if a Python call is set.', {
-                node: annotationCall,
-                property: 'annotation',
-                code: CODE_PYTHON_NAME_MUTUALLY_EXCLUSIVE_WITH_PYTHON_CALL,
-            });
+        if (!hasAnnotationCallOf(node, builtinAnnotations.PythonCall)) {
+            return;
         }
+
+        const firstPythonName = findFirstAnnotationCallOf(node, builtinAnnotations.PythonName);
+        if (!firstPythonName) {
+            return;
+        }
+
+        accept('error', 'A Python name must not be set if a Python call is set.', {
+            node: firstPythonName,
+            property: 'annotation',
+            code: CODE_PYTHON_NAME_MUTUALLY_EXCLUSIVE_WITH_PYTHON_CALL,
+        });
     };
 };
 

--- a/src/language/validation/safe-ds-validator.ts
+++ b/src/language/validation/safe-ds-validator.ts
@@ -124,7 +124,10 @@ import {
     namedTypeTypeArgumentListMustNotHavePositionalArgumentsAfterNamedArguments,
 } from './other/types/namedTypes.js';
 import { classMustNotInheritItself, classMustOnlyInheritASingleClass } from './inheritance.js';
-import { pythonNameShouldDifferFromSafeDsName } from './builtins/pythonName.js';
+import {
+    pythonNameMustNotBeSetIfPythonCallIsSet,
+    pythonNameShouldDifferFromSafeDsName,
+} from './builtins/pythonName.js';
 import { pythonModuleShouldDifferFromSafeDsPackage } from './builtins/pythonModule.js';
 import { divisionDivisorMustNotBeZero } from './other/expressions/infixOperations.js';
 import { constantParameterMustHaveConstantDefaultValue } from './other/declarations/parameters.js';
@@ -209,7 +212,11 @@ export const registerValidationChecks = function (services: SafeDsServices) {
         SdsEnumBody: [enumBodyShouldNotBeEmpty],
         SdsEnumVariant: [enumVariantMustContainUniqueNames, enumVariantParameterListShouldNotBeEmpty],
         SdsExpressionLambda: [expressionLambdaMustContainUniqueNames],
-        SdsFunction: [functionMustContainUniqueNames, functionResultListShouldNotBeEmpty],
+        SdsFunction: [
+            functionMustContainUniqueNames,
+            functionResultListShouldNotBeEmpty,
+            pythonNameMustNotBeSetIfPythonCallIsSet(services),
+        ],
         SdsImport: [importPackageMustExist(services), importPackageShouldNotBeEmpty(services)],
         SdsImportedDeclaration: [importedDeclarationAliasShouldDifferFromDeclarationName],
         SdsIndexedAccess: [indexedAccessesShouldBeUsedWithCaution],

--- a/tests/resources/validation/builtins/annotations/pythonModule/error.sdstest
+++ b/tests/resources/validation/builtins/annotations/pythonModule/error.sdstest
@@ -1,4 +1,4 @@
 // $TEST$ info "The Python module is identical to the Safe-DS package, so the annotation call can be removed."
-»@PythonModule("tests.validation.builtins.annotations.pythonModule")«
+@»PythonModule«("tests.validation.builtins.annotations.pythonModule")
 
 package tests.validation.builtins.annotations.pythonModule

--- a/tests/resources/validation/builtins/annotations/pythonModule/no error.sdstest
+++ b/tests/resources/validation/builtins/annotations/pythonModule/no error.sdstest
@@ -1,6 +1,6 @@
 // $TEST$ no info "The Python module is identical to the Safe-DS package, so the annotation call can be removed."
-»@PythonModule("tests.validation.builtins.annotations.pythonModule.other")«
+@»PythonModule«("tests.validation.builtins.annotations.pythonModule.other")
 // $TEST$ no info "The Python module is identical to the Safe-DS package, so the annotation call can be removed."
-»@PythonModule("tests.validation.builtins.annotations.pythonModule")«
+@»PythonModule«("tests.validation.builtins.annotations.pythonModule")
 
 package tests.validation.builtins.annotations.pythonModule

--- a/tests/resources/validation/builtins/annotations/pythonName/identical to safe-ds name/main.sdstest
+++ b/tests/resources/validation/builtins/annotations/pythonName/identical to safe-ds name/main.sdstest
@@ -1,11 +1,11 @@
-package tests.validation.builtins.annotations.pythonName
+package tests.validation.builtins.annotations.pythonName.identicalToSafeDsName
 
 // $TEST$ info "The Python name is identical to the Safe-DS name, so the annotation call can be removed."
-»@PythonName("TestClass1")«
+@»PythonName«("TestClass1")
 class TestClass1
 
 // $TEST$ no info "The Python name is identical to the Safe-DS name, so the annotation call can be removed."
-»@PythonName("Test_Class_2")«
+@»PythonName«("Test_Class_2")
 // $TEST$ no info "The Python name is identical to the Safe-DS name, so the annotation call can be removed."
-»@PythonName("TestClass2")«
+@»PythonName«("TestClass2")
 class TestClass2

--- a/tests/resources/validation/builtins/annotations/pythonName/identical to safe-ds name/no annotation.sdstest
+++ b/tests/resources/validation/builtins/annotations/pythonName/identical to safe-ds name/no annotation.sdstest
@@ -1,4 +1,4 @@
-package tests.validation.builtins.annotations.pythonName
+package tests.validation.builtins.annotations.pythonName.identicalToSafeDsName
 
 // $TEST$ no info "The Python name is identical to the Safe-DS name, so the annotation call can be removed."
 class TestClass3

--- a/tests/resources/validation/builtins/annotations/pythonName/mutually exclusive with python call/main.sdstest
+++ b/tests/resources/validation/builtins/annotations/pythonName/mutually exclusive with python call/main.sdstest
@@ -1,0 +1,26 @@
+package tests.validation.builtins.annotations.pythonName.mutuallyExclusiveWithPythonCall
+
+@PythonCall("myFunction1()")
+// $TEST$ error "A Python name must not be set if a Python call is set."
+@»PythonName«("my_function_1")
+// $TEST$ no error "A Python name must not be set if a Python call is set."
+@»PythonName«("my_function_1")
+fun myFunction1()
+
+// $TEST$ error "A Python name must not be set if a Python call is set."
+@»PythonName«("my_function_2")
+// $TEST$ no error "A Python name must not be set if a Python call is set."
+@»PythonName«("my_function_2")
+@PythonCall("myFunction2()")
+fun myFunction2()
+
+// $TEST$ no error "A Python name must not be set if a Python call is set."
+@»PythonName«("my_function_3")
+fun myFunction3()
+
+// $TEST$ no error "A Python name must not be set if a Python call is set."
+@»PythonName«("my_function_2")
+// $TEST$ no error "A Python name must not be set if a Python call is set."
+@»PythonName«("my_function_2")
+@PythonCall("myFunction2()")
+class MyClass()


### PR DESCRIPTION
### Summary of Changes

`@PythonCall` is a more general version of `@PythonName`. If `@PythonCall` is set, `@PythonName` gets ignored completely. We now show an error if both annotation are used together on a function.