### PR TITLE
feat: compute types of parameters of lambdas that are passed as default value

### DIFF
--- a/packages/safe-ds-lang/src/language/typing/model.ts
+++ b/packages/safe-ds-lang/src/language/typing/model.ts
@@ -46,6 +46,7 @@ export class CallableType extends Type {
 
     constructor(
         readonly callable: SdsCallable,
+        readonly parameter: SdsParameter | undefined,
         readonly inputType: NamedTupleType<SdsParameter>,
         readonly outputType: NamedTupleType<SdsAbstractResult>,
     ) {
@@ -68,6 +69,7 @@ export class CallableType extends Type {
 
         return (
             other.callable === this.callable &&
+            other.parameter === this.parameter &&
             other.inputType.equals(this.inputType) &&
             other.outputType.equals(this.outputType)
         );
@@ -84,6 +86,7 @@ export class CallableType extends Type {
     override unwrap(): CallableType {
         return new CallableType(
             this.callable,
+            this.parameter,
             new NamedTupleType(...this.inputType.entries.map((it) => it.unwrap())),
             new NamedTupleType(...this.outputType.entries.map((it) => it.unwrap())),
         );

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
@@ -236,7 +236,7 @@ export class SafeDsTypeChecker {
                 new NamedTupleEntry<SdsAbstractResult>(undefined, 'instance', instanceType),
             );
 
-            return new CallableType(declaration, parameterEntries, resultEntries);
+            return new CallableType(declaration, undefined, parameterEntries, resultEntries);
         } else if (instanceType instanceof EnumVariantType) {
             const declaration = instanceType.declaration;
 
@@ -249,7 +249,7 @@ export class SafeDsTypeChecker {
                 new NamedTupleEntry<SdsAbstractResult>(undefined, 'instance', instanceType),
             );
 
-            return new CallableType(declaration, parameterEntries, resultEntries);
+            return new CallableType(declaration, undefined, parameterEntries, resultEntries);
         } else {
             return UnknownType;
         }

--- a/packages/safe-ds-lang/tests/language/typing/model.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/model.test.ts
@@ -52,10 +52,12 @@ describe('type model', async () => {
             value: () =>
                 new CallableType(
                     callable1,
+                    undefined,
                     new NamedTupleType(new NamedTupleEntry(parameter1, 'p1', UnknownType)),
                     new NamedTupleType(),
                 ),
-            unequalValueOfSameType: () => new CallableType(callable2, new NamedTupleType(), new NamedTupleType()),
+            unequalValueOfSameType: () =>
+                new CallableType(callable2, undefined, new NamedTupleType(), new NamedTupleType()),
             valueOfOtherType: () => UnknownType,
         },
         {
@@ -125,6 +127,7 @@ describe('type model', async () => {
         {
             value: new CallableType(
                 callable1,
+                undefined,
                 new NamedTupleType(new NamedTupleEntry(parameter1, 'p1', UnknownType)),
                 new NamedTupleType(),
             ),
@@ -133,6 +136,7 @@ describe('type model', async () => {
         {
             value: new CallableType(
                 callable1,
+                undefined,
                 new NamedTupleType(new NamedTupleEntry(parameter2, 'p2', UnknownType)),
                 new NamedTupleType(),
             ),
@@ -179,17 +183,19 @@ describe('type model', async () => {
 
     const unwrapTests: UnwrapTest[] = [
         {
-            type: new CallableType(callable1, new NamedTupleType(), new NamedTupleType()),
-            expectedType: new CallableType(callable1, new NamedTupleType(), new NamedTupleType()),
+            type: new CallableType(callable1, undefined, new NamedTupleType(), new NamedTupleType()),
+            expectedType: new CallableType(callable1, undefined, new NamedTupleType(), new NamedTupleType()),
         },
         {
             type: new CallableType(
                 callable1,
+                undefined,
                 new NamedTupleType(new NamedTupleEntry(parameter1, 'p1', new UnionType(UnknownType))),
                 new NamedTupleType(new NamedTupleEntry(result, 'r', new UnionType(UnknownType))),
             ),
             expectedType: new CallableType(
                 callable1,
+                undefined,
                 new NamedTupleType(new NamedTupleEntry(parameter1, 'p1', UnknownType)),
                 new NamedTupleType(new NamedTupleEntry(result, 'r', UnknownType)),
             ),
@@ -253,17 +259,17 @@ describe('type model', async () => {
 
     const updateNullabilityTest: UpdateNullabilityTest[] = [
         {
-            type: new CallableType(callable1, new NamedTupleType(), new NamedTupleType()),
+            type: new CallableType(callable1, undefined, new NamedTupleType(), new NamedTupleType()),
             isNullable: true,
             expectedType: new UnionType(
-                new CallableType(callable1, new NamedTupleType(), new NamedTupleType()),
+                new CallableType(callable1, undefined, new NamedTupleType(), new NamedTupleType()),
                 new LiteralType(NullConstant),
             ),
         },
         {
-            type: new CallableType(callable1, new NamedTupleType(), new NamedTupleType()),
+            type: new CallableType(callable1, undefined, new NamedTupleType(), new NamedTupleType()),
             isNullable: false,
-            expectedType: new CallableType(callable1, new NamedTupleType(), new NamedTupleType()),
+            expectedType: new CallableType(callable1, undefined, new NamedTupleType(), new NamedTupleType()),
         },
         {
             type: new LiteralType(new BooleanConstant(true)),
@@ -386,13 +392,14 @@ describe('type model', async () => {
         describe('getParameterTypeByIndex', () => {
             it.each([
                 {
-                    type: new CallableType(callable1, new NamedTupleType(), new NamedTupleType()),
+                    type: new CallableType(callable1, undefined, new NamedTupleType(), new NamedTupleType()),
                     index: 0,
                     expectedType: UnknownType,
                 },
                 {
                     type: new CallableType(
                         callable1,
+                        undefined,
                         new NamedTupleType(new NamedTupleEntry(parameter1, 'p1', new ClassType(class1, false))),
                         new NamedTupleType(),
                     ),

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of block lambdas/that are passed as default values/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of block lambdas/that are passed as default values/main.sdstest
@@ -1,0 +1,17 @@
+package tests.typing.declarations.parameters.ofBlockLambdas.thatArePassedAsDefaultValues
+
+fun higherOrderFunction1(
+    // $TEST$ equivalence_class parameterType1
+    // $TEST$ equivalence_class parameterType1
+    param: (a: »String«) -> () = (»p«) {}
+)
+
+fun higherOrderFunction2(
+    // $TEST$ serialization ?
+    param: () -> () = (»p«) {}
+)
+
+fun normalFunction(
+    // $TEST$ serialization ?
+    param: Int = (»p«) {}
+)

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of expression lambdas/that are passed as default values/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of expression lambdas/that are passed as default values/main.sdstest
@@ -1,0 +1,17 @@
+package tests.typing.declarations.parameters.ofExpressionLambdas.thatArePassedAsArguments
+
+fun higherOrderFunction1(
+    // $TEST$ equivalence_class parameterType1
+    // $TEST$ equivalence_class parameterType1
+    param: (a: »String«) -> r: String = (»p«) -> ""
+)
+
+fun higherOrderFunction2(
+    // $TEST$ serialization ?
+    param: () -> r: String = (»p«) -> ""
+)
+
+fun normalFunction(
+    // $TEST$ serialization ?
+    param: Int = (»p«) -> ""
+)

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/block lambdas/that are passed as default values/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/block lambdas/that are passed as default values/main.sdstest
@@ -1,0 +1,37 @@
+package tests.typing.expressions.blockLambdas.thatArePassedAsDefaultValues
+
+fun higherOrderFunction1(
+    // $TEST$ serialization (p: String) -> (r: literal<1>, s: literal<"">)
+    param1: (p: String) -> (r: Int, s: String) = »(p) {
+        yield r = 1;
+        yield s = "";
+    }«,
+    // $TEST$ serialization (p: String) -> (r: literal<1>, s: ?)
+    param2: (p: String) -> (r: Int, s: String) = »(p) {
+        yield r, yield s = 1;
+    }«,
+)
+
+fun higherOrderFunction2(
+    // $TEST$ serialization (p: ?) -> (r: literal<1>, s: literal<"">)
+    param1: () -> () = »(p) {
+        yield r = 1;
+        yield s = "";
+    }«,
+    // $TEST$ serialization (p: ?) -> (r: literal<1>, s: ?)
+    param2: () -> () = »(p) {
+        yield r, yield s = 1;
+    }«,
+)
+
+fun normalFunction(
+    // $TEST$ serialization (p: ?) -> (r: literal<1>, s: literal<"">)
+    param1: Int = »(p) {
+        yield r = 1;
+        yield s = "";
+    }«,
+    // $TEST$ serialization (p: ?) -> (r: literal<1>, s: ?)
+    param2: Int = »(p) {
+        yield r, yield s = 1;
+    }«,
+)

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/expression lambdas/that are passed as default values/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/expression lambdas/that are passed as default values/main.sdstest
@@ -1,0 +1,16 @@
+package tests.typing.expressions.expressionLambdas.thatArePassedAsDefaultValues
+
+fun higherOrderFunction1(
+    // $TEST$ serialization (p: String) -> (result: literal<1>)
+    param: (p: String) -> (r: Int) = »(p) -> 1«
+)
+
+fun higherOrderFunction2(
+    // $TEST$ serialization (p: ?) -> (result: literal<1>)
+    param: () -> () = »(p) -> 1«
+)
+
+fun normalFunction(
+    // $TEST$ serialization (p: ?) -> (result: literal<1>)
+    param: Int = »(p) -> 1«
+)


### PR DESCRIPTION
### Summary of Changes

The types of parameter of lambdas that are passed as default value are now inferred from the context.