### PR TITLE
fix: potential stack overflow when computing impurity reasons

### DIFF
--- a/packages/safe-ds-lang/src/language/helpers/nodeProperties.ts
+++ b/packages/safe-ds-lang/src/language/helpers/nodeProperties.ts
@@ -187,6 +187,10 @@ export const findFirstAnnotationCallOf = (
     node: SdsAnnotatedObject | undefined,
     expected: SdsAnnotation | undefined,
 ): SdsAnnotationCall | undefined => {
+    if (!node || !expected) {
+        return undefined;
+    }
+
     return getAnnotationCalls(node).find((it) => {
         const actual = it.annotation?.ref;
         return actual === expected;

--- a/packages/safe-ds-lang/src/language/purity/safe-ds-purity-computer.ts
+++ b/packages/safe-ds-lang/src/language/purity/safe-ds-purity-computer.ts
@@ -233,7 +233,13 @@ export class SafeDsPurityComputer {
                 return [UnknownCallableCall];
             } else if (isSdsFunction(it)) {
                 return this.getImpurityReasonsForFunction(it);
-            } else if (isSdsParameter(it) && !this.isPureParameter(it)) {
+            } else if (
+                isSdsParameter(it) &&
+                // Leads to endless recursion if we don't check this
+                // (see test case "should return the impurity reasons of a parameter call in a function")
+                !isSdsFunction(getContainerOfType(it, isSdsCallable)) &&
+                !this.isPureParameter(it)
+            ) {
                 return [new PotentiallyImpureParameterCall(it)];
             } else {
                 return EMPTY_STREAM;

--- a/packages/safe-ds-lang/tests/language/flow/safe-ds-call-graph-computer.test.ts
+++ b/packages/safe-ds-lang/tests/language/flow/safe-ds-call-graph-computer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { EmptyFileSystem, isNamed, streamAst } from 'langium';
+import { isNamed, streamAst } from 'langium';
 import {
     isSdsBlockLambda,
     isSdsCall,
@@ -9,14 +9,15 @@ import {
     SdsCall,
     SdsCallable,
 } from '../../../src/language/generated/ast.js';
-import { createSafeDsServices } from '../../../src/language/index.js';
+import { createSafeDsServicesWithBuiltins } from '../../../src/language/index.js';
 import { createCallGraphTests } from './creator.js';
 import { getNodeOfType } from '../../helpers/nodeFinder.js';
 import { isRangeEqual } from 'langium/test';
 import { locationToString } from '../../helpers/location.js';
 import { AssertionError } from 'assert';
+import { NodeFileSystem } from 'langium/node';
 
-const services = createSafeDsServices(EmptyFileSystem).SafeDs;
+const services = (await createSafeDsServicesWithBuiltins(NodeFileSystem)).SafeDs;
 const callGraphComputer = services.flow.CallGraphComputer;
 
 describe('SafeDsCallGraphComputer', () => {

--- a/packages/safe-ds-lang/tests/language/purity/safe-ds-purity-computer.test.ts
+++ b/packages/safe-ds-lang/tests/language/purity/safe-ds-purity-computer.test.ts
@@ -778,6 +778,7 @@ describe('SafeDsPurityComputer', async () => {
                 services,
                 `
                 package test
+
                 @Pure fun default() -> result: Any
 
                 @Pure fun myFunction(

--- a/packages/safe-ds-lang/tests/language/purity/safe-ds-purity-computer.test.ts
+++ b/packages/safe-ds-lang/tests/language/purity/safe-ds-purity-computer.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { NodeFileSystem } from 'langium/node';
 import { createSafeDsServicesWithBuiltins } from '../../../src/language/index.js';
-import { isSdsCallable, isSdsExpression, isSdsParameter } from '../../../src/language/generated/ast.js';
+import { isSdsCall, isSdsCallable, isSdsExpression, isSdsParameter } from '../../../src/language/generated/ast.js';
 import { getNodeOfType } from '../../helpers/nodeFinder.js';
 
 const services = (await createSafeDsServicesWithBuiltins(NodeFileSystem)).SafeDs;
@@ -762,6 +762,33 @@ describe('SafeDsPurityComputer', async () => {
                 .getImpurityReasonsForExpression(expression)
                 .map((reason) => reason.toString());
             expect(actual).toStrictEqual(expected);
+        });
+
+        /*
+         * This code caused a stack overflow error in a prior implementation of the purity computer:
+         * 1. "f()" calls the parameter "f".
+         * 2. For called parameters, we check whether they must be pure. Otherwise, we add an impurity reason.
+         * 3. This requires the computation of the impurity reasons of the containing callable "myFunction".
+         * 4. This requires visiting all calls inside "myFunction".
+         * 5. This includes the call of "f()".
+         * 6. We compute the impurity reasons of "f()" and are back at the start.
+         */
+        it('should return the impurity reasons of a parameter call in a function', async () => {
+            const call = await getNodeOfType(
+                services,
+                `
+                package test
+                @Pure fun default() -> result: Any
+
+                @Pure fun myFunction(
+                    f: () -> (result: Any) = default,
+                    g: Any = f()
+                )
+            `,
+                isSdsCall,
+            );
+
+            expect(() => purityComputer.getImpurityReasonsForExpression(call)).not.toThrow();
         });
     });
 });


### PR DESCRIPTION
### Summary of Changes

Calls of function parameters inside the same function lead to a stack overflow when computing purity, like in the following example:

```
package test

@Pure fun default() -> result: Any

@Pure fun myFunction(
    f: () -> (result: Any) = default,
    g: Any = f() // <--
)
```

1. "f()" calls the parameter "f".
2. For called parameters, we check whether they must be pure. Otherwise, we add an impurity reason.
3. This requires the computation of the impurity reasons of the containing callable "myFunction".
4. This requires visiting all calls inside "myFunction".
5. This includes the call of "f()".
6. We compute the impurity reasons of "f()" and are back at the start.