### PR TITLE
feat: mark type parameter lists and type argument lists as experimental

### DIFF
--- a/packages/safe-ds-lang/src/language/validation/experimentalLanguageFeatures.ts
+++ b/packages/safe-ds-lang/src/language/validation/experimentalLanguageFeatures.ts
@@ -1,14 +1,17 @@
+import { hasContainerOfType, ValidationAcceptor } from 'langium';
 import {
     isSdsIndexedAccess,
     isSdsMap,
+    isSdsTypeArgumentList,
     isSdsUnionType,
     SdsConstraintList,
     SdsIndexedAccess,
     SdsLiteralType,
     SdsMap,
+    type SdsTypeArgumentList,
+    type SdsTypeParameterList,
     SdsUnionType,
 } from '../generated/ast.js';
-import { hasContainerOfType, ValidationAcceptor } from 'langium';
 
 export const CODE_EXPERIMENTAL_LANGUAGE_FEATURE = 'experimental/language-feature';
 
@@ -58,6 +61,30 @@ export const unionTypesShouldBeUsedWithCaution = (node: SdsUnionType, accept: Va
     accept('warning', 'Union types are experimental and may change without prior notice.', {
         node,
         keyword: 'union',
+        code: CODE_EXPERIMENTAL_LANGUAGE_FEATURE,
+    });
+};
+
+export const typeArgumentListsShouldBeUsedWithCaution = (
+    node: SdsTypeArgumentList,
+    accept: ValidationAcceptor,
+): void => {
+    if (hasContainerOfType(node.$container, isSdsTypeArgumentList)) {
+        return;
+    }
+
+    accept('warning', 'Type argument lists & type arguments are experimental and may change without prior notice.', {
+        node,
+        code: CODE_EXPERIMENTAL_LANGUAGE_FEATURE,
+    });
+};
+
+export const typeParameterListsShouldBeUsedWithCaution = (
+    node: SdsTypeParameterList,
+    accept: ValidationAcceptor,
+): void => {
+    accept('warning', 'Type parameter lists & type parameters are experimental and may change without prior notice.', {
+        node,
         code: CODE_EXPERIMENTAL_LANGUAGE_FEATURE,
     });
 };

--- a/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
+++ b/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
@@ -31,6 +31,8 @@ import {
     indexedAccessesShouldBeUsedWithCaution,
     literalTypesShouldBeUsedWithCaution,
     mapsShouldBeUsedWithCaution,
+    typeArgumentListsShouldBeUsedWithCaution,
+    typeParameterListsShouldBeUsedWithCaution,
     unionTypesShouldBeUsedWithCaution,
 } from './experimentalLanguageFeatures.js';
 import { classMustNotInheritItself, classMustOnlyInheritASingleClass } from './inheritance.js';
@@ -316,12 +318,13 @@ export const registerValidationChecks = function (services: SafeDsServices) {
             segmentShouldBeUsed(services),
         ],
         SdsTemplateString: [templateStringMustHaveExpressionBetweenTwoStringParts],
+        SdsTypeArgumentList: [typeArgumentListsShouldBeUsedWithCaution],
         SdsTypeParameter: [
             typeParameterMustHaveSufficientContext,
             typeParameterMustNotBeUsedInNestedNamedTypeDeclarations,
         ],
         SdsTypeParameterConstraint: [typeParameterConstraintLeftOperandMustBeOwnTypeParameter],
-        SdsTypeParameterList: [typeParameterListShouldNotBeEmpty],
+        SdsTypeParameterList: [typeParameterListsShouldBeUsedWithCaution, typeParameterListShouldNotBeEmpty],
         SdsUnionType: [
             unionTypeMustBeUsedInCorrectContext,
             unionTypeMustHaveTypes,

--- a/packages/safe-ds-lang/tests/resources/validation/experimental language feature/type argument lists/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/experimental language feature/type argument lists/main.sdstest
@@ -1,0 +1,8 @@
+
+package tests.validation.experimentalLanguageFeature.typeArgumentLists
+
+// $TEST$ warning "Type argument lists & type arguments are experimental and may change without prior notice."
+class MyClass1(p: MyClass1»<>«)
+
+// $TEST$ no warning "Type argument lists & type arguments are experimental and may change without prior notice."
+class MyClass2<T>(p: MyClass2<MyClass1»<>«>)

--- a/packages/safe-ds-lang/tests/resources/validation/experimental language feature/type parameter lists/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/experimental language feature/type parameter lists/main.sdstest
@@ -1,0 +1,13 @@
+
+package tests.validation.experimentalLanguageFeature.typeParameterLists
+
+// $TEST$ warning "Type parameter lists & type parameters are experimental and may change without prior notice."
+class MyClass»<>«
+
+// $TEST$ warning "Type parameter lists & type parameters are experimental and may change without prior notice."
+enum MyEnum {
+    MyEnumVariant»<>«
+}
+
+// $TEST$ warning "Type parameter lists & type parameters are experimental and may change without prior notice."
+fun myFunction»<>«()


### PR DESCRIPTION
Closes #753

### Summary of Changes

Mark type parameter lists and type argument lists as experimental. This also applies to the contained type parameters and type arguments.