### PR TITLE
fix: signature help for optional parameters

### DIFF
--- a/packages/safe-ds-lang/src/language/lsp/safe-ds-signature-help-provider.ts
+++ b/packages/safe-ds-lang/src/language/lsp/safe-ds-signature-help-provider.ts
@@ -17,7 +17,7 @@ import type {
 } from 'vscode-languageserver';
 import { createMarkupContent } from '../documentation/safe-ds-comment-provider.js';
 import { isSdsAbstractCall, SdsCallable, SdsParameter } from '../generated/ast.js';
-import { getParameters } from '../helpers/nodeProperties.js';
+import { getParameters, Parameter } from '../helpers/nodeProperties.js';
 import { type SafeDsNodeMapper } from '../helpers/safe-ds-node-mapper.js';
 import type { SafeDsServices } from '../safe-ds-module.js';
 import { type SafeDsTypeComputer } from '../typing/safe-ds-type-computer.js';
@@ -108,8 +108,9 @@ export class SafeDsSignatureHelpProvider implements SignatureHelpProvider {
     };
 
     private getParameterLabel = (parameter: SdsParameter) => {
+        const optionality = Parameter.isOptional(parameter) ? '?' : '';
         const type = this.typeComputer.computeType(parameter);
-        return `${parameter.name}: ${type}`;
+        return `${parameter.name}${optionality}: ${type}`;
     };
 
     /* c8 ignore start */

--- a/packages/safe-ds-lang/tests/language/lsp/safe-ds-signature-help-provider.test.ts
+++ b/packages/safe-ds-lang/tests/language/lsp/safe-ds-signature-help-provider.test.ts
@@ -176,6 +176,28 @@ describe('SafeDsSignatureHelpProvider', async () => {
                 },
             ],
         },
+        // https://github.com/Safe-DS/DSL/issues/791
+        {
+            testName: 'optional parameter',
+            code: `
+                fun f(p: Int = 0)
+
+                pipeline myPipeline {
+                    f(»«);
+                }
+            `,
+            expectedSignature: [
+                {
+                    label: 'f(p?: Int) -> ()',
+                    documentation: undefined,
+                    parameters: [
+                        {
+                            label: 'p?: Int',
+                        },
+                    ],
+                },
+            ],
+        },
     ])('should assign the correct signature ($testName)', async ({ code, expectedSignature }) => {
         const actualSignatureHelp = await getActualSignatureHelp(code);
         expect(actualSignatureHelp?.signatures).toStrictEqual(expectedSignature);


### PR DESCRIPTION
Closes #791

### Summary of Changes

Optional parameters in the signature help now get highlighted properly.