### PR TITLE
fix: stack overflow when evaluating recursive calls

### DIFF
--- a/packages/safe-ds-lang/tests/resources/partial evaluation/recursive cases/calls/recursion/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/partial evaluation/recursive cases/calls/recursion/main.sdstest
@@ -1,0 +1,6 @@
+package tests.partialValidation.recursiveCases.calls.recursion
+
+segment mySegment() -> r: Int {
+    // $TEST$ serialization ?
+    yield r = »mySegment()«;
+}


### PR DESCRIPTION
### Summary of Changes

The partial evaluator was also evaluating recursive calls, which led to a stack overflow. We now check whether the call is recursive before evaluating it.