### PR TITLE
fix: Wait for tree-kill during deactivation if child process does not respond

### DIFF
--- a/packages/safe-ds-vscode/src/extension/pythonServer.ts
+++ b/packages/safe-ds-vscode/src/extension/pythonServer.ts
@@ -77,7 +77,7 @@ export const stopPythonServer = async function (): Promise<void> {
             await new Promise<void>((resolve, _reject) => {
                 treeKill(pid, (error) => {
                     resolve();
-                    if (error !== undefined && error !== null) {
+                    if (error) {
                         logError(`Error while killing runner process tree: ${error}`);
                     }
                 });

--- a/packages/safe-ds-vscode/src/extension/pythonServer.ts
+++ b/packages/safe-ds-vscode/src/extension/pythonServer.ts
@@ -60,6 +60,10 @@ export const startPythonServer = async function (): Promise<void> {
     logOutput('Started python server successfully');
 };
 
+/**
+ * Stop the python server process, if any currently exist. This will first try a graceful shutdown.
+ * If that fails, the whole process tree (starting at the child process spawned by startPythonServer) will get killed.
+ */
 export const stopPythonServer = async function (): Promise<void> {
     logOutput('Stopping python server...');
     if (pythonServer !== undefined) {


### PR DESCRIPTION
If the child process does not respond, tree kill does not wait for the process to end.
This may cause VS Code to continue with shutting down, killing the first process of the tree only.
The reference to the tree is then lost, and tree-kill can no longer continue killing the other processes.
To fix this, await the completion of tree-kill.

Added some more logging