### PR TITLE
fix: use correct paths and module names to correctly execute Safe-DS files with spaces

### DIFF
--- a/packages/safe-ds-lang/src/language/generation/safe-ds-python-generator.ts
+++ b/packages/safe-ds-lang/src/language/generation/safe-ds-python-generator.ts
@@ -224,7 +224,11 @@ export class SafeDsPythonGenerator {
     }
 
     private formatGeneratedFileName(baseName: string): string {
-        return `gen_${baseName.replaceAll('%2520', '_').replaceAll(/[ .-]/gu, '_').replaceAll(/\\W/gu, '')}`;
+        return `gen_${this.sanitizeModuleNameForPython(baseName)}`;
+    }
+
+    sanitizeModuleNameForPython(moduleName: string): string {
+        return moduleName.replaceAll('%2520', '_').replaceAll(/[ .-]/gu, '_').replaceAll(/\\W/gu, '');
     }
 
     private generateModule(module: SdsModule): CompositeGeneratorNode {

--- a/packages/safe-ds-vscode/src/extension/pythonServer.ts
+++ b/packages/safe-ds-vscode/src/extension/pythonServer.ts
@@ -282,11 +282,23 @@ export const executePipeline = async function (services: SafeDsServices, pipelin
     }
     mainPipelineName = services.builtins.Annotations.getPythonName(firstPipeline) || firstPipeline.name;
     if (pipelinePath.endsWith('.sdspipe')) {
-        mainModuleName = path.basename(pipelinePath, '.sdspipe').replaceAll('%2520', '_').replaceAll(/[ .-]/gu, '_').replaceAll(/\\W/gu, '');
+        mainModuleName = path
+            .basename(pipelinePath, '.sdspipe')
+            .replaceAll('%2520', '_')
+            .replaceAll(/[ .-]/gu, '_')
+            .replaceAll(/\\W/gu, '');
     } else if (pipelinePath.endsWith('.sdstest')) {
-        mainModuleName = path.basename(pipelinePath, '.sdstest').replaceAll('%2520', '_').replaceAll(/[ .-]/gu, '_').replaceAll(/\\W/gu, '');
+        mainModuleName = path
+            .basename(pipelinePath, '.sdstest')
+            .replaceAll('%2520', '_')
+            .replaceAll(/[ .-]/gu, '_')
+            .replaceAll(/\\W/gu, '');
     } else {
-        mainModuleName = path.basename(pipelinePath).replaceAll('%2520', '_').replaceAll(/[ .-]/gu, '_').replaceAll(/\\W/gu, '');
+        mainModuleName = path
+            .basename(pipelinePath)
+            .replaceAll('%2520', '_')
+            .replaceAll(/[ .-]/gu, '_')
+            .replaceAll(/\\W/gu, '');
     }
     //
     const generatedDocuments = services.generation.PythonGenerator.generate(document, {
@@ -304,7 +316,10 @@ export const executePipeline = async function (services: SafeDsServices, pipelin
                 ? sdsFileName.substring(0, sdsFileName.length - path.extname(sdsFileName).length)
                 : sdsFileName;
 
-        lastGeneratedSource.set(path.join(workspaceRelativeFilePath, sdsFileName).replaceAll("\\", "/"), generatedDocument.getText());
+        lastGeneratedSource.set(
+            path.join(workspaceRelativeFilePath, sdsFileName).replaceAll('\\', '/'),
+            generatedDocument.getText(),
+        );
         if (fsPath.endsWith('.map')) {
             // exclude sourcemaps from sending to runner
             continue;

--- a/packages/safe-ds-vscode/src/extension/pythonServer.ts
+++ b/packages/safe-ds-vscode/src/extension/pythonServer.ts
@@ -282,23 +282,11 @@ export const executePipeline = async function (services: SafeDsServices, pipelin
     }
     mainPipelineName = services.builtins.Annotations.getPythonName(firstPipeline) || firstPipeline.name;
     if (pipelinePath.endsWith('.sdspipe')) {
-        mainModuleName = path
-            .basename(pipelinePath, '.sdspipe')
-            .replaceAll('%2520', '_')
-            .replaceAll(/[ .-]/gu, '_')
-            .replaceAll(/\\W/gu, '');
+        mainModuleName = services.generation.PythonGenerator.sanitizeModuleNameForPython(path.basename(pipelinePath, '.sdspipe'));
     } else if (pipelinePath.endsWith('.sdstest')) {
-        mainModuleName = path
-            .basename(pipelinePath, '.sdstest')
-            .replaceAll('%2520', '_')
-            .replaceAll(/[ .-]/gu, '_')
-            .replaceAll(/\\W/gu, '');
+        mainModuleName = services.generation.PythonGenerator.sanitizeModuleNameForPython(path.basename(pipelinePath, '.sdstest'));
     } else {
-        mainModuleName = path
-            .basename(pipelinePath)
-            .replaceAll('%2520', '_')
-            .replaceAll(/[ .-]/gu, '_')
-            .replaceAll(/\\W/gu, '');
+        mainModuleName = services.generation.PythonGenerator.sanitizeModuleNameForPython(path.basename(pipelinePath));
     }
     //
     const generatedDocuments = services.generation.PythonGenerator.generate(document, {
@@ -320,6 +308,8 @@ export const executePipeline = async function (services: SafeDsServices, pipelin
             path.join(workspaceRelativeFilePath, sdsFileName).replaceAll('\\', '/'),
             generatedDocument.getText(),
         );
+        // Check for sourcemaps after they are already added to the pipeline context
+        // This needs to happen after lastGeneratedSource.set, as errors would not get mapped otherwise
         if (fsPath.endsWith('.map')) {
             // exclude sourcemaps from sending to runner
             continue;

--- a/packages/safe-ds-vscode/src/extension/pythonServer.ts
+++ b/packages/safe-ds-vscode/src/extension/pythonServer.ts
@@ -282,9 +282,13 @@ export const executePipeline = async function (services: SafeDsServices, pipelin
     }
     mainPipelineName = services.builtins.Annotations.getPythonName(firstPipeline) || firstPipeline.name;
     if (pipelinePath.endsWith('.sdspipe')) {
-        mainModuleName = services.generation.PythonGenerator.sanitizeModuleNameForPython(path.basename(pipelinePath, '.sdspipe'));
+        mainModuleName = services.generation.PythonGenerator.sanitizeModuleNameForPython(
+            path.basename(pipelinePath, '.sdspipe'),
+        );
     } else if (pipelinePath.endsWith('.sdstest')) {
-        mainModuleName = services.generation.PythonGenerator.sanitizeModuleNameForPython(path.basename(pipelinePath, '.sdstest'));
+        mainModuleName = services.generation.PythonGenerator.sanitizeModuleNameForPython(
+            path.basename(pipelinePath, '.sdstest'),
+        );
     } else {
         mainModuleName = services.generation.PythonGenerator.sanitizeModuleNameForPython(path.basename(pipelinePath));
     }


### PR DESCRIPTION
Closes #810

### Summary of Changes

- fix: use correct paths and module names to correctly execute Safe-DS files that contain spaces and fix access to source mappings for these files
