### PR TITLE
feat: mark constraint lists as experimental

### DIFF
--- a/packages/safe-ds-lang/src/language/validation/experimentalLanguageFeatures.ts
+++ b/packages/safe-ds-lang/src/language/validation/experimentalLanguageFeatures.ts
@@ -2,6 +2,7 @@ import {
     isSdsIndexedAccess,
     isSdsMap,
     isSdsUnionType,
+    SdsConstraintList,
     SdsIndexedAccess,
     SdsLiteralType,
     SdsMap,
@@ -10,6 +11,14 @@ import {
 import { hasContainerOfType, ValidationAcceptor } from 'langium';
 
 export const CODE_EXPERIMENTAL_LANGUAGE_FEATURE = 'experimental/language-feature';
+
+export const constraintListsShouldBeUsedWithCaution = (node: SdsConstraintList, accept: ValidationAcceptor): void => {
+    accept('warning', 'Constraint lists & constraints are experimental and may change without prior notice.', {
+        node,
+        keyword: 'where',
+        code: CODE_EXPERIMENTAL_LANGUAGE_FEATURE,
+    });
+};
 
 export const indexedAccessesShouldBeUsedWithCaution = (node: SdsIndexedAccess, accept: ValidationAcceptor): void => {
     if (hasContainerOfType(node.$container, isSdsIndexedAccess)) {

--- a/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
+++ b/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
@@ -27,6 +27,7 @@ import {
 import { singleUseAnnotationsMustNotBeRepeated } from './builtins/repeatable.js';
 import { annotationCallMustHaveCorrectTarget, targetShouldNotHaveDuplicateEntries } from './builtins/target.js';
 import {
+    constraintListsShouldBeUsedWithCaution,
     indexedAccessesShouldBeUsedWithCaution,
     literalTypesShouldBeUsedWithCaution,
     mapsShouldBeUsedWithCaution,
@@ -221,7 +222,7 @@ export const registerValidationChecks = function (services: SafeDsServices) {
             classMustNotInheritItself(services),
         ],
         SdsClassBody: [classBodyShouldNotBeEmpty],
-        SdsConstraintList: [constraintListShouldNotBeEmpty],
+        SdsConstraintList: [constraintListsShouldBeUsedWithCaution, constraintListShouldNotBeEmpty],
         SdsDeclaration: [
             nameMustNotStartWithCodegenPrefix,
             nameShouldHaveCorrectCasing,

--- a/packages/safe-ds-lang/tests/resources/validation/experimental language feature/constraint lists/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/experimental language feature/constraint lists/main.sdstest
@@ -1,0 +1,4 @@
+package tests.validation.experimentalLanguageFeature.constraintLists
+
+// $TEST$ warning "Constraint lists & constraints are experimental and may change without prior notice."
+fun myFunction() »where« {}


### PR DESCRIPTION
### Summary of Changes

When we add more constraint types (e.g. #18), we might also have to change the overall concept. Thus, constraint lists are now marked as experimental (which also applies to the contained constraints).