### PR TITLE
feat: improve location of warning about duplicate annotation target

### DIFF
--- a/packages/safe-ds-lang/src/language/validation/builtins/target.ts
+++ b/packages/safe-ds-lang/src/language/validation/builtins/target.ts
@@ -1,4 +1,4 @@
-import { ValidationAcceptor } from 'langium';
+import { getContainerOfType, ValidationAcceptor } from 'langium';
 import {
     isSdsAnnotation,
     isSdsAttribute,
@@ -6,6 +6,7 @@ import {
     isSdsEnum,
     isSdsEnumVariant,
     isSdsFunction,
+    isSdsList,
     isSdsModule,
     isSdsParameter,
     isSdsPipeline,
@@ -14,17 +15,20 @@ import {
     isSdsTypeParameter,
     SdsAnnotation,
     SdsAnnotationCall,
+    SdsEnumVariant,
 } from '../../generated/ast.js';
 import { SafeDsServices } from '../../safe-ds-module.js';
-import { duplicatesBy, isEmpty } from '../../../helpers/collectionUtils.js';
-import { pluralize } from '../../../helpers/stringUtils.js';
 import { findFirstAnnotationCallOf, getAnnotationCallTarget } from '../../helpers/nodeProperties.js';
+import { EvaluatedEnumVariant } from '../../partialEvaluation/model.js';
 
 export const CODE_TARGET_DUPLICATE_TARGET = 'target/duplicate-target';
 export const CODE_TARGET_WRONG_TARGET = 'target/wrong-target';
 
 export const targetShouldNotHaveDuplicateEntries = (services: SafeDsServices) => {
     const builtinAnnotations = services.builtins.Annotations;
+    const builtinEnums = services.builtins.Enums;
+    const partialEvaluator = services.evaluation.PartialEvaluator;
+    const nodeMapper = services.helpers.NodeMapper;
 
     return (node: SdsAnnotation, accept: ValidationAcceptor) => {
         const annotationCall = findFirstAnnotationCallOf(node, builtinAnnotations.Target);
@@ -32,24 +36,30 @@ export const targetShouldNotHaveDuplicateEntries = (services: SafeDsServices) =>
             return;
         }
 
-        const validTargets = builtinAnnotations.streamValidTargets(node).map((it) => `'${it.name}'`);
-        const duplicateTargets = duplicatesBy(validTargets, (it) => it)
-            .distinct()
-            .toArray();
-
-        if (isEmpty(duplicateTargets)) {
+        const targets = nodeMapper.callToParameterValue(annotationCall, 'targets');
+        if (!isSdsList(targets)) {
             return;
         }
 
-        const noun = pluralize(duplicateTargets.length, 'target');
-        const duplicateTargetString = duplicateTargets.join(', ');
-        const verb = pluralize(duplicateTargets.length, 'occurs', 'occur');
+        const knownTargets = new Set<SdsEnumVariant>();
+        for (const target of targets.elements) {
+            const evaluatedTarget = partialEvaluator.evaluate(target);
+            if (
+                !(evaluatedTarget instanceof EvaluatedEnumVariant) ||
+                getContainerOfType(evaluatedTarget.variant, isSdsEnum) !== builtinEnums.AnnotationTarget
+            ) {
+                continue;
+            }
 
-        accept('warning', `The ${noun} ${duplicateTargetString} ${verb} multiple times.`, {
-            node: annotationCall,
-            property: 'annotation',
-            code: CODE_TARGET_DUPLICATE_TARGET,
-        });
+            if (knownTargets.has(evaluatedTarget.variant)) {
+                accept('warning', `The target '${evaluatedTarget.variant.name}' was set already.`, {
+                    node: target,
+                    code: CODE_TARGET_DUPLICATE_TARGET,
+                });
+            } else {
+                knownTargets.add(evaluatedTarget.variant);
+            }
+        }
     };
 };
 

--- a/packages/safe-ds-lang/tests/resources/validation/builtins/annotations/target/duplicate target/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/builtins/annotations/target/duplicate target/main.sdstest
@@ -1,34 +1,43 @@
 package tests.validation.builtins.annotations.target.duplicateTarget
 
-// $TEST$ no warning r"The targets? occurs? multiple times."
-@»Target«([AnnotationTarget.Annotation])
+@Target([
+    // $TEST$ no warning "The target 'Annotation' was set already."
+    »AnnotationTarget.Annotation«
+])
 
 /*
  * We already show another error if the `@Target` annotation is called multiple times.
  */
 
-// $TEST$ no warning r"The targets? occurs? multiple times."
-@»Target«([
-    AnnotationTarget.Annotation,
-    AnnotationTarget.Annotation,
+@Target([
+    // $TEST$ no warning "The target 'Annotation' was set already."
+    »AnnotationTarget.Annotation«,
+    // $TEST$ no warning "The target 'Annotation' was set already."
+    »AnnotationTarget.Annotation«,
 ])
 annotation TestAnnotation1
 
-// $TEST$ warning "The target 'Annotation' occurs multiple times."
-@»Target«([
-    AnnotationTarget.Annotation,
-    AnnotationTarget.Annotation,
+@Target([
+    // $TEST$ no warning "The target 'Annotation' was set already."
+    »AnnotationTarget.Annotation«,
+    // $TEST$ warning "The target 'Annotation' was set already."
+    »AnnotationTarget.Annotation«,
 ])
 annotation TestAnnotation2
 
-// $TEST$ warning "The targets 'Class', 'Annotation' occur multiple times."
-@»Target«([
-    AnnotationTarget.Class,
-    AnnotationTarget.Class,
-    AnnotationTarget.Class,
-    AnnotationTarget.Annotation,
-    AnnotationTarget.Annotation,
-    AnnotationTarget.Annotation,
+@Target([
+    // $TEST$ no warning "The target 'Class' was set already."
+    »AnnotationTarget.Class«,
+    // $TEST$ warning "The target 'Class' was set already."
+    »AnnotationTarget.Class«,
+    // $TEST$ warning "The target 'Class' was set already."
+    »AnnotationTarget.Class«,
+    // $TEST$ no warning "The target 'Annotation' was set already."
+    »AnnotationTarget.Annotation«,
+    // $TEST$ warning "The target 'Annotation' was set already."
+    »AnnotationTarget.Annotation«,
+    // $TEST$ warning "The target 'Annotation' was set already."
+    »AnnotationTarget.Annotation«,
 ])
 annotation TestAnnotation3
 
@@ -36,13 +45,18 @@ annotation TestAnnotation3
  * We already show another error if an annotation is called with arguments of invalid type.
  */
 
- // $TEST$ no warning r"The targets? occurs? multiple times."
-@»Target«(1)
+@Target(
+    // $TEST$ no warning "The target 'Class' was set already."
+    »AnnotationTarget.Class«,
+    // $TEST$ no warning "The target 'Class' was set already."
+    »AnnotationTarget.Class«
+)
 annotation TestAnnotation4
 
-// $TEST$ no warning r"The targets? occurs? multiple times."
-@»Target«([
-    1,
-    1,
+@Target([
+    // $TEST$ no warning r"The target '.*' was set already\."
+    »1«,
+    // $TEST$ no warning r"The target '.*' was set already\."
+    »1«,
 ])
 annotation TestAnnotation5

--- a/packages/safe-ds-lang/tests/resources/validation/builtins/annotations/target/duplicate target/no target annotation.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/builtins/annotations/target/duplicate target/no target annotation.sdstest
@@ -1,5 +1,5 @@
 package tests.validation.builtins.annotations.target.duplicateTarget
 
-// $TEST$ no warning r"The targets? occurs? multiple times."
+// $TEST$ no warning r"The target '.*' was already set\."
 
 annotation TestAnnotation6


### PR DESCRIPTION
### Summary of Changes

Warn about duplicate annotation targets on the actual duplicate targets instead of the containing annotation call.