### PR TITLE
feat: minor improvements for purity info

### DIFF
--- a/packages/safe-ds-lang/src/resources/builtins/safeds/lang/codeGeneration.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/lang/codeGeneration.sdsstub
@@ -8,6 +8,7 @@ package safeds.lang
  * call. `$this` is replaced by the receiver of the call. `$param` is replaced by the value of the parameter called
  * `param`. Otherwise, the string is used as-is.
  */
+@Experimental
 @Target([AnnotationTarget.Function])
 annotation PythonCall(
     callSpecification: String

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/lang/purity.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/lang/purity.sdsstub
@@ -59,6 +59,13 @@ enum ImpurityReason {
     FileWriteToParameterizedPath(parameterName: String)
 
     /**
+     * The function calls another, potentially impure function that gets passed as a parameter.
+     *
+     * @param parameterName The name of the parameter that accepts the function.
+     */
+    PotentiallyImpureParameterCall(parameterName: String)
+
+    /**
      * The function is impure for some other reason. If possible, use a more specific reason.
      */
     Other

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/lang/purity.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/lang/purity.sdsstub
@@ -1,14 +1,17 @@
 package safeds.lang
 
 /**
- * Indicates that the function has no side effects and always returns the same results given the same arguments.
+ * **If called on a function:** Indicates that the function has no side effects and always returns the same results
+ * given the same arguments.
  *
- * Calls to such a function may be eliminated, if the result is not used. Moreover, the function can be memoized, i.e.
+ * Calls to such a function may be eliminated, if its results are not used. Moreover, the function can be memoized, i.e.
  * we can remember its results for a set of arguments. Finally, a pure function can be called at any time, allowing
  * reordering of calls or parallelization.
+ *
+ * **If called on a parameter:** Indicates that the parameter only accepts pure functions.
  */
 @Experimental
-@Target([AnnotationTarget.Function])
+@Target([AnnotationTarget.Function, AnnotationTarget.Parameter])
 annotation Pure
 
 /**


### PR DESCRIPTION
### Summary of Changes

* Allow use of `@Pure` on parameters to indicate that the parameter only accepts pure functions.
* Add another reason for impurity: A function calls another function, which may be impure, that is given by a parameter