### PR TITLE
feat: short-circuit `and`, `or`, and `?:` if RHS has no side effects

### DIFF
--- a/packages/safe-ds-lang/tests/language/partialEvaluation/safe-ds-partial-evalutator.test.ts
+++ b/packages/safe-ds-lang/tests/language/partialEvaluation/safe-ds-partial-evalutator.test.ts
@@ -1,13 +1,13 @@
 import { AssertionError } from 'assert';
 import { NodeFileSystem } from 'langium/node';
 import { describe, it } from 'vitest';
-import { createSafeDsServices } from '../../../src/language/index.js';
+import { createSafeDsServicesWithBuiltins } from '../../../src/language/index.js';
 import { locationToString } from '../../helpers/location.js';
 import { getNodeByLocation } from '../../helpers/nodeFinder.js';
 import { loadDocuments } from '../../helpers/testResources.js';
 import { createPartialEvaluationTests } from './creator.js';
 
-const services = createSafeDsServices(NodeFileSystem).SafeDs;
+const services = (await createSafeDsServicesWithBuiltins(NodeFileSystem)).SafeDs;
 const partialEvaluator = services.evaluation.PartialEvaluator;
 
 describe('partial evaluation', async () => {

--- a/packages/safe-ds-lang/tests/resources/partial evaluation/recursive cases/infix operations/and/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/partial evaluation/recursive cases/infix operations/and/main.sdstest
@@ -17,10 +17,10 @@ pipeline test {
     »1 and true«;
 
     // $TEST$ serialization ?
-    »false and 0«;
+    »true and 0«;
 
     // $TEST$ serialization ?
-    »unresolved and false«;
+    »unresolved and true«;
 
     // $TEST$ serialization ?
     »true and unresolved«;

--- a/packages/safe-ds-lang/tests/resources/partial evaluation/recursive cases/infix operations/and/short circuiting.sdstest
+++ b/packages/safe-ds-lang/tests/resources/partial evaluation/recursive cases/infix operations/and/short circuiting.sdstest
@@ -1,0 +1,30 @@
+package tests.partialValidation.recursiveCases.infixOperations.`and`
+
+@Pure
+fun pureFunction() -> result: Boolean
+
+@Impure([ImpurityReason.FileReadFromConstantPath("test.txt")])
+fun functionWithoutSideEffects() -> result: Boolean
+
+@Impure([ImpurityReason.FileWriteToConstantPath("test.txt")])
+fun functionWithSideEffects() -> result: Boolean
+
+pipeline test {
+    // $TEST$ serialization false
+    »false and pureFunction()«;
+
+    // $TEST$ serialization false
+    »false and functionWithoutSideEffects()«;
+
+    // $TEST$ serialization ?
+    »false and functionWithSideEffects()«;
+
+    // $TEST$ serialization ?
+    »true and pureFunction()«;
+
+    // $TEST$ serialization ?
+    »true and functionWithoutSideEffects()«;
+
+    // $TEST$ serialization ?
+    »true and functionWithSideEffects()«;
+}

--- a/packages/safe-ds-lang/tests/resources/partial evaluation/recursive cases/infix operations/elvis/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/partial evaluation/recursive cases/infix operations/elvis/main.sdstest
@@ -7,9 +7,12 @@ pipeline test {
     // $TEST$ serialization false
     »null ?: false«;
 
-    // $TEST$ serialization ?
-    »unresolved ?: true«;
+    // $TEST$ serialization $ExpressionLambdaClosure
+    »(() -> 1) ?: false«;
 
     // $TEST$ serialization ?
-    »true ?: unresolved«;
+    »unresolved ?: null«;
+
+    // $TEST$ serialization ?
+    »null ?: unresolved«;
 }

--- a/packages/safe-ds-lang/tests/resources/partial evaluation/recursive cases/infix operations/elvis/short circuiting.sdstest
+++ b/packages/safe-ds-lang/tests/resources/partial evaluation/recursive cases/infix operations/elvis/short circuiting.sdstest
@@ -1,0 +1,30 @@
+package tests.partialValidation.recursiveCases.infixOperations.elvis
+
+@Pure
+fun pureFunction() -> result: Boolean
+
+@Impure([ImpurityReason.FileReadFromConstantPath("test.txt")])
+fun functionWithoutSideEffects() -> result: Boolean
+
+@Impure([ImpurityReason.FileWriteToConstantPath("test.txt")])
+fun functionWithSideEffects() -> result: Boolean
+
+pipeline test {
+    // $TEST$ serialization 1
+    »1 ?: pureFunction()«;
+
+    // $TEST$ serialization 1
+    »1 ?: functionWithoutSideEffects()«;
+
+    // $TEST$ serialization ?
+    »1 ?: functionWithSideEffects()«;
+
+    // $TEST$ serialization ?
+    »null ?: pureFunction()«;
+
+    // $TEST$ serialization ?
+    »null ?: functionWithoutSideEffects()«;
+
+    // $TEST$ serialization ?
+    »null ?: functionWithSideEffects()«;
+}

--- a/packages/safe-ds-lang/tests/resources/partial evaluation/recursive cases/infix operations/or/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/partial evaluation/recursive cases/infix operations/or/main.sdstest
@@ -14,7 +14,7 @@ pipeline test {
     »true or true«;
 
     // $TEST$ serialization ?
-    »1 or true«;
+    »1 or false«;
 
     // $TEST$ serialization ?
     »false or 0«;
@@ -23,5 +23,5 @@ pipeline test {
     »unresolved or false«;
 
     // $TEST$ serialization ?
-    »true or unresolved«;
+    »false or unresolved«;
 }

--- a/packages/safe-ds-lang/tests/resources/partial evaluation/recursive cases/infix operations/or/short circuiting.sdstest
+++ b/packages/safe-ds-lang/tests/resources/partial evaluation/recursive cases/infix operations/or/short circuiting.sdstest
@@ -1,0 +1,30 @@
+package tests.partialValidation.recursiveCases.infixOperations.`or`
+
+@Pure
+fun pureFunction() -> result: Boolean
+
+@Impure([ImpurityReason.FileReadFromConstantPath("test.txt")])
+fun functionWithoutSideEffects() -> result: Boolean
+
+@Impure([ImpurityReason.FileWriteToConstantPath("test.txt")])
+fun functionWithSideEffects() -> result: Boolean
+
+pipeline test {
+    // $TEST$ serialization true
+    »true or pureFunction()«;
+
+    // $TEST$ serialization true
+    »true or functionWithoutSideEffects()«;
+
+    // $TEST$ serialization ?
+    »true or functionWithSideEffects()«;
+
+    // $TEST$ serialization ?
+    »false or pureFunction()«;
+
+    // $TEST$ serialization ?
+    »false or functionWithoutSideEffects()«;
+
+    // $TEST$ serialization ?
+    »false or functionWithSideEffects()«;
+}

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/operations/elvis/non nullable left operand.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/operations/elvis/non nullable left operand.sdstest
@@ -1,18 +1,32 @@
-package tests.typing.operations.elvis
+package tests.typing.operations.elvis.nonNullableLeftOperand
 
-fun intOrNull() -> a: Int?
+@Pure fun int() -> a: Int
+@Pure fun intOrNull() -> a: Int?
 
 pipeline elvisWithNonNullableLeftOperand {
-    // $TEST$ equivalence_class leftOperand
+    // $TEST$ equivalence_class leftOperand1
     »1«;
-    // $TEST$ equivalence_class leftOperand
+    // $TEST$ equivalence_class leftOperand1
     »1 ?: intOrNull()«;
-    // $TEST$ equivalence_class leftOperand
+    // $TEST$ equivalence_class leftOperand1
     »1 ?: 1«;
-    // $TEST$ equivalence_class leftOperand
+    // $TEST$ equivalence_class leftOperand1
     »1 ?: 1.0«;
-    // $TEST$ equivalence_class leftOperand
+    // $TEST$ equivalence_class leftOperand1
     »1 ?: ""«;
-    // $TEST$ equivalence_class leftOperand
+    // $TEST$ equivalence_class leftOperand1
     »1 ?: null«;
+
+    // $TEST$ equivalence_class leftOperand2
+    »int()«;
+    // $TEST$ equivalence_class leftOperand2
+    »int() ?: intOrNull()«;
+    // $TEST$ equivalence_class leftOperand2
+    »int() ?: 1«;
+    // $TEST$ equivalence_class leftOperand2
+    »int() ?: 1.0«;
+    // $TEST$ equivalence_class leftOperand2
+    »int() ?: ""«;
+    // $TEST$ equivalence_class leftOperand2
+    »int() ?: null«;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/operations/elvis/nullable left operand.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/operations/elvis/nullable left operand.sdstest
@@ -1,7 +1,7 @@
-package tests.typing.operations.elvis
+package tests.typing.operations.elvis.nullableLeftOperand
 
-fun intOrNull() -> a: Int?
-fun stringOrNull() -> s: String?
+@Pure fun intOrNull() -> a: Int?
+@Pure fun stringOrNull() -> s: String?
 
 pipeline elvisWithNullableLeftOperand {
     // $TEST$ serialization Int?


### PR DESCRIPTION
Closes #15

### Summary of Changes

Evaluate `and`, `or`, and `?:` if the RHS has no side effects and the LHS determines the result.