### PR TITLE
refactor: remove references to `__dirname` where possible

### DIFF
--- a/packages/safe-ds-cli/esbuild.mjs
+++ b/packages/safe-ds-cli/esbuild.mjs
@@ -35,7 +35,6 @@ const ctx = await esbuild.context({
     target: 'ES2020',
     // VSCode's extension host is still using cjs, so we need to transform the code
     format: 'cjs',
-    // To prevent confusing node, we explicitly use the `.cjs` extension
     outExtension: {
         '.js': '.cjs',
     },

--- a/packages/safe-ds-cli/src/generate.ts
+++ b/packages/safe-ds-cli/src/generate.ts
@@ -7,7 +7,7 @@ import { extractDocument } from './cli-util.js';
 import { createSafeDsServices } from 'safe-ds';
 
 /* c8 ignore start */
-export const generateAction = async (fileName: string, opts: GenerateOptions): Promise<void> => {
+export const generate = async (fileName: string, opts: GenerateOptions): Promise<void> => {
     const services = createSafeDsServices(NodeFileSystem).SafeDs;
     const document = await extractDocument(fileName, services);
     const generatedFiles = services.generation.PythonGenerator.generate(document, opts.destination);

--- a/packages/safe-ds-cli/src/main.ts
+++ b/packages/safe-ds-cli/src/main.ts
@@ -1,18 +1,19 @@
 import { Command } from 'commander';
 import { SafeDsLanguageMetaData } from 'safe-ds';
-import { generateAction } from './generator.js';
+import { generate } from './generate.js';
 import * as path from 'node:path';
-
-const packagePath = path.resolve(__dirname, '..', 'package.json');
 
 const fileExtensions = SafeDsLanguageMetaData.fileExtensions.join(', ');
 
 const program = new Command();
 
+// Version command
+const packagePath = path.resolve(__dirname, '..', 'package.json');
 program
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     .version(require(packagePath).version);
 
+// Generate command
 program
     .command('generate')
     .argument('<file>', `possible file extensions: ${fileExtensions}`)
@@ -20,6 +21,6 @@ program
     .option('-r, --root <dir>', 'source root folder')
     .option('-q, --quiet', 'whether the program should print something', false)
     .description('generate Python code')
-    .action(generateAction);
+    .action(generate);
 
 program.parse(process.argv);

--- a/packages/safe-ds-cli/tests/main.test.ts
+++ b/packages/safe-ds-cli/tests/main.test.ts
@@ -1,11 +1,7 @@
 import { beforeAll, describe, expect, it } from 'vitest';
-import path from 'node:path';
 import { execSync, spawnSync } from 'node:child_process';
-import url from 'node:url';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
-const projectRoot = path.resolve(__dirname, '..');
+const projectRoot = new URL('..', import.meta.url);
 
 describe('program', () => {
     beforeAll(() => {

--- a/packages/safe-ds-vscode/tests/helpers/testResources.ts
+++ b/packages/safe-ds-vscode/tests/helpers/testResources.ts
@@ -4,8 +4,9 @@ import { SAFE_DS_FILE_EXTENSIONS } from '../../src/language/helpers/fileExtensio
 import { BuildOptions, LangiumDocument, URI } from 'langium';
 import { SafeDsServices } from '../../src/language/safe-ds-module.js';
 import { groupBy } from '../../src/helpers/collectionUtils.js';
+import { fileURLToPath } from 'url';
 
-const TEST_RESOURCES_PATH = path.join(__dirname, '..', 'resources');
+const TEST_RESOURCES_PATH = fileURLToPath(new URL('../resources', import.meta.url));
 
 /**
  * A path relative to `tests/resources/`.


### PR DESCRIPTION
### Summary of Changes

Where possible, replace `__dirname` (which does not work in modules) with `meta.import.url`, which does. Once VS Code can handle ESM, we can set the output format to "ESM" in the ESBuild configs.

See also:
* [Node.js Docs](https://nodejs.org/dist/latest/docs/api/esm.html#esm_no_filename_or_dirname)
* [StackOverflow](https://stackoverflow.com/questions/46745014/alternative-for-dirname-in-node-js-when-using-es6-modules)