### PR TITLE
fix: wrong`"assignment/nothing-assigned"` error if RHS calls expression lambda

### DIFF
--- a/packages/safe-ds-lang/src/language/helpers/safe-ds-node-mapper.ts
+++ b/packages/safe-ds-lang/src/language/helpers/safe-ds-node-mapper.ts
@@ -8,6 +8,7 @@ import {
     isSdsCallable,
     isSdsClass,
     isSdsEnumVariant,
+    isSdsExpressionLambda,
     isSdsNamedType,
     isSdsParameter,
     isSdsReference,
@@ -116,6 +117,15 @@ export class SafeDsNodeMapper {
         if (isSdsClass(callable) || isSdsEnumVariant(callable)) {
             if (assigneePosition === 0) {
                 return expression;
+            } else {
+                return undefined;
+            }
+        }
+
+        // If the RHS calls an expression lambda, the first assignee gets its result
+        if (isSdsExpressionLambda(callable)) {
+            if (assigneePosition === 0) {
+                return callable.result;
             } else {
                 return undefined;
             }

--- a/packages/safe-ds-lang/tests/language/helpers/safe-ds-node-mapper/assigneeToAssignedObject.test.ts
+++ b/packages/safe-ds-lang/tests/language/helpers/safe-ds-node-mapper/assigneeToAssignedObject.test.ts
@@ -136,6 +136,18 @@ describe('SafeDsNodeMapper', () => {
                 expected: ['r1', 'r2'],
             },
             {
+                name: 'expression lambda',
+                code: `
+                    segment mySegment() {
+                        val f = () -> 1;
+
+                        val a, val b = f();
+                    };
+                `,
+                expected: ['1', undefined],
+                index: 1,
+            },
+            {
                 name: 'function (one result)',
                 code: `
                     fun f() -> (r1: Int)
@@ -179,10 +191,12 @@ describe('SafeDsNodeMapper', () => {
 
         const abstractResultNameOrNull = (node: SdsAssignee): string | undefined => {
             const assignedObject = nodeMapper.assigneeToAssignedObject(node);
-            if (isSdsAbstractResult(assignedObject)) {
+            if (!assignedObject) {
+                return undefined;
+            } else if (isSdsAbstractResult(assignedObject)) {
                 return assignedObject.name;
             } else {
-                return undefined;
+                return assignedObject.$cstNode?.text;
             }
         };
     });


### PR DESCRIPTION
### Summary of Changes

If the RHS of an assignment calls an expression lambda, an incorrect `"assignment/nothing-assigned"` was shown on the first assignee. This PR fixes this.