### PR TITLE
test: public segments are never marked as unused

### DIFF
--- a/packages/safe-ds-lang/tests/resources/validation/other/declarations/segments/unused/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/other/declarations/segments/unused/main.sdstest
@@ -12,6 +12,12 @@ internal segment »myUnusedInternalSegment«() {}
 // $TEST$ no warning "This segment is unused and can be removed."
 internal segment »myUsedInternalSegment«() {}
 
+// $TEST$ no warning "This segment is unused and can be removed."
+segment »myUnusedPublicSegment«() {}
+
+// $TEST$ no warning "This segment is unused and can be removed."
+segment »myUsedPublicSegment«() {}
+
 pipeline myPipeline1 {
     myUsedPrivateSegment();
 }

--- a/packages/safe-ds-lang/tests/resources/validation/other/declarations/segments/unused/same package.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/other/declarations/segments/unused/same package.sdstest
@@ -2,4 +2,5 @@ package tests.validation.other.declarations.segments.unused
 
 pipeline myPipeline2 {
     myUsedInternalSegment();
+    myUsedPublicSegment();
 }


### PR DESCRIPTION
### Summary of Changes

Add a missing test to ensure that public segments are never marked as unused.