### PR TITLE
feat: customize rendering of `@param`, `@result`, and `@typeParam` tags

### DIFF
--- a/packages/safe-ds-lang/src/helpers/stringUtils.ts
+++ b/packages/safe-ds-lang/src/helpers/stringUtils.ts
@@ -1,4 +1,14 @@
 /**
+ * Normalizes line breaks to `\n`.
+ *
+ * @param text The text to normalize.
+ * @return The normalized text.
+ */
+export const normalizeLineBreaks = (text: string | undefined): string => {
+    return text?.replace(/\r\n?/gu, '\n') ?? '';
+};
+
+/**
  * Based on the given count, returns the singular or plural form of the given word.
  */
 export const pluralize = (count: number, singular: string, plural: string = `${singular}s`): string => {

--- a/packages/safe-ds-lang/tests/helpers/stringUtils.test.ts
+++ b/packages/safe-ds-lang/tests/helpers/stringUtils.test.ts
@@ -1,5 +1,32 @@
 import { describe, expect, it } from 'vitest';
-import { pluralize } from '../../src/helpers/stringUtils.js';
+import { normalizeLineBreaks, pluralize } from '../../src/helpers/stringUtils.js';
+
+describe('normalizeLineBreaks', () => {
+    it.each([
+        {
+            text: undefined,
+            expected: '',
+        },
+        {
+            text: '',
+            expected: '',
+        },
+        {
+            text: 'foo\nbar',
+            expected: 'foo\nbar',
+        },
+        {
+            text: 'foo\rbar',
+            expected: 'foo\nbar',
+        },
+        {
+            text: 'foo\r\nbar',
+            expected: 'foo\nbar',
+        },
+    ])(`should normalize line breaks (%#)`, ({ text, expected }) => {
+        expect(normalizeLineBreaks(text)).toBe(expected);
+    });
+});
 
 describe('pluralize', () => {
     it.each([

--- a/packages/safe-ds-lang/tests/language/lsp/formatting/creator.ts
+++ b/packages/safe-ds-lang/tests/language/lsp/formatting/creator.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import { EmptyFileSystem, URI } from 'langium';
 import { Diagnostic } from 'vscode-languageserver';
+import { normalizeLineBreaks } from '../../../../src/helpers/stringUtils.js';
 import { createSafeDsServices } from '../../../../src/language/index.js';
 import { getSyntaxErrors } from '../../../helpers/diagnostics.js';
 import { TestDescription, TestDescriptionError } from '../../../helpers/testDescription.js';
@@ -62,16 +63,6 @@ const invalidTest = (error: TestDescriptionError): FormattingTest => {
         uri: URI.file(''),
         error,
     };
-};
-
-/**
- * Normalizes line breaks to `\n`.
- *
- * @param code The code to normalize.
- * @return The normalized code.
- */
-const normalizeLineBreaks = (code: string): string => {
-    return code.replace(/\r\n?/gu, '\n');
 };
 
 /**


### PR DESCRIPTION
Closes partially #669

### Summary of Changes

Write tag in bold and the declaration name in italics for rendered `@param`, `@result` and `@typeParam` tags.