### PR TITLE
fix: wrong detection of useless statements that call parameters/unknown callables

### DIFF
--- a/packages/safe-ds-lang/src/language/flow/model.ts
+++ b/packages/safe-ds-lang/src/language/flow/model.ts
@@ -1,9 +1,9 @@
-import { SdsCallable } from '../generated/ast.js';
+import { SdsCallable, SdsParameter } from '../generated/ast.js';
 import { stream, Stream } from 'langium';
 
 export class CallGraph {
     constructor(
-        readonly root: SdsCallable | undefined,
+        readonly root: SdsCallable | SdsParameter | undefined,
         readonly children: CallGraph[],
         readonly isRecursive: boolean = false,
     ) {}
@@ -12,11 +12,11 @@ export class CallGraph {
      * Traverses the call graph depth-first in pre-order and returns a stream of all callables that are called directly
      * or indirectly.
      */
-    streamCalledCallables(): Stream<SdsCallable | undefined> {
+    streamCalledCallables(): Stream<SdsCallable | SdsParameter | undefined> {
         return stream(this.streamCalledCallablesGenerator());
     }
 
-    private *streamCalledCallablesGenerator(): Generator<SdsCallable | undefined, void> {
+    private *streamCalledCallablesGenerator(): Generator<SdsCallable | SdsParameter | undefined, void> {
         yield this.root;
 
         for (const child of this.children) {

--- a/packages/safe-ds-lang/src/language/flow/safe-ds-call-graph-computer.ts
+++ b/packages/safe-ds-lang/src/language/flow/safe-ds-call-graph-computer.ts
@@ -167,7 +167,7 @@ export class SafeDsCallGraphComputer {
         return this.getExecutedCallsInCallable(syntheticCall.callable.callable, syntheticCall.substitutions);
     }
 
-    private getExecutedCallsInCallable(callable: SdsCallable, substitutions: ParameterSubstitutions) {
+    private getExecutedCallsInCallable(callable: SdsCallable | SdsParameter, substitutions: ParameterSubstitutions) {
         if (isSdsBlockLambda(callable) || isSdsExpressionLambda(callable) || isSdsSegment(callable)) {
             return this.getExecutedCallsInPipelineCallable(callable, substitutions);
         } else if (isSdsClass(callable) || isSdsEnumVariant(callable) || isSdsFunction(callable)) {
@@ -279,7 +279,7 @@ export class SafeDsCallGraphComputer {
 
             // Parameter might have a default value
             if (!callableOrParameter.defaultValue) {
-                return undefined;
+                return new NamedCallable(callableOrParameter);
             }
             return this.getEvaluatedCallable(callableOrParameter.defaultValue, substitutions);
         } else if (isNamed(callableOrParameter)) {
@@ -314,7 +314,7 @@ export class SafeDsCallGraphComputer {
         args: SdsArgument[],
         substitutions: ParameterSubstitutions,
     ): ParameterSubstitutions {
-        if (!callable) {
+        if (!callable || isSdsParameter(callable.callable)) {
             return NO_SUBSTITUTIONS;
         }
 
@@ -322,7 +322,7 @@ export class SafeDsCallGraphComputer {
         const substitutionsOnCreation = callable.substitutionsOnCreation;
 
         // Substitutions on call
-        const parameters = getParameters(callable?.callable);
+        const parameters = getParameters(callable.callable);
         const substitutionsOnCall = new Map(
             args.flatMap((it) => {
                 // Ignore arguments that don't get assigned to a parameter

--- a/packages/safe-ds-lang/src/language/partialEvaluation/model.ts
+++ b/packages/safe-ds-lang/src/language/partialEvaluation/model.ts
@@ -144,7 +144,9 @@ export const isConstant = (node: EvaluatedNode): node is Constant => {
 // Callables
 // -------------------------------------------------------------------------------------------------
 
-export abstract class EvaluatedCallable<out T extends SdsCallable = SdsCallable> extends EvaluatedNode {
+export abstract class EvaluatedCallable<
+    out T extends SdsCallable | SdsParameter = SdsCallable | SdsParameter,
+> extends EvaluatedNode {
     abstract readonly callable: T;
     abstract readonly substitutionsOnCreation: ParameterSubstitutions;
     override readonly isFullyEvaluated: boolean = false;
@@ -175,7 +177,7 @@ export class BlockLambdaClosure extends EvaluatedCallable<SdsBlockLambda> {
     }
 
     override toString(): string {
-        return `$BlockLambdaClosure`;
+        return `$blockLambdaClosure`;
     }
 }
 
@@ -204,11 +206,11 @@ export class ExpressionLambdaClosure extends EvaluatedCallable<SdsExpressionLamb
     }
 
     override toString(): string {
-        return '$ExpressionLambdaClosure';
+        return '$expressionLambdaClosure';
     }
 }
 
-export class NamedCallable<T extends SdsCallable & NamedAstNode> extends EvaluatedCallable<T> {
+export class NamedCallable<T extends (SdsCallable & NamedAstNode) | SdsParameter> extends EvaluatedCallable<T> {
     override readonly isFullyEvaluated: boolean = false;
     override readonly substitutionsOnCreation: ParameterSubstitutions = new Map();
 

--- a/packages/safe-ds-lang/src/language/purity/model.ts
+++ b/packages/safe-ds-lang/src/language/purity/model.ts
@@ -101,6 +101,23 @@ export class PotentiallyImpureParameterCall extends ImpurityReason {
 }
 
 /**
+ * The function calls an unknown callable.
+ */
+class UnknownCallableCallClass extends ImpurityReason {
+    override isSideEffect = true;
+
+    override equals(other: unknown): boolean {
+        return other instanceof UnknownCallableCallClass;
+    }
+
+    override toString(): string {
+        return 'Unknown callable call';
+    }
+}
+
+export const UnknownCallableCall = new UnknownCallableCallClass();
+
+/**
  * A function contains a call that leads to endless recursion.
  */
 class EndlessRecursionClass extends ImpurityReason {

--- a/packages/safe-ds-lang/src/language/purity/safe-ds-purity-computer.ts
+++ b/packages/safe-ds-lang/src/language/purity/safe-ds-purity-computer.ts
@@ -20,6 +20,7 @@ import {
     UnknownCallableCall,
 } from './model.js';
 import {
+    isSdsAnnotation,
     isSdsAssignment,
     isSdsCallable,
     isSdsClass,
@@ -99,7 +100,12 @@ export class SafeDsPurityComputer {
      */
     isPureParameter(node: SdsParameter | undefined): boolean {
         const containingCallable = getContainerOfType(node, isSdsCallable);
-        if (!containingCallable || isSdsClass(containingCallable) || isSdsEnumVariant(containingCallable)) {
+        if (
+            !containingCallable ||
+            isSdsAnnotation(containingCallable) ||
+            isSdsClass(containingCallable) ||
+            isSdsEnumVariant(containingCallable)
+        ) {
             return true;
         } else if (isSdsFunction(containingCallable)) {
             const expectedImpurityReason = new PotentiallyImpureParameterCall(node);

--- a/packages/safe-ds-lang/tests/language/partialEvaluation/model.test.ts
+++ b/packages/safe-ds-lang/tests/language/partialEvaluation/model.test.ts
@@ -187,11 +187,11 @@ describe('partial evaluation model', async () => {
         },
         {
             value: new BlockLambdaClosure(blockLambda1, new Map()),
-            expectedString: '$BlockLambdaClosure',
+            expectedString: '$blockLambdaClosure',
         },
         {
             value: new ExpressionLambdaClosure(expressionLambda1, new Map()),
-            expectedString: '$ExpressionLambdaClosure',
+            expectedString: '$expressionLambdaClosure',
         },
         {
             value: new NamedCallable(segment1),

--- a/packages/safe-ds-lang/tests/language/purity/model.test.ts
+++ b/packages/safe-ds-lang/tests/language/purity/model.test.ts
@@ -9,6 +9,7 @@ import {
     type ImpurityReason,
     OtherImpurityReason,
     PotentiallyImpureParameterCall,
+    UnknownCallableCall,
 } from '../../../src/language/purity/model.js';
 import { getNodeOfType } from '../../helpers/nodeFinder.js';
 import { type EqualsTest, ToStringTest } from '../../helpers/testDescription.js';
@@ -32,6 +33,10 @@ describe('purity model', async () => {
             value: () => new PotentiallyImpureParameterCall(undefined),
             unequalValueOfSameType: () => new PotentiallyImpureParameterCall(parameter),
             valueOfOtherType: () => new FileRead('test.txt'),
+        },
+        {
+            value: () => UnknownCallableCall,
+            valueOfOtherType: () => EndlessRecursion,
         },
         {
             value: () => EndlessRecursion,
@@ -98,6 +103,10 @@ describe('purity model', async () => {
         {
             value: new PotentiallyImpureParameterCall(parameter),
             expectedString: 'Potentially impure call of f.p',
+        },
+        {
+            value: UnknownCallableCall,
+            expectedString: 'Unknown callable call',
         },
         {
             value: EndlessRecursion,

--- a/packages/safe-ds-lang/tests/language/purity/safe-ds-purity-computer.test.ts
+++ b/packages/safe-ds-lang/tests/language/purity/safe-ds-purity-computer.test.ts
@@ -73,6 +73,15 @@ describe('SafeDsPurityComputer', async () => {
                 `,
                 expected: false,
             },
+            {
+                testName: 'pure parameter call',
+                code: `
+                    package test
+
+                    class MyClass(param: () -> (result: Int), value: Int = param())
+                `,
+                expected: true,
+            },
         ])('should return whether a callable is pure ($testName)', async ({ code, expected }) => {
             const callable = await getNodeOfType(services, code, isSdsCallable);
             expect(purityComputer.isPureCallable(callable)).toBe(expected);
@@ -170,6 +179,15 @@ describe('SafeDsPurityComputer', async () => {
                 `,
                 expected: false,
             },
+            {
+                testName: 'pure parameter call',
+                code: `
+                    package test
+
+                    class MyClass(param: () -> (result: Int), value: Int = param())
+                `,
+                expected: true,
+            },
         ])('should return whether an expression is pure ($testName)', async ({ code, expected }) => {
             const expression = await getNodeOfType(services, code, isSdsExpression);
             expect(purityComputer.isPureExpression(expression)).toBe(expected);
@@ -250,6 +268,15 @@ describe('SafeDsPurityComputer', async () => {
                     }
                 `,
                 expected: true,
+            },
+            {
+                testName: 'pure parameter call',
+                code: `
+                    package test
+
+                    class MyClass(param: () -> (result: Int), value: Int = param())
+                `,
+                expected: false,
             },
         ])('should return whether a callable has side effects ($testName)', async ({ code, expected }) => {
             const callable = await getNodeOfType(services, code, isSdsCallable);
@@ -361,6 +388,15 @@ describe('SafeDsPurityComputer', async () => {
                     }
                 `,
                 expected: true,
+            },
+            {
+                testName: 'pure parameter call',
+                code: `
+                    package test
+
+                    class MyClass(param: () -> (result: Int), value: Int = param())
+                `,
+                expected: false,
             },
         ])('should return whether a call has side effects ($testName)', async ({ code, expected }) => {
             const expression = await getNodeOfType(services, code, isSdsExpression);
@@ -493,6 +529,15 @@ describe('SafeDsPurityComputer', async () => {
                 `,
                 expected: ['Potentially impure call of test.mySegment.param'],
             },
+            {
+                testName: 'pure parameter call',
+                code: `
+                    package test
+
+                    class MyClass(param: () -> (result: Int), value: Int = param())
+                `,
+                expected: [],
+            },
         ])('should return the impurity reasons of a callable ($testName)', async ({ code, expected }) => {
             const callable = await getNodeOfType(services, code, isSdsCallable);
             const actual = purityComputer.getImpurityReasonsForCallable(callable).map((reason) => reason.toString());
@@ -604,6 +649,15 @@ describe('SafeDsPurityComputer', async () => {
                     }
                 `,
                 expected: ['Potentially impure call of test.mySegment.param'],
+            },
+            {
+                testName: 'pure parameter call',
+                code: `
+                    package test
+
+                    class MyClass(param: () -> (result: Int), value: Int = param())
+                `,
+                expected: [],
             },
         ])('should return the impurity reasons of a callable ($testName)', async ({ code, expected }) => {
             const expression = await getNodeOfType(services, code, isSdsExpression);

--- a/packages/safe-ds-lang/tests/language/purity/safe-ds-purity-computer.test.ts
+++ b/packages/safe-ds-lang/tests/language/purity/safe-ds-purity-computer.test.ts
@@ -51,6 +51,17 @@ describe('SafeDsPurityComputer', async () => {
                 `,
                 expected: false,
             },
+            {
+                testName: 'unknown callable',
+                code: `
+                    package test
+
+                    segment a() {
+                        unresolved();
+                    }
+                `,
+                expected: false,
+            },
         ])('should return whether a callable is pure ($testName)', async ({ code, expected }) => {
             const callable = await getNodeOfType(services, code, isSdsCallable);
             expect(purityComputer.isPureCallable(callable)).toBe(expected);
@@ -126,6 +137,17 @@ describe('SafeDsPurityComputer', async () => {
                 `,
                 expected: false,
             },
+            {
+                testName: 'unknown callable',
+                code: `
+                    package test
+
+                    segment a() {
+                        unresolved();
+                    }
+                `,
+                expected: false,
+            },
         ])('should return whether an expression is pure ($testName)', async ({ code, expected }) => {
             const expression = await getNodeOfType(services, code, isSdsExpression);
             expect(purityComputer.isPureExpression(expression)).toBe(expected);
@@ -181,6 +203,17 @@ describe('SafeDsPurityComputer', async () => {
 
                     segment a() {
                         a();
+                    }
+                `,
+                expected: true,
+            },
+            {
+                testName: 'unknown callable',
+                code: `
+                    package test
+
+                    segment a() {
+                        unresolved();
                     }
                 `,
                 expected: true,
@@ -270,6 +303,17 @@ describe('SafeDsPurityComputer', async () => {
 
                     segment a() {
                         a();
+                    }
+                `,
+                expected: true,
+            },
+            {
+                testName: 'unknown callable',
+                code: `
+                    package test
+
+                    segment a() {
+                        unresolved();
                     }
                 `,
                 expected: true,
@@ -383,6 +427,17 @@ describe('SafeDsPurityComputer', async () => {
                 `,
                 expected: ['Endless recursion'],
             },
+            {
+                testName: 'unknown callable',
+                code: `
+                    package test
+
+                    segment a() {
+                        unresolved();
+                    }
+                `,
+                expected: ['Unknown callable call'],
+            },
         ])('should return the impurity reasons of a callable ($testName)', async ({ code, expected }) => {
             const callable = await getNodeOfType(services, code, isSdsCallable);
             const actual = purityComputer.getImpurityReasonsForCallable(callable).map((reason) => reason.toString());
@@ -472,6 +527,17 @@ describe('SafeDsPurityComputer', async () => {
                     }
                 `,
                 expected: ['Endless recursion'],
+            },
+            {
+                testName: 'unknown callable',
+                code: `
+                    package test
+
+                    segment a() {
+                        unresolved();
+                    }
+                `,
+                expected: ['Unknown callable call'],
             },
         ])('should return the impurity reasons of a callable ($testName)', async ({ code, expected }) => {
             const expression = await getNodeOfType(services, code, isSdsExpression);

--- a/packages/safe-ds-lang/tests/language/purity/safe-ds-purity-computer.test.ts
+++ b/packages/safe-ds-lang/tests/language/purity/safe-ds-purity-computer.test.ts
@@ -62,6 +62,17 @@ describe('SafeDsPurityComputer', async () => {
                 `,
                 expected: false,
             },
+            {
+                testName: 'potentially impure parameter call',
+                code: `
+                    package test
+
+                    segment mySegment(param: () -> ()) {
+                        param();
+                    }
+                `,
+                expected: false,
+            },
         ])('should return whether a callable is pure ($testName)', async ({ code, expected }) => {
             const callable = await getNodeOfType(services, code, isSdsCallable);
             expect(purityComputer.isPureCallable(callable)).toBe(expected);
@@ -148,6 +159,17 @@ describe('SafeDsPurityComputer', async () => {
                 `,
                 expected: false,
             },
+            {
+                testName: 'potentially impure parameter call',
+                code: `
+                    package test
+
+                    segment mySegment(param: () -> ()) {
+                        param();
+                    }
+                `,
+                expected: false,
+            },
         ])('should return whether an expression is pure ($testName)', async ({ code, expected }) => {
             const expression = await getNodeOfType(services, code, isSdsExpression);
             expect(purityComputer.isPureExpression(expression)).toBe(expected);
@@ -214,6 +236,17 @@ describe('SafeDsPurityComputer', async () => {
 
                     segment a() {
                         unresolved();
+                    }
+                `,
+                expected: true,
+            },
+            {
+                testName: 'potentially impure parameter call',
+                code: `
+                    package test
+
+                    segment mySegment(param: () -> ()) {
+                        param();
                     }
                 `,
                 expected: true,
@@ -314,6 +347,17 @@ describe('SafeDsPurityComputer', async () => {
 
                     segment a() {
                         unresolved();
+                    }
+                `,
+                expected: true,
+            },
+            {
+                testName: 'potentially impure parameter call',
+                code: `
+                    package test
+
+                    segment mySegment(param: () -> ()) {
+                        param();
                     }
                 `,
                 expected: true,
@@ -438,6 +482,17 @@ describe('SafeDsPurityComputer', async () => {
                 `,
                 expected: ['Unknown callable call'],
             },
+            {
+                testName: 'potentially impure parameter call',
+                code: `
+                    package test
+
+                    segment mySegment(param: () -> ()) {
+                        param();
+                    }
+                `,
+                expected: ['Potentially impure call of test.mySegment.param'],
+            },
         ])('should return the impurity reasons of a callable ($testName)', async ({ code, expected }) => {
             const callable = await getNodeOfType(services, code, isSdsCallable);
             const actual = purityComputer.getImpurityReasonsForCallable(callable).map((reason) => reason.toString());
@@ -538,6 +593,17 @@ describe('SafeDsPurityComputer', async () => {
                     }
                 `,
                 expected: ['Unknown callable call'],
+            },
+            {
+                testName: 'potentially impure parameter call',
+                code: `
+                    package test
+
+                    segment mySegment(param: () -> ()) {
+                        param();
+                    }
+                `,
+                expected: ['Potentially impure call of test.mySegment.param'],
             },
         ])('should return the impurity reasons of a callable ($testName)', async ({ code, expected }) => {
             const expression = await getNodeOfType(services, code, isSdsExpression);

--- a/packages/safe-ds-lang/tests/resources/call graph/callable type call.sdstest
+++ b/packages/safe-ds-lang/tests/resources/call graph/callable type call.sdstest
@@ -1,6 +1,6 @@
 package tests.callGraph.callableTypeCall
 
 segment mySegment(param: () -> ()) {
-    // $TEST$ ["undefined"]
+    // $TEST$ ["param"]
     »param()«;
 }

--- a/packages/safe-ds-lang/tests/resources/partial evaluation/base cases/block lambdas/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/partial evaluation/base cases/block lambdas/main.sdstest
@@ -1,6 +1,6 @@
 package tests.partialValidation.baseCases.expressionLambdas
 
 pipeline test {
-    // $TEST$ serialization $ExpressionLambdaClosure
+    // $TEST$ serialization $expressionLambdaClosure
     »() -> 1«;
 }

--- a/packages/safe-ds-lang/tests/resources/partial evaluation/base cases/expression lambdas/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/partial evaluation/base cases/expression lambdas/main.sdstest
@@ -1,6 +1,6 @@
 package tests.partialValidation.baseCases.blockLambdas
 
 pipeline test {
-    // $TEST$ serialization $BlockLambdaClosure
+    // $TEST$ serialization $blockLambdaClosure
     »() {}«;
 }

--- a/packages/safe-ds-lang/tests/resources/partial evaluation/recursive cases/infix operations/elvis/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/partial evaluation/recursive cases/infix operations/elvis/main.sdstest
@@ -7,7 +7,7 @@ pipeline test {
     // $TEST$ serialization false
     »null ?: false«;
 
-    // $TEST$ serialization $ExpressionLambdaClosure
+    // $TEST$ serialization $expressionLambdaClosure
     »(() -> 1) ?: false«;
 
     // $TEST$ serialization ?

--- a/packages/safe-ds-lang/tests/resources/validation/other/statements/assignments/has no effect/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/other/statements/assignments/has no effect/main.sdstest
@@ -19,3 +19,11 @@ segment mySegment() -> a: Int {
         »yield a = 1;«
     };
 }
+
+segment mySegment2(f: () -> (r: Int)) {
+    // $TEST$ no warning "This statement does nothing."
+    »_ = f();«
+
+    // $TEST$ no warning "This statement does nothing."
+    »_ = unresolved();«
+}

--- a/packages/safe-ds-lang/tests/resources/validation/other/statements/expression statements/has no effect/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/other/statements/expression statements/has no effect/main.sdstest
@@ -81,3 +81,11 @@ segment mySegment() {
     // $TEST$ no warning "This statement does nothing."
     »recursiveA();«
 }
+
+segment mySegment2(f: () -> (r: Int)) {
+    // $TEST$ no warning "This statement does nothing."
+    »f();«
+
+    // $TEST$ no warning "This statement does nothing."
+    »unresolved();«
+}


### PR DESCRIPTION
### Summary of Changes

Statements that called parameters (with unknown value) or unknown callables were wrongly marked as unused. Because if this, an incorrect warning was shown and no code was generated for them.