### PR TITLE
feat: error if type parameter is used in nested named type declaration

### DIFF
--- a/docs/language/common/types.md
+++ b/docs/language/common/types.md
@@ -40,7 +40,7 @@ A declaration with an _enum type_ must be one of the [variants][variants] of the
 
 ```sds
 enum SomeEnum {
-    SomeEnumVariant,
+    SomeEnumVariant
     SomeOtherEnumVariant(count: Int)
 }
 ```

--- a/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
+++ b/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
@@ -72,7 +72,10 @@ import {
     segmentShouldBeUsed,
 } from './other/declarations/segments.js';
 import { typeParameterConstraintLeftOperandMustBeOwnTypeParameter } from './other/declarations/typeParameterConstraints.js';
-import { typeParameterMustHaveSufficientContext } from './other/declarations/typeParameters.js';
+import {
+    typeParameterMustHaveSufficientContext,
+    typeParameterMustNotBeUsedInNestedNamedTypeDeclarations,
+} from './other/declarations/typeParameters.js';
 import { callArgumentsMustBeConstantIfParameterIsConstant } from './other/expressions/calls.js';
 import { divisionDivisorMustNotBeZero } from './other/expressions/infixOperations.js';
 import {
@@ -309,7 +312,10 @@ export const registerValidationChecks = function (services: SafeDsServices) {
             segmentShouldBeUsed(services),
         ],
         SdsTemplateString: [templateStringMustHaveExpressionBetweenTwoStringParts],
-        SdsTypeParameter: [typeParameterMustHaveSufficientContext],
+        SdsTypeParameter: [
+            typeParameterMustHaveSufficientContext,
+            typeParameterMustNotBeUsedInNestedNamedTypeDeclarations,
+        ],
         SdsTypeParameterConstraint: [typeParameterConstraintLeftOperandMustBeOwnTypeParameter],
         SdsTypeParameterList: [typeParameterListShouldNotBeEmpty],
         SdsUnionType: [

--- a/packages/safe-ds-lang/tests/resources/validation/other/declarations/constraints/type parameter constraints/left operand must be own type parameter/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/other/declarations/constraints/type parameter constraints/left operand must be own type parameter/main.sdstest
@@ -1,4 +1,4 @@
-package tests.validation.other.declarations.typeParameterConstraints.typeParameterOnContainer
+package tests.validation.other.declarations.constraints.typeParameterConstraints.typeParameterOnContainer
 
 annotation MyAnnotation where {
     // $TEST$ no error "The left operand must refer to a type parameter of the declaration with the constraint."

--- a/packages/safe-ds-lang/tests/resources/validation/other/declarations/type parameters/usage/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/other/declarations/type parameters/usage/main.sdstest
@@ -1,0 +1,29 @@
+package tests.validation.other.declarations.typeParameters.usage
+
+// $TEST$ no error "Type parameters cannot be used in nested named type declarations."
+class MyClass<T>(p: »T«) {
+    // $TEST$ no error "Type parameters cannot be used in nested named type declarations."
+    attr a: »T«
+
+    // $TEST$ no error "Type parameters cannot be used in nested named type declarations."
+    // $TEST$ no error "Type parameters cannot be used in nested named type declarations."
+    // $TEST$ no error "Type parameters cannot be used in nested named type declarations."
+    // $TEST$ no error "Type parameters cannot be used in nested named type declarations."
+    fun f<S>(p1: »T«, p2: »S«) -> (r1: »T«, r2: »S«)
+
+    // $TEST$ error "Type parameters cannot be used in nested named type declarations."
+    // $TEST$ no error "Type parameters cannot be used in nested named type declarations."
+    class MyInnerClass<S>(p1: »T«, p2: »S«) {
+        // $TEST$ error "Type parameters cannot be used in nested named type declarations."
+        attr a: »T«
+
+        // $TEST$ error "Type parameters cannot be used in nested named type declarations."
+        fun f(p: »T«)
+    }
+
+    enum MyInnerEnum {
+        // $TEST$ error "Type parameters cannot be used in nested named type declarations."
+        // $TEST$ no error "Type parameters cannot be used in nested named type declarations."
+        MyEnumVariant<S>(p1: »T«, p2: »S«)
+    }
+}


### PR DESCRIPTION
Closes #748

### Summary of Changes

Show an error if a type parameter of a class is used inside a nested named type declaration.