### PR TITLE
fix: handling of default values in entry point of call graph computation

### DIFF
--- a/packages/safe-ds-lang/src/language/flow/safe-ds-call-graph-computer.ts
+++ b/packages/safe-ds-lang/src/language/flow/safe-ds-call-graph-computer.ts
@@ -263,7 +263,7 @@ export class SafeDsCallGraphComputer {
         if (!callableOrParameter || isSdsAnnotation(callableOrParameter) || isSdsCallableType(callableOrParameter)) {
             return undefined;
         } else if (isSdsParameter(callableOrParameter)) {
-            // Parameter is set explicitly
+            // Parameter is set
             const substitution = substitutions.get(callableOrParameter);
             if (substitution) {
                 if (substitution instanceof EvaluatedCallable) {
@@ -274,11 +274,8 @@ export class SafeDsCallGraphComputer {
                 }
             }
 
-            // Parameter might have a default value
-            if (!callableOrParameter.defaultValue) {
-                return new NamedCallable(callableOrParameter);
-            }
-            return this.getEvaluatedCallable(callableOrParameter.defaultValue, substitutions);
+            // Parameter is not set
+            return new NamedCallable(callableOrParameter);
         } else if (isNamed(callableOrParameter)) {
             return new NamedCallable(callableOrParameter);
         } else if (isSdsBlockLambda(callableOrParameter)) {
@@ -311,6 +308,8 @@ export class SafeDsCallGraphComputer {
         args: SdsArgument[],
         substitutions: ParameterSubstitutions,
     ): ParameterSubstitutions {
+        // TODO: Use this in the partial evaluator too. Here (maybe) filter and keep only the substitutions that are
+        //  callables.
         if (!callable || isSdsParameter(callable.callable)) {
             return NO_SUBSTITUTIONS;
         }
@@ -318,7 +317,7 @@ export class SafeDsCallGraphComputer {
         // Substitutions on creation
         const substitutionsOnCreation = callable.substitutionsOnCreation;
 
-        // Substitutions on call
+        // Substitutions on call via arguments
         const parameters = getParameters(callable.callable);
         const substitutionsOnCall = new Map(
             args.flatMap((it) => {
@@ -347,7 +346,19 @@ export class SafeDsCallGraphComputer {
             }),
         );
 
-        return new Map([...substitutionsOnCreation, ...substitutionsOnCall]);
+        // Substitutions on call via default values
+        let result = new Map([...substitutionsOnCreation, ...substitutionsOnCall]);
+        for (const parameter of parameters) {
+            if (!result.has(parameter) && parameter.defaultValue) {
+                // Default values may depend on the values of previous parameters, so we have to evaluate them in order
+                const value = this.getEvaluatedCallable(parameter.defaultValue, result);
+                if (value) {
+                    result = new Map([...result, [parameter, value]]);
+                }
+            }
+        }
+
+        return result;
     }
 
     /**

--- a/packages/safe-ds-lang/src/language/flow/safe-ds-call-graph-computer.ts
+++ b/packages/safe-ds-lang/src/language/flow/safe-ds-call-graph-computer.ts
@@ -116,10 +116,7 @@ export class SafeDsCallGraphComputer {
         }
     }
 
-    private doGetCallGraph(
-        node: SdsCall | SdsCallable,
-        substitutions: ParameterSubstitutions = NO_SUBSTITUTIONS,
-    ): CallGraph {
+    private doGetCallGraph(node: SdsCall | SdsCallable, substitutions: ParameterSubstitutions): CallGraph {
         if (isSdsCall(node)) {
             const call = this.createSyntheticCallForCall(node, substitutions);
             return this.getCallGraphWithRecursionCheck(call, []);

--- a/packages/safe-ds-lang/tests/resources/call graph/block lambda call/default value/previous parameter.sdstest
+++ b/packages/safe-ds-lang/tests/resources/call graph/block lambda call/default value/previous parameter.sdstest
@@ -1,0 +1,13 @@
+package tests.callGraph.blockLambdaCall.defaultValue.previousParameter
+
+@Pure fun default() -> result: Any
+
+pipeline myPipeline {
+    val lambda = (
+        f: () -> (result: Any) = default,
+        g: Any = f()
+    ) {};
+
+    // $TEST$ ["$blockLambda", "default"]
+    »lambda()«;
+}

--- a/packages/safe-ds-lang/tests/resources/call graph/class call/default value/previous parameter.sdstest
+++ b/packages/safe-ds-lang/tests/resources/call graph/class call/default value/previous parameter.sdstest
@@ -1,0 +1,13 @@
+package tests.callGraph.classCall.defaultValue.previousParameter
+
+@Pure fun default() -> result: Any
+
+class MyClass(
+    f: () -> (result: Any) = default,
+    g: Any = f()
+)
+
+pipeline myPipeline {
+    // $TEST$ ["MyClass", "default", "default"]
+    »MyClass()«;
+}

--- a/packages/safe-ds-lang/tests/resources/call graph/default value handling in entry point.sdstest
+++ b/packages/safe-ds-lang/tests/resources/call graph/default value handling in entry point.sdstest
@@ -1,0 +1,12 @@
+package tests.callGraph.defaultValueHandlingInEntryPoint
+
+/*
+ * We must **not** assume that the default value is used just because no substitution is given for a parameter.
+ */
+
+@Pure fun default() -> r: Any
+
+segment mySegment(param: () -> () = default) {
+    // $TEST$ ["param"]
+    »param()«;
+}

--- a/packages/safe-ds-lang/tests/resources/call graph/enum variant call/default value/previous parameter.sdstest
+++ b/packages/safe-ds-lang/tests/resources/call graph/enum variant call/default value/previous parameter.sdstest
@@ -1,0 +1,15 @@
+package tests.callGraph.enumVariantCall.defaultValue.previousParameter
+
+@Pure fun default() -> result: Any
+
+enum MyEnum {
+    MyVariant(
+        f: () -> (result: Any) = default,
+        g: Any = f()
+    )
+}
+
+pipeline myPipeline {
+    // $TEST$ ["MyVariant", "default", "default"]
+    »MyEnum.MyVariant()«;
+}

--- a/packages/safe-ds-lang/tests/resources/call graph/expression lambda call/default value/previous parameter.sdstest
+++ b/packages/safe-ds-lang/tests/resources/call graph/expression lambda call/default value/previous parameter.sdstest
@@ -1,0 +1,13 @@
+package tests.callGraph.expressionLambdaCall.defaultValue.previousParameter
+
+@Pure fun default() -> result: Any
+
+pipeline myPipeline {
+    val lambda = (
+        f: () -> (result: Any) = default,
+        g: Any = f()
+    ) -> 1;
+
+    // $TEST$ ["$expressionLambda", "default"]
+    »lambda()«;
+}

--- a/packages/safe-ds-lang/tests/resources/call graph/function call/default value/previous parameter.sdstest
+++ b/packages/safe-ds-lang/tests/resources/call graph/function call/default value/previous parameter.sdstest
@@ -1,0 +1,13 @@
+package tests.callGraph.functionCall.defaultValue.previousParameter
+
+@Pure fun default() -> result: Any
+
+@Pure fun myFunction(
+    f: () -> (result: Any) = default,
+    g: Any = f()
+)
+
+pipeline myPipeline {
+    // $TEST$ ["myFunction", "default", "default"]
+    »myFunction()«;
+}

--- a/packages/safe-ds-lang/tests/resources/call graph/segment call/default value/previous parameter.sdstest
+++ b/packages/safe-ds-lang/tests/resources/call graph/segment call/default value/previous parameter.sdstest
@@ -1,0 +1,13 @@
+package tests.callGraph.segmentCall.defaultValue.previousParameter
+
+@Pure fun default() -> result: Any
+
+segment mySegment(
+    f: () -> (result: Any) = default,
+    g: Any = f()
+) {}
+
+pipeline myPipeline {
+    // $TEST$ ["mySegment", "default"]
+    »mySegment()«;
+}


### PR DESCRIPTION
### Summary of Changes

Consider the following code:

```
@Pure fun default() -> r: Any

segment mySegment(param: () -> () = default) {
    »param()«;
}
```

When computing the call graph for the `param()` call, we were previously always substituting `param` with its default value, since the parameter substitutions were empty in the entry point. Because of this, we were incorrectly considering the `param()` call as pure, just like the segment `mySegment`.
