### PR TITLE
feat: check whether purity of callable parameters of functions is set properly

### DIFF
--- a/packages/safe-ds-lang/src/language/builtins/safe-ds-enums.ts
+++ b/packages/safe-ds-lang/src/language/builtins/safe-ds-enums.ts
@@ -1,7 +1,9 @@
 import { getContainerOfType, URI } from 'langium';
 import { resourceNameToUri } from '../../helpers/resources.js';
-import { isSdsEnum, SdsEnum } from '../generated/ast.js';
+import { isSdsEnum, SdsEnum, type SdsEnumVariant } from '../generated/ast.js';
+import { getEnumVariants } from '../helpers/nodeProperties.js';
 import { EvaluatedEnumVariant, EvaluatedNode } from '../partialEvaluation/model.js';
+import type { SafeDsServices } from '../safe-ds-module.js';
 import { SafeDsModuleMembers } from './safe-ds-module-members.js';
 
 const ANNOTATION_USAGE_URI = resourceNameToUri('builtins/safeds/lang/annotationUsage.sdsstub');
@@ -24,5 +26,21 @@ export class SafeDsEnums extends SafeDsModuleMembers<SdsEnum> {
 
     private getEnum(uri: URI, name: string): SdsEnum | undefined {
         return this.getModuleMember(uri, name, isSdsEnum);
+    }
+}
+
+export class SafeDsImpurityReasons {
+    private readonly builtinEnums: SafeDsEnums;
+
+    constructor(services: SafeDsServices) {
+        this.builtinEnums = services.builtins.Enums;
+    }
+
+    get PotentiallyImpureParameterCall(): SdsEnumVariant | undefined {
+        return this.getEnumVariant('PotentiallyImpureParameterCall');
+    }
+
+    private getEnumVariant(name: string): SdsEnumVariant | undefined {
+        return getEnumVariants(this.builtinEnums.ImpurityReason).find((variant) => variant.name === name);
     }
 }

--- a/packages/safe-ds-lang/src/language/safe-ds-module.ts
+++ b/packages/safe-ds-lang/src/language/safe-ds-module.ts
@@ -11,7 +11,7 @@ import {
 } from 'langium';
 import { SafeDsAnnotations } from './builtins/safe-ds-annotations.js';
 import { SafeDsClasses } from './builtins/safe-ds-classes.js';
-import { SafeDsEnums } from './builtins/safe-ds-enums.js';
+import { SafeDsEnums, SafeDsImpurityReasons } from './builtins/safe-ds-enums.js';
 import { SafeDsCommentProvider } from './documentation/safe-ds-comment-provider.js';
 import { SafeDsDocumentationProvider } from './documentation/safe-ds-documentation-provider.js';
 import { SafeDsCallGraphComputer } from './flow/safe-ds-call-graph-computer.js';
@@ -49,6 +49,7 @@ export type SafeDsAddedServices = {
         Annotations: SafeDsAnnotations;
         Classes: SafeDsClasses;
         Enums: SafeDsEnums;
+        ImpurityReasons: SafeDsImpurityReasons;
     };
     evaluation: {
         PartialEvaluator: SafeDsPartialEvaluator;
@@ -93,6 +94,7 @@ export const SafeDsModule: Module<SafeDsServices, PartialLangiumServices & SafeD
         Annotations: (services) => new SafeDsAnnotations(services),
         Classes: (services) => new SafeDsClasses(services),
         Enums: (services) => new SafeDsEnums(services),
+        ImpurityReasons: (services) => new SafeDsImpurityReasons(services),
     },
     documentation: {
         CommentProvider: (services) => new SafeDsCommentProvider(services),

--- a/packages/safe-ds-lang/src/language/validation/purity.ts
+++ b/packages/safe-ds-lang/src/language/validation/purity.ts
@@ -2,7 +2,7 @@ import { stream, type ValidationAcceptor } from 'langium';
 import { isSubset } from '../../helpers/collectionUtils.js';
 import { isSdsCall, isSdsFunction, isSdsList, type SdsFunction, type SdsParameter } from '../generated/ast.js';
 import { findFirstAnnotationCallOf, getArguments, getParameters } from '../helpers/nodeProperties.js';
-import { StringConstant } from '../partialEvaluation/model.js';
+import { EvaluatedEnumVariant, StringConstant } from '../partialEvaluation/model.js';
 import type { SafeDsServices } from '../safe-ds-module.js';
 import { CallableType } from '../typing/model.js';
 
@@ -13,6 +13,52 @@ export const CODE_PURITY_INVALID_PARAMETER_NAME = 'purity/invalid-parameter-name
 export const CODE_PURITY_MUST_BE_SPECIFIED = 'purity/must-be-specified';
 export const CODE_PURITY_POTENTIALLY_IMPURE_PARAMETER_NOT_CALLABLE = 'purity/potentially-impure-parameter-not-callable';
 export const CODE_PURITY_PURE_PARAMETER_MUST_HAVE_CALLABLE_TYPE = 'purity/pure-parameter-must-have-callable-type';
+
+export const callableParameterPurityMustBeSpecified = (services: SafeDsServices) => {
+    const builtinAnnotations = services.builtins.Annotations;
+    const possibleImpurityReasons = services.builtins.ImpurityReasons;
+    const typeComputer = services.types.TypeComputer;
+
+    return (node: SdsFunction, accept: ValidationAcceptor) => {
+        const potentiallyImpureParameterCall = possibleImpurityReasons.PotentiallyImpureParameterCall;
+        if (!potentiallyImpureParameterCall) {
+            return;
+        }
+
+        const parameterNameParameter = getParameters(potentiallyImpureParameterCall).find(
+            (it) => it.name === 'parameterName',
+        )!;
+        const impurityReasons = builtinAnnotations.streamImpurityReasons(node).toArray();
+
+        for (const parameter of getParameters(node)) {
+            if (builtinAnnotations.isPure(parameter)) {
+                continue;
+            }
+
+            const parameterType = typeComputer.computeType(parameter);
+            if (!(parameterType instanceof CallableType)) {
+                continue;
+            }
+
+            const expectedImpurityReason = new EvaluatedEnumVariant(
+                possibleImpurityReasons.PotentiallyImpureParameterCall,
+                new Map([[parameterNameParameter, new StringConstant(parameter.name)]]),
+            );
+
+            if (!impurityReasons.some((it) => it.equals(expectedImpurityReason))) {
+                accept(
+                    'error',
+                    "The purity of a callable parameter must be specified. Call the annotation '@Pure' or add the impurity reason 'PotentiallyImpureParameterCall' to the containing function.",
+                    {
+                        node: parameter,
+                        property: 'name',
+                        code: CODE_PURITY_MUST_BE_SPECIFIED,
+                    },
+                );
+            }
+        }
+    };
+};
 
 export const functionPurityMustBeSpecified = (services: SafeDsServices) => {
     const annotations = services.builtins.Annotations;
@@ -90,6 +136,7 @@ export const impurityReasonsOfOverridingMethodMustBeSubsetOfOverriddenMethod = (
 export const impurityReasonParameterNameMustBelongToParameterOfCorrectType = (services: SafeDsServices) => {
     const builtinAnnotations = services.builtins.Annotations;
     const builtinEnums = services.builtins.Enums;
+    const impurityReasons = services.builtins.ImpurityReasons;
     const nodeMapper = services.helpers.NodeMapper;
     const partialEvaluator = services.evaluation.PartialEvaluator;
     const typeComputer = services.types.TypeComputer;
@@ -151,7 +198,7 @@ export const impurityReasonParameterNameMustBelongToParameterOfCorrectType = (se
             }
 
             // The parameter must have the correct type
-            if (evaluatedReason.variant.name === 'PotentiallyImpureParameterCall') {
+            if (evaluatedReason.variant === impurityReasons.PotentiallyImpureParameterCall) {
                 const parameter = getParameters(node).find((it) => it.name === evaluatedParameterName.value)!;
                 if (!parameter.type) {
                     continue;

--- a/packages/safe-ds-lang/src/language/validation/purity.ts
+++ b/packages/safe-ds-lang/src/language/validation/purity.ts
@@ -55,6 +55,7 @@ export const callableParameterPurityMustBeSpecified = (services: SafeDsServices)
                     },
                 );
             } else if (
+                !builtinAnnotations.isPure(node) &&
                 !builtinAnnotations.isPure(parameter) &&
                 !impurityReasons.some((it) => it.equals(expectedImpurityReason))
             ) {

--- a/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
+++ b/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
@@ -135,6 +135,7 @@ import {
     unionTypeShouldNotHaveDuplicateTypes,
 } from './other/types/unionTypes.js';
 import {
+    callableParameterPurityMustBeSpecified,
     functionPurityMustBeSpecified,
     impurityReasonParameterNameMustBelongToParameterOfCorrectType,
     impurityReasonShouldNotBeSetMultipleTimes,
@@ -254,6 +255,7 @@ export const registerValidationChecks = function (services: SafeDsServices) {
         SdsEnumVariant: [enumVariantMustContainUniqueNames, enumVariantParameterListShouldNotBeEmpty],
         SdsExpressionLambda: [expressionLambdaMustContainUniqueNames],
         SdsFunction: [
+            callableParameterPurityMustBeSpecified(services),
             functionMustContainUniqueNames,
             functionResultListShouldNotBeEmpty,
             functionPurityMustBeSpecified(services),

--- a/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
+++ b/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
@@ -136,7 +136,7 @@ import {
 } from './other/types/unionTypes.js';
 import {
     functionPurityMustBeSpecified,
-    impurityReasonParameterNameMustBelongToParameter,
+    impurityReasonParameterNameMustBelongToParameterOfCorrectType,
     impurityReasonShouldNotBeSetMultipleTimes,
     impurityReasonsOfOverridingMethodMustBeSubsetOfOverriddenMethod,
     pureParameterMustHaveCallableType,
@@ -258,7 +258,7 @@ export const registerValidationChecks = function (services: SafeDsServices) {
             functionResultListShouldNotBeEmpty,
             functionPurityMustBeSpecified(services),
             impurityReasonsOfOverridingMethodMustBeSubsetOfOverriddenMethod(services),
-            impurityReasonParameterNameMustBelongToParameter(services),
+            impurityReasonParameterNameMustBelongToParameterOfCorrectType(services),
             impurityReasonShouldNotBeSetMultipleTimes(services),
             pythonCallMustOnlyContainValidTemplateExpressions(services),
             pythonNameMustNotBeSetIfPythonCallIsSet(services),

--- a/packages/safe-ds-lang/tests/resources/validation/purity/callable parameter with unspecified purity/class.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/purity/callable parameter with unspecified purity/class.sdstest
@@ -1,0 +1,9 @@
+package tests.validation.purity.callableParameterWithUnspecifiedPurity
+
+// $TEST$ no error "The purity of a callable parameter must be specified. Call the annotation '@Pure' or add the impurity reason 'PotentiallyImpureParameterCall' to the containing function."
+
+class MyClass(
+    p1: Int,
+    @Pure p2: () -> (),
+    »p3«: () -> ()
+)

--- a/packages/safe-ds-lang/tests/resources/validation/purity/callable parameter with unspecified purity/function.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/purity/callable parameter with unspecified purity/function.sdstest
@@ -15,7 +15,7 @@ fun pureFunction(
     »p1«: Int,
     // $TEST$ no error "The purity of a callable parameter must be specified. Call the annotation '@Pure' or add the impurity reason 'PotentiallyImpureParameterCall' to the containing function."
     @Pure »p2«: () -> (),
-    // $TEST$ error "The purity of a callable parameter must be specified. Call the annotation '@Pure' or add the impurity reason 'PotentiallyImpureParameterCall' to the containing function."
+    // $TEST$ no error "The purity of a callable parameter must be specified. Call the annotation '@Pure' or add the impurity reason 'PotentiallyImpureParameterCall' to the containing function."
     »p3«: () -> ()
 )
 

--- a/packages/safe-ds-lang/tests/resources/validation/purity/callable parameter with unspecified purity/function.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/purity/callable parameter with unspecified purity/function.sdstest
@@ -1,0 +1,44 @@
+package tests.validation.purity.callableParameterWithUnspecifiedPurity
+
+fun functionWithUnknownPurity(
+    // $TEST$ no error "The purity of a callable parameter must be specified. Call the annotation '@Pure' or add the impurity reason 'PotentiallyImpureParameterCall' to the containing function."
+    »p1«: Int,
+    // $TEST$ no error "The purity of a callable parameter must be specified. Call the annotation '@Pure' or add the impurity reason 'PotentiallyImpureParameterCall' to the containing function."
+    @Pure »p2«: () -> (),
+    // $TEST$ error "The purity of a callable parameter must be specified. Call the annotation '@Pure' or add the impurity reason 'PotentiallyImpureParameterCall' to the containing function."
+    »p3«: () -> ()
+)
+
+@Pure
+fun pureFunction(
+    // $TEST$ no error "The purity of a callable parameter must be specified. Call the annotation '@Pure' or add the impurity reason 'PotentiallyImpureParameterCall' to the containing function."
+    »p1«: Int,
+    // $TEST$ no error "The purity of a callable parameter must be specified. Call the annotation '@Pure' or add the impurity reason 'PotentiallyImpureParameterCall' to the containing function."
+    @Pure »p2«: () -> (),
+    // $TEST$ error "The purity of a callable parameter must be specified. Call the annotation '@Pure' or add the impurity reason 'PotentiallyImpureParameterCall' to the containing function."
+    »p3«: () -> ()
+)
+
+@Impure([])
+fun impureFunctionWithoutReasons(
+    // $TEST$ no error "The purity of a callable parameter must be specified. Call the annotation '@Pure' or add the impurity reason 'PotentiallyImpureParameterCall' to the containing function."
+    »p1«: Int,
+    // $TEST$ no error "The purity of a callable parameter must be specified. Call the annotation '@Pure' or add the impurity reason 'PotentiallyImpureParameterCall' to the containing function."
+    @Pure »p2«: () -> (),
+    // $TEST$ error "The purity of a callable parameter must be specified. Call the annotation '@Pure' or add the impurity reason 'PotentiallyImpureParameterCall' to the containing function."
+    »p3«: () -> ()
+)
+
+@Impure([
+    ImpurityReason.PotentiallyImpureParameterCall("p1"),
+    ImpurityReason.PotentiallyImpureParameterCall("p2"),
+    ImpurityReason.PotentiallyImpureParameterCall("p3")
+])
+fun impureFunctionWithReasons(
+    // $TEST$ no error "The purity of a callable parameter must be specified. Call the annotation '@Pure' or add the impurity reason 'PotentiallyImpureParameterCall' to the containing function."
+    »p1«: Int,
+    // $TEST$ no error "The purity of a callable parameter must be specified. Call the annotation '@Pure' or add the impurity reason 'PotentiallyImpureParameterCall' to the containing function."
+    @Pure »p2«: () -> (),
+    // $TEST$ no error "The purity of a callable parameter must be specified. Call the annotation '@Pure' or add the impurity reason 'PotentiallyImpureParameterCall' to the containing function."
+    »p3«: () -> ()
+)

--- a/packages/safe-ds-lang/tests/resources/validation/purity/potentially impure parameter must have callable type/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/purity/potentially impure parameter must have callable type/main.sdstest
@@ -1,0 +1,20 @@
+package tests.validation.purity.potentiallyImpureParameterMustHaveCallableType
+
+@Impure([
+    // $TEST$ error "The parameter 'a' must have a callable type."
+    ImpurityReason.PotentiallyImpureParameterCall(»"a"«),
+    // $TEST$ error "The parameter 'b' must have a callable type."
+    ImpurityReason.PotentiallyImpureParameterCall(»"b"«),
+    // $TEST$ no error r"The parameter '.*' must have a callable type\."
+    ImpurityReason.PotentiallyImpureParameterCall(»"c"«),
+    // $TEST$ no error r"The parameter '.*' must have a callable type\."
+    ImpurityReason.PotentiallyImpureParameterCall(»"d"«),
+    // $TEST$ no error r"The parameter '.*' must have a callable type\."
+    ImpurityReason.PotentiallyImpureParameterCall(»"e"«),
+])
+fun myFunction(
+    a: Int,
+    b: Unresolved,
+    c: () -> (),
+    d,
+)

--- a/packages/safe-ds-lang/tests/resources/validation/purity/pure and potentially impure callable parameter/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/purity/pure and potentially impure callable parameter/main.sdstest
@@ -1,0 +1,45 @@
+package tests.validation.purity.pureAndPotentiallyImpureCallableParameter
+
+fun functionWithUnknownPurity(
+    // $TEST$ no error "'@Pure' and the impurity reason 'PotentiallyImpureParameterCall' on the containing function are mutually exclusive."
+    @Pure »p1«: Int,
+    // $TEST$ no error "'@Pure' and the impurity reason 'PotentiallyImpureParameterCall' on the containing function are mutually exclusive."
+    @Pure »p2«: () -> (),
+    // $TEST$ no error "'@Pure' and the impurity reason 'PotentiallyImpureParameterCall' on the containing function are mutually exclusive."
+    »p3«: () -> ()
+)
+
+
+@Impure([])
+fun impureFunctionWithoutReasons(
+    // $TEST$ no error "'@Pure' and the impurity reason 'PotentiallyImpureParameterCall' on the containing function are mutually exclusive."
+    @Pure »p1«: Int,
+    // $TEST$ no error "'@Pure' and the impurity reason 'PotentiallyImpureParameterCall' on the containing function are mutually exclusive."
+    @Pure »p2«: () -> (),
+    // $TEST$ no error "'@Pure' and the impurity reason 'PotentiallyImpureParameterCall' on the containing function are mutually exclusive."
+    »p3«: () -> ()
+)
+
+@Impure([
+    ImpurityReason.PotentiallyImpureParameterCall("p1"),
+    ImpurityReason.PotentiallyImpureParameterCall("p2"),
+    ImpurityReason.PotentiallyImpureParameterCall("p3")
+])
+fun impureFunctionWithReasons(
+    // $TEST$ no error "'@Pure' and the impurity reason 'PotentiallyImpureParameterCall' on the containing function are mutually exclusive."
+    @Pure »p1«: Int,
+    // $TEST$ error "'@Pure' and the impurity reason 'PotentiallyImpureParameterCall' on the containing function are mutually exclusive."
+    @Pure »p2«: () -> (),
+    // $TEST$ no error "'@Pure' and the impurity reason 'PotentiallyImpureParameterCall' on the containing function are mutually exclusive."
+    »p3«: () -> ()
+)
+
+@Pure
+fun pureFunction(
+    // $TEST$ no error "'@Pure' and the impurity reason 'PotentiallyImpureParameterCall' on the containing function are mutually exclusive."
+    @Pure »p1«: Int,
+    // $TEST$ no error "'@Pure' and the impurity reason 'PotentiallyImpureParameterCall' on the containing function are mutually exclusive."
+    @Pure »p2«: () -> (),
+    // $TEST$ no error "'@Pure' and the impurity reason 'PotentiallyImpureParameterCall' on the containing function are mutually exclusive."
+    »p3«: () -> ()
+)


### PR DESCRIPTION
Closes #732

### Summary of Changes

A callable parameter of functions must either be pure or `PotentiallyImpureParameterCall` must be included as an impurity reason on the containing function. However, the two are mutually exclusive. Now an error is shown if none or both are set.