### PR TITLE
feat: syntax highlighting in documentation comments

### DIFF
--- a/src/language/lsp/safe-ds-semantic-token-provider.ts
+++ b/src/language/lsp/safe-ds-semantic-token-provider.ts
@@ -24,6 +24,7 @@ import {
     isSdsPipeline,
     isSdsPlaceholder,
     isSdsReference,
+    isSdsResult,
     isSdsSchema,
     isSdsSegment,
     isSdsTypeArgument,
@@ -206,6 +207,12 @@ export class SafeDsSemanticTokenProvider extends AbstractSemanticTokenProvider {
             return {
                 type: SemanticTokenTypes.variable,
                 modifier: [SemanticTokenModifiers.readonly, ...additionalModifiers],
+            };
+        } else if (isSdsResult(node)) {
+            return {
+                // For lack of a better option, we use the token type for parameters here
+                type: SemanticTokenTypes.parameter,
+                modifier: additionalModifiers,
             };
         } else if (isSdsSchema(node)) {
             return {

--- a/syntaxes/safe-ds.tmLanguage.json
+++ b/syntaxes/safe-ds.tmLanguage.json
@@ -1,98 +1,94 @@
 {
-  "name": "safe-ds",
-  "scopeName": "source.safe-ds",
-  "fileTypes": [
-    ".sdspipe",
-    ".sdsstub",
-    ".sdstest"
-  ],
-  "patterns": [
-    {
-      "include": "#comments"
-    },
-    {
-      "name": "constant.numeric.safe-ds",
-      "match": "\\b([0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?)\\b"
-    },
-    {
-      "name": "constant.language.safe-ds",
-      "match": "\\b(false|null|true)\\b"
-    },
-    {
-      "name": "storage.type.safe-ds",
-      "match": "\\b(annotation|attr|class|enum|fun|package|pipeline|schema|segment|val)\\b"
-    },
-    {
-      "name": "storage.modifier.safe-ds",
-      "match": "\\b(const|in|internal|out|private|static)\\b"
-    },
-    {
-      "name": "keyword.operator.safe-ds",
-      "match": "\\b(and|not|or|sub|super)\\b"
-    },
-    {
-      "name": "keyword.other.safe-ds",
-      "match": "\\b(as|from|import|literal|union|where|yield)\\b"
-    },
-    {
-      "name": "meta.safe-ds",
-      "begin": "\\`",
-      "end": "\\`"
-    },
-    {
-      "name": "string.interpolated.safe-ds",
-      "begin": "\"|}}",
-      "end": "{{|\"",
-      "patterns": [
+    "name": "safe-ds",
+    "scopeName": "source.safe-ds",
+    "fileTypes": [
+        ".sdspipe",
+        ".sdsstub",
+        ".sdstest"
+    ],
+    "patterns": [
         {
-          "include": "#string-character-escape"
-        }
-      ]
-    },
-    {
-      "name": "string.quoted.double.safe-ds",
-      "begin": "\"",
-      "end": "\"",
-      "patterns": [
-        {
-          "include": "#string-character-escape"
-        }
-      ]
-    }
-  ],
-  "repository": {
-    "comments": {
-      "patterns": [
-        {
-          "name": "comment.line.double-slash.safe-ds",
-          "begin": "//",
-          "beginCaptures": {
-            "1": {
-              "name": "punctuation.whitespace.comment.leading.safe-ds"
-            }
-          },
-          "end": "(?=$)"
+            "include": "#comments"
         },
         {
-          "name": "comment.block.safe-ds",
-          "begin": "/\\*",
-          "beginCaptures": {
-            "0": {
-              "name": "punctuation.definition.comment.safe-ds"
-            }
-          },
-          "end": "\\*/",
-          "endCaptures": {
-            "0": {
-              "name": "punctuation.definition.comment.safe-ds"
-            }
-          }
+            "name": "constant.numeric.safe-ds",
+            "match": "\\b([0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?)\\b"
+        },
+        {
+            "name": "constant.language.safe-ds",
+            "match": "\\b(false|null|true)\\b"
+        },
+        {
+            "name": "storage.type.safe-ds",
+            "match": "\\b(annotation|attr|class|enum|fun|package|pipeline|schema|segment|val)\\b"
+        },
+        {
+            "name": "storage.modifier.safe-ds",
+            "match": "\\b(const|in|internal|out|private|static)\\b"
+        },
+        {
+            "name": "keyword.operator.safe-ds",
+            "match": "\\b(and|not|or|sub|super)\\b"
+        },
+        {
+            "name": "keyword.other.safe-ds",
+            "match": "\\b(as|from|import|literal|union|where|yield)\\b"
+        },
+        {
+            "name": "meta.safe-ds",
+            "begin": "\\`",
+            "end": "\\`"
+        },
+        {
+            "name": "string.interpolated.safe-ds",
+            "begin": "\"|}}",
+            "end": "{{|\"",
+            "patterns": [
+                {
+                    "include": "#string-character-escape"
+                }
+            ]
+        },
+        {
+            "name": "string.quoted.double.safe-ds",
+            "begin": "\"",
+            "end": "\"",
+            "patterns": [
+                {
+                    "include": "#string-character-escape"
+                }
+            ]
         }
-      ]
-    },
-    "string-character-escape": {
-      "name": "constant.character.escape.safe-ds",
-      "match": "\\\\(b|f|n|r|t|v|0|'|\"|{|\\\\|u[0-9a-fA-F]{4})"
+    ],
+    "repository": {
+        "comments": {
+            "patterns": [
+                {
+                    "name": "comment.line.double-slash.safe-ds",
+                    "begin": "//",
+                    "end": "(?=$)"
+                },
+                {
+                    "name": "comment.block.documentation.safe-ds",
+                    "begin": "/\\*\\*",
+                    "end": "\\*/",
+                    "patterns": [
+                        {
+                            "name": "keyword.other.safe-ds",
+                            "match": "(@param|@result|@since|@typeParam)\\b"
+                        }
+                    ]
+                },
+                {
+                    "name": "comment.block.safe-ds",
+                    "begin": "/\\*",
+                    "end": "\\*/"
+                }
+            ]
+        },
+        "string-character-escape": {
+            "name": "constant.character.escape.safe-ds",
+            "match": "\\\\(b|f|n|r|t|v|0|'|\"|{|\\\\|u[0-9a-fA-F]{4})"
+        }
     }
-  }
 }

--- a/syntaxes/safe-ds.tmLanguage.json
+++ b/syntaxes/safe-ds.tmLanguage.json
@@ -74,8 +74,30 @@
                     "end": "\\*/",
                     "patterns": [
                         {
-                            "name": "keyword.other.safe-ds",
-                            "match": "(@param|@result|@since|@typeParam)\\b"
+                            "match": "(@param|@result)\\s+([_a-zA-Z][_a-zA-Z0-9]*)?",
+                            "captures": {
+                                "1": {
+                                    "name": "keyword.other.safe-ds"
+                                },
+                                "2": {
+                                    "name": "variable.parameter.safe-ds"
+                                }
+                            }
+                        },
+                        {
+                            "match": "(@since)\\b",
+                            "name": "keyword.other.safe-ds"
+                        },
+                        {
+                            "match": "(@typeParam)\\s+([_a-zA-Z][_a-zA-Z0-9]*)?",
+                            "captures": {
+                                "1": {
+                                    "name": "keyword.other.safe-ds"
+                                },
+                                "2": {
+                                    "name": "entity.name.type.parameter"
+                                }
+                            }
                         }
                     ]
                 },

--- a/tests/language/lsp/safe-ds-semantic-token-provider.test.ts
+++ b/tests/language/lsp/safe-ds-semantic-token-provider.test.ts
@@ -101,6 +101,11 @@ describe('SafeDsSemanticTokenProvider', async () => {
             expectedTokenTypes: [SemanticTokenTypes.variable],
         },
         {
+            testName: 'result declaration',
+            code: 'fun f() -> (<|r|>: String)',
+            expectedTokenTypes: [SemanticTokenTypes.parameter],
+        },
+        {
             testName: 'schema declaration',
             code: 'schema <|S|>() {}',
             expectedTokenTypes: [SemanticTokenTypes.type],


### PR DESCRIPTION
Closes partially #669

### Summary of Changes

Highlight tags in documentation comments:

![image](https://github.com/Safe-DS/DSL/assets/2501322/940096a3-a248-4856-bd47-b1ecd7aa8fa5)
