### PR TITLE
feat: scoping for references to containing declarations

### DIFF
--- a/packages/safe-ds-lang/src/language/scoping/safe-ds-scope-provider.ts
+++ b/packages/safe-ds-lang/src/language/scoping/safe-ds-scope-provider.ts
@@ -251,25 +251,25 @@ export class SafeDsScopeProvider extends DefaultScopeProvider {
         // Declarations in this file
         currentScope = this.globalDeclarationsInSameFile(node, currentScope);
 
-        // // Declarations in containing classes
-        // context.containingClassOrNull()?.let {
-        //     result = classMembers(it, result)
-        // }
-        //
+        // Declarations in containing declarations
+        currentScope = this.containingDeclarations(node, currentScope);
 
         // Declarations in containing blocks
         return this.localDeclarations(node, currentScope);
     }
 
-    // private fun classMembers(context: SdsClass, parentScope: IScope): IScope {
-    //     return when (val containingClassOrNull = context.containingClassOrNull()) {
-    //         is SdsClass -> Scopes.scopeFor(
-    //             context.classMembersOrEmpty(),
-    //             classMembers(containingClassOrNull, parentScope),
-    //         )
-    //     else -> Scopes.scopeFor(context.classMembersOrEmpty(), parentScope)
-    //     }
-    // }
+    private containingDeclarations(node: AstNode, outerScope: Scope): Scope {
+        const result = [];
+
+        // Only containing classes, enums, and enum variants can be referenced
+        let current = getContainerOfType(node.$container, isSdsNamedTypeDeclaration);
+        while (current) {
+            result.push(current);
+            current = getContainerOfType(current.$container, isSdsNamedTypeDeclaration);
+        }
+
+        return this.createScopeForNodes(result, outerScope);
+    }
 
     private globalDeclarationsInSameFile(node: AstNode, outerScope: Scope): Scope {
         const module = getContainerOfType(node, isSdsModule);

--- a/packages/safe-ds-lang/tests/resources/scoping/references/in same file/to containing declarations/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/scoping/references/in same file/to containing declarations/main.sdstest
@@ -42,7 +42,7 @@ class »MyClass«(
         p = »MyClass«()
     )
     @MyAnnotation(
-        // $TEST$ references enum
+        // $TEST$ unresolved
         p = »MyEnum«
     )
     // $TEST$ target enum
@@ -73,7 +73,7 @@ class »MyClass«(
     }
 
     @MyAnnotation(
-        // $TEST$ references innerClass
+        // $TEST$ references outerClass
         p = »MyClass«()
     )
     @MyAnnotation(

--- a/packages/safe-ds-lang/tests/resources/scoping/references/in same file/to containing declarations/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/scoping/references/in same file/to containing declarations/main.sdstest
@@ -1,0 +1,115 @@
+package tests.scoping.references.inSameFile.toContainingDeclarations
+
+@Repeatable
+annotation MyAnnotation(p: Any?)
+
+// $TEST$ target outerClass
+class »MyClass«(
+    @MyAnnotation(
+        // $TEST$ references outerClass
+        p = »MyClass«()
+    )
+    // $TEST$ references outerClass
+    p: Any? = »MyClass«()
+) {
+
+    @MyAnnotation(
+        // $TEST$ references outerClass
+        p = »MyClass«()
+    )
+    @MyAnnotation(
+        // $TEST$ unresolved
+        p = »MyEnum«
+    )
+    fun f(
+        @MyAnnotation(
+            // $TEST$ references outerClass
+            p = »MyClass«()
+        )
+        // $TEST$ references outerClass
+        p1: Any? = »MyClass«(),
+
+        @MyAnnotation(
+            // $TEST$ unresolved
+            p = »MyEnum«
+        )
+        // $TEST$ unresolved
+        p2: Any? = »MyEnum«
+    )
+
+    @MyAnnotation(
+        // $TEST$ references outerClass
+        p = »MyClass«()
+    )
+    @MyAnnotation(
+        // $TEST$ unresolved
+        p = »MyEnum«
+    )
+    // $TEST$ target enum
+    enum »MyEnum« {
+        // $TEST$ target variant
+        »MyEnumVariant«(
+            @MyAnnotation(
+                // $TEST$ references outerClass
+                p = »MyClass«()
+            )
+            // $TEST$ references outerClass
+            p1: Any? = »MyClass«(),
+
+            @MyAnnotation(
+                // $TEST$ references enum
+                p = »MyEnum«
+            )
+            // $TEST$ references enum
+            p2: Any? = »MyEnum«,
+
+            @MyAnnotation(
+                // $TEST$ references variant
+                p = »MyEnumVariant«
+            )
+            // $TEST$ references variant
+            p3: Any? = »MyEnumVariant«,
+        )
+    }
+
+    @MyAnnotation(
+        // $TEST$ references outerClass
+        p = »MyClass«()
+    )
+    @MyAnnotation(
+        // $TEST$ unresolved
+        p = »MyEnum«
+    )
+    // $TEST$ target innerClass
+    class »MyClass«(
+        @MyAnnotation(
+            // $TEST$ references innerClass
+            p = »MyClass«()
+        )
+        // $TEST$ references innerClass
+        p1: Any? = »MyClass«(),
+
+        @MyAnnotation(
+            // $TEST$ unresolved
+            p = »MyEnum«
+        )
+        // $TEST$ unresolved
+        p2: Any? = »MyEnum«
+    ) {
+        fun f(
+            @MyAnnotation(
+                // $TEST$ references innerClass
+                p = »MyClass«()
+            )
+            // $TEST$ references innerClass
+            p1: Any? = »MyClass«(),
+
+            @MyAnnotation(
+                // $TEST$ unresolved
+                p = »MyEnum«
+            )
+            // $TEST$ unresolved
+            p2: Any? = »MyEnum«
+        )
+    }
+}

--- a/packages/safe-ds-lang/tests/resources/scoping/references/in same file/to containing declarations/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/scoping/references/in same file/to containing declarations/main.sdstest
@@ -42,7 +42,7 @@ class »MyClass«(
         p = »MyClass«()
     )
     @MyAnnotation(
-        // $TEST$ unresolved
+        // $TEST$ references enum
         p = »MyEnum«
     )
     // $TEST$ target enum
@@ -73,7 +73,7 @@ class »MyClass«(
     }
 
     @MyAnnotation(
-        // $TEST$ references outerClass
+        // $TEST$ references innerClass
         p = »MyClass«()
     )
     @MyAnnotation(


### PR DESCRIPTION
Closes #540

### Summary of Changes

Implement the same scoping rules for references to containing declarations as for named types.