### PR TITLE
feat: type checking for list & map literals

### DIFF
--- a/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
+++ b/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
@@ -149,6 +149,7 @@ import {
     indexedAccessIndexMustHaveCorrectType,
     indexedAccessReceiverMustBeListOrMap,
     infixOperationOperandsMustHaveCorrectType,
+    listMustNotContainNamedTuples,
     namedTypeMustSetAllTypeParameters,
     parameterDefaultValueTypeMustMatchParameterType,
     parameterMustHaveTypeHint,
@@ -253,6 +254,7 @@ export const registerValidationChecks = function (services: SafeDsServices) {
             lambdaParametersMustNotBeAnnotated,
             lambdaParameterMustNotHaveConstModifier,
         ],
+        SdsList: [listMustNotContainNamedTuples(services)],
         SdsLiteralType: [
             literalTypeMustHaveLiterals,
             literalTypeMustNotContainListLiteral,

--- a/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
+++ b/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
@@ -150,6 +150,7 @@ import {
     indexedAccessReceiverMustBeListOrMap,
     infixOperationOperandsMustHaveCorrectType,
     listMustNotContainNamedTuples,
+    mapMustNotContainNamedTuples,
     namedTypeMustSetAllTypeParameters,
     parameterDefaultValueTypeMustMatchParameterType,
     parameterMustHaveTypeHint,
@@ -262,7 +263,7 @@ export const registerValidationChecks = function (services: SafeDsServices) {
             literalTypesShouldBeUsedWithCaution,
             literalTypeShouldNotHaveDuplicateLiteral(services),
         ],
-        SdsMap: [mapsShouldBeUsedWithCaution],
+        SdsMap: [mapMustNotContainNamedTuples(services), mapsShouldBeUsedWithCaution],
         SdsMemberAccess: [
             memberAccessMustBeNullSafeIfReceiverIsNullable(services),
             memberAccessNullSafetyShouldBeNeeded(services),

--- a/packages/safe-ds-lang/src/language/validation/types.ts
+++ b/packages/safe-ds-lang/src/language/validation/types.ts
@@ -16,6 +16,7 @@ import {
     SdsIndexedAccess,
     SdsInfixOperation,
     SdsList,
+    SdsMap,
     SdsNamedType,
     SdsParameter,
     SdsPrefixOperation,
@@ -202,6 +203,32 @@ export const listMustNotContainNamedTuples = (services: SafeDsServices) => {
             if (elementType instanceof NamedTupleType) {
                 accept('error', `Cannot add a value of type '${elementType}' to a list.`, {
                     node: element,
+                    code: CODE_TYPE_MISMATCH,
+                });
+            }
+        }
+    };
+};
+
+export const mapMustNotContainNamedTuples = (services: SafeDsServices) => {
+    const typeComputer = services.types.TypeComputer;
+
+    return (node: SdsMap, accept: ValidationAcceptor): void => {
+        for (const entry of node.entries) {
+            const keyType = typeComputer.computeType(entry.key);
+            if (keyType instanceof NamedTupleType) {
+                accept('error', `Cannot use a value of type '${keyType}' as a map key.`, {
+                    node: entry,
+                    property: 'key',
+                    code: CODE_TYPE_MISMATCH,
+                });
+            }
+
+            const valueKey = typeComputer.computeType(entry.value);
+            if (valueKey instanceof NamedTupleType) {
+                accept('error', `Cannot use a value of type '${valueKey}' as a map value.`, {
+                    node: entry,
+                    property: 'value',
                     code: CODE_TYPE_MISMATCH,
                 });
             }

--- a/packages/safe-ds-lang/src/language/validation/types.ts
+++ b/packages/safe-ds-lang/src/language/validation/types.ts
@@ -15,6 +15,7 @@ import {
     SdsCall,
     SdsIndexedAccess,
     SdsInfixOperation,
+    SdsList,
     SdsNamedType,
     SdsParameter,
     SdsPrefixOperation,
@@ -23,6 +24,7 @@ import {
 } from '../generated/ast.js';
 import { getTypeArguments, getTypeParameters } from '../helpers/nodeProperties.js';
 import { SafeDsServices } from '../safe-ds-module.js';
+import { NamedTupleType } from '../typing/model.js';
 
 export const CODE_TYPE_CALLABLE_RECEIVER = 'type/callable-receiver';
 export const CODE_TYPE_MISMATCH = 'type/mismatch';
@@ -187,6 +189,22 @@ export const infixOperationOperandsMustHaveCorrectType = (services: SafeDsServic
                     );
                 }
                 return;
+        }
+    };
+};
+
+export const listMustNotContainNamedTuples = (services: SafeDsServices) => {
+    const typeComputer = services.types.TypeComputer;
+
+    return (node: SdsList, accept: ValidationAcceptor): void => {
+        for (const element of node.elements) {
+            const elementType = typeComputer.computeType(element);
+            if (elementType instanceof NamedTupleType) {
+                accept('error', `Cannot add a value of type '${elementType}' to a list.`, {
+                    node: element,
+                    code: CODE_TYPE_MISMATCH,
+                });
+            }
         }
     };
 };

--- a/packages/safe-ds-lang/tests/resources/validation/types/checking/lists/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/types/checking/lists/main.sdstest
@@ -1,0 +1,16 @@
+package tests.validation.types.checking.lists
+
+fun noResults()
+fun oneResult() -> r: Int
+fun twoResults() -> (r1: Int, r2: Int)
+
+segment mySegment() {
+    [
+        // $TEST$ error "Cannot add a value of type '()' to a list."
+        »noResults()«,
+        // $TEST$ no error r"Cannot add a value of type '.*' to a list\."
+        »oneResult()«,
+        // $TEST$ error "Cannot add a value of type '(r1: Int, r2: Int)' to a list."
+        »twoResults()«
+    ];
+}

--- a/packages/safe-ds-lang/tests/resources/validation/types/checking/maps/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/types/checking/maps/main.sdstest
@@ -1,0 +1,19 @@
+package tests.validation.types.checking.maps
+
+fun noResults()
+fun oneResult() -> r: Int
+fun twoResults() -> (r1: Int, r2: Int)
+
+segment mySegment() {
+    {
+        // $TEST$ error "Cannot use a value of type '()' as a map key."
+        // $TEST$ error "Cannot use a value of type '()' as a map value."
+        »noResults()«: »noResults()«,
+        // $TEST$ no error r"Cannot use a value of type '.*' as a map key\."
+        // $TEST$ no error r"Cannot use a value of type '.*' as a map value\."
+        »oneResult()«: »oneResult()«,
+        // $TEST$ error "Cannot use a value of type '(r1: Int, r2: Int)' as a map key."
+        // $TEST$ error "Cannot use a value of type '(r1: Int, r2: Int)' as a map value."
+        »twoResults()«: »twoResults()«
+    };
+}


### PR DESCRIPTION
Closes #712

### Summary of Changes

Don't allow calls that produce no or multiple results inside list & map literals. In other cases, the existing type checking already took care of this.