### PR TITLE
fix: renaming of declarations that are imported under an alias

### DIFF
--- a/packages/safe-ds-lang/src/language/helpers/nodeProperties.ts
+++ b/packages/safe-ds-lang/src/language/helpers/nodeProperties.ts
@@ -17,6 +17,7 @@ import {
     isSdsModuleMember,
     isSdsParameter,
     isSdsPlaceholder,
+    isSdsQualifiedImport,
     isSdsSegment,
     isSdsTypeParameterList,
     SdsAbstractCall,
@@ -232,8 +233,18 @@ export const getImports = (node: SdsModule | undefined): SdsImport[] => {
     return node?.imports ?? [];
 };
 
-export const getImportedDeclarations = (node: SdsQualifiedImport | undefined): SdsImportedDeclaration[] => {
-    return node?.importedDeclarationList?.importedDeclarations ?? [];
+export const getImportedDeclarations = (node: SdsModule | SdsQualifiedImport | undefined): SdsImportedDeclaration[] => {
+    if (isSdsModule(node)) {
+        return getImports(node).flatMap((imp) => {
+            if (isSdsQualifiedImport(imp)) {
+                return getImportedDeclarations(imp);
+            } else {
+                return [];
+            }
+        });
+    } else {
+        return node?.importedDeclarationList?.importedDeclarations ?? [];
+    }
 };
 
 export const getLiterals = (node: SdsLiteralType | undefined): SdsLiteral[] => {

--- a/packages/safe-ds-lang/src/language/lsp/safe-ds-document-symbol-provider.ts
+++ b/packages/safe-ds-lang/src/language/lsp/safe-ds-document-symbol-provider.ts
@@ -1,6 +1,5 @@
 import { type AstNode, DefaultDocumentSymbolProvider, type LangiumDocument } from 'langium';
 import type { DocumentSymbol } from 'vscode-languageserver';
-import type { SafeDsAnnotations } from '../builtins/safe-ds-annotations.js';
 import {
     isSdsAnnotation,
     isSdsAttribute,
@@ -11,20 +10,15 @@ import {
     isSdsSegment,
 } from '../generated/ast.js';
 import type { SafeDsServices } from '../safe-ds-module.js';
-import type { SafeDsTypeComputer } from '../typing/safe-ds-type-computer.js';
 import type { SafeDsNodeInfoProvider } from './safe-ds-node-info-provider.js';
 
 export class SafeDsDocumentSymbolProvider extends DefaultDocumentSymbolProvider {
-    private readonly builtinAnnotations: SafeDsAnnotations;
     private readonly nodeInfoProvider: SafeDsNodeInfoProvider;
-    private readonly typeComputer: SafeDsTypeComputer;
 
     constructor(services: SafeDsServices) {
         super(services);
 
-        this.builtinAnnotations = services.builtins.Annotations;
         this.nodeInfoProvider = services.lsp.NodeInfoProvider;
-        this.typeComputer = services.types.TypeComputer;
     }
 
     protected override getSymbol(document: LangiumDocument, node: AstNode): DocumentSymbol[] {

--- a/packages/safe-ds-lang/src/language/lsp/safe-ds-rename-provider.ts
+++ b/packages/safe-ds-lang/src/language/lsp/safe-ds-rename-provider.ts
@@ -1,0 +1,135 @@
+import {
+    AstNode,
+    AstNodeLocator,
+    DefaultRenameProvider,
+    findDeclarationNodeAtOffset,
+    getContainerOfType,
+    LangiumDocument,
+    LangiumDocuments,
+    ReferenceDescription,
+    Stream,
+    URI,
+} from 'langium';
+import { Position, RenameParams, TextEdit, WorkspaceEdit } from 'vscode-languageserver';
+import { SafeDsServices } from '../safe-ds-module.js';
+import { isSdsImportedDeclaration, isSdsModule } from '../generated/ast.js';
+import { getImportedDeclarations } from '../helpers/nodeProperties.js';
+
+export class SafeDsRenameProvider extends DefaultRenameProvider {
+    private readonly astNodeLocator: AstNodeLocator;
+    private readonly langiumDocuments: LangiumDocuments;
+
+    constructor(services: SafeDsServices) {
+        super(services);
+
+        this.astNodeLocator = services.workspace.AstNodeLocator;
+        this.langiumDocuments = services.shared.workspace.LangiumDocuments;
+    }
+
+    override async rename(document: LangiumDocument, params: RenameParams): Promise<WorkspaceEdit | undefined> {
+        const references = this.findReferencesToRename(document, params.position);
+        return this.createWorkspaceEdit(references, params.newName);
+    }
+
+    private findReferencesToRename(
+        document: LangiumDocument,
+        position: Position,
+    ): Stream<ReferenceDescription> | undefined {
+        const rootNode = document.parseResult.value.$cstNode;
+        if (!rootNode) {
+            /* c8 ignore next 2 */
+            return undefined;
+        }
+
+        const offset = document.textDocument.offsetAt(position);
+        const leafNode = findDeclarationNodeAtOffset(rootNode, offset, this.grammarConfig.nameRegexp);
+        if (!leafNode) {
+            /* c8 ignore next 2 */
+            return undefined;
+        }
+
+        const targetNode = this.references.findDeclaration(leafNode);
+        if (!targetNode) {
+            /* c8 ignore next 2 */
+            return undefined;
+        }
+
+        const options = { onlyLocal: false, includeDeclaration: true };
+        return this.references.findReferences(targetNode, options).filter((ref) => this.mustBeRenamed(ref));
+    }
+
+    private mustBeRenamed(ref: ReferenceDescription): boolean {
+        // References in the same file must always be renamed
+        if (ref.local) {
+            return true;
+        }
+
+        // References in imported declaration nodes must always be renamed
+        const sourceNode = this.getAstNode(ref.sourceUri, ref.sourcePath);
+        if (isSdsImportedDeclaration(sourceNode)) {
+            return true;
+        }
+
+        // Other references must be renamed unless they are imported under an alias
+        const sourceModule = getContainerOfType(sourceNode, isSdsModule);
+        if (!sourceModule) {
+            /* c8 ignore next 2 */
+            return false;
+        }
+
+        const referenceText = this.getReferenceText(ref);
+        if (!referenceText) {
+            /* c8 ignore next 2 */
+            return false;
+        }
+
+        const targetNode = this.getAstNode(ref.targetUri, ref.targetPath);
+        return !getImportedDeclarations(sourceModule).some((imp) => {
+            return imp.declaration?.ref === targetNode && imp.alias?.alias === referenceText;
+        });
+    }
+
+    private getAstNode(uri: URI, path: string): AstNode | undefined {
+        if (!this.langiumDocuments.hasDocument(uri)) {
+            /* c8 ignore next 2 */
+            return undefined;
+        }
+
+        const document = this.langiumDocuments.getOrCreateDocument(uri);
+        return this.astNodeLocator.getAstNode(document.parseResult.value, path);
+    }
+
+    private getReferenceText(ref: ReferenceDescription): string | undefined {
+        if (!this.langiumDocuments.hasDocument(ref.sourceUri)) {
+            /* c8 ignore next 2 */
+            return undefined;
+        }
+
+        const document = this.langiumDocuments.getOrCreateDocument(ref.sourceUri);
+        return document.textDocument.getText(ref.segment.range);
+    }
+
+    private createWorkspaceEdit(
+        references: Stream<ReferenceDescription> | undefined,
+        newName: string,
+    ): WorkspaceEdit | undefined {
+        if (!references) {
+            /* c8 ignore next 2 */
+            return undefined;
+        }
+
+        const changes: Record<string, TextEdit[]> = {};
+
+        references.forEach((ref) => {
+            const change = TextEdit.replace(ref.segment.range, newName);
+            const uri = ref.sourceUri.toString();
+            if (!changes[uri]) {
+                changes[uri] = [];
+            }
+
+            changes[uri]!.push(change);
+        });
+
+        return { changes };
+    }
+}

--- a/packages/safe-ds-lang/src/language/safe-ds-module.ts
+++ b/packages/safe-ds-lang/src/language/safe-ds-module.ts
@@ -42,6 +42,7 @@ import { SafeDsPackageManager } from './workspace/safe-ds-package-manager.js';
 import { SafeDsWorkspaceManager } from './workspace/safe-ds-workspace-manager.js';
 import { SafeDsPurityComputer } from './purity/safe-ds-purity-computer.js';
 import { SafeDsSettingsProvider } from './workspace/safe-ds-settings-provider.js';
+import { SafeDsRenameProvider } from './lsp/safe-ds-rename-provider.js';
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -124,6 +125,7 @@ export const SafeDsModule: Module<SafeDsServices, PartialLangiumServices & SafeD
         Formatter: () => new SafeDsFormatter(),
         InlayHintProvider: (services) => new SafeDsInlayHintProvider(services),
         NodeInfoProvider: (services) => new SafeDsNodeInfoProvider(services),
+        RenameProvider: (services) => new SafeDsRenameProvider(services),
         SemanticTokenProvider: (services) => new SafeDsSemanticTokenProvider(services),
         SignatureHelp: (services) => new SafeDsSignatureHelpProvider(services),
         TypeHierarchyProvider: (services) => new SafeDsTypeHierarchyProvider(services),

--- a/packages/safe-ds-lang/tests/language/lsp/safe-ds-rename-provider.test.ts
+++ b/packages/safe-ds-lang/tests/language/lsp/safe-ds-rename-provider.test.ts
@@ -1,0 +1,331 @@
+import { NodeFileSystem } from 'langium/node';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createSafeDsServicesWithBuiltins, getModuleMembers } from '../../../src/language/index.js';
+import { clearDocuments } from 'langium/test';
+import { SdsModule } from '../../../src/language/generated/ast.js';
+import { URI } from 'langium';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+
+const services = (await createSafeDsServicesWithBuiltins(NodeFileSystem)).SafeDs;
+const documentBuilder = services.shared.workspace.DocumentBuilder;
+const langiumDocuments = services.shared.workspace.LangiumDocuments;
+const langiumDocumentFactory = services.shared.workspace.LangiumDocumentFactory;
+const nameProvider = services.references.NameProvider;
+const renameProvider = services.lsp.RenameProvider!;
+
+const resourceUri = 'file:///resource.sdsstub';
+const mainUri = 'file:///main.sdspipe';
+
+describe('SafeDsRenameProvider', async () => {
+    const testCases: RenameProviderTest[] = [
+        {
+            testName: 'local reference',
+            descriptions: [
+                {
+                    uri: resourceUri,
+                    originalContent: `
+                        package test
+
+                        class MyClass
+
+                        fun f(p: MyClass)
+                    `,
+                    expectedOutput: `
+                        package test
+
+                        class SomeClass
+
+                        fun f(p: SomeClass)
+                    `,
+                },
+            ],
+        },
+        {
+            testName: 'implicit import',
+            descriptions: [
+                {
+                    uri: resourceUri,
+                    originalContent: `
+                        package test
+
+                        class MyClass
+                    `,
+                    expectedOutput: `
+                        package test
+
+                        class SomeClass
+                    `,
+                },
+                {
+                    uri: mainUri,
+                    originalContent: `
+                        package test
+
+                        fun f(p: MyClass)
+                    `,
+                    expectedOutput: `
+                        package test
+
+                        fun f(p: SomeClass)
+                    `,
+                },
+            ],
+        },
+        {
+            testName: 'explicit import (wildcard)',
+            descriptions: [
+                {
+                    uri: resourceUri,
+                    originalContent: `
+                        package test
+
+                        class MyClass
+                    `,
+                    expectedOutput: `
+                        package test
+
+                        class SomeClass
+                    `,
+                },
+                {
+                    uri: mainUri,
+                    originalContent: `
+                        package test2
+
+                        from test import *
+
+                        fun f(p: MyClass)
+                    `,
+                    expectedOutput: `
+                        package test2
+
+                        from test import *
+
+                        fun f(p: SomeClass)
+                    `,
+                },
+            ],
+        },
+        {
+            testName: 'explicit import (qualified, no alias)',
+            descriptions: [
+                {
+                    uri: resourceUri,
+                    originalContent: `
+                        package test
+
+                        class MyClass
+                    `,
+                    expectedOutput: `
+                        package test
+
+                        class SomeClass
+                    `,
+                },
+                {
+                    uri: mainUri,
+                    originalContent: `
+                        package test2
+
+                        from test import MyClass
+
+                        fun f(p: MyClass)
+                    `,
+                    expectedOutput: `
+                        package test2
+
+                        from test import SomeClass
+
+                        fun f(p: SomeClass)
+                    `,
+                },
+            ],
+        },
+        {
+            testName: 'explicit import (qualified, alias, different name)',
+            descriptions: [
+                {
+                    uri: resourceUri,
+                    originalContent: `
+                        package test
+
+                        class MyClass
+                    `,
+                    expectedOutput: `
+                        package test
+
+                        class SomeClass
+                    `,
+                },
+                {
+                    uri: mainUri,
+                    originalContent: `
+                        package test2
+
+                        from test import MyClass as MyClass2
+
+                        fun f(p: MyClass2)
+                    `,
+                    expectedOutput: `
+                        package test2
+
+                        from test import SomeClass as MyClass2
+
+                        fun f(p: MyClass2)
+                    `,
+                },
+            ],
+        },
+        {
+            testName: 'explicit import (qualified, alias, same name)',
+            descriptions: [
+                {
+                    uri: resourceUri,
+                    originalContent: `
+                        package test
+
+                        class MyClass
+                    `,
+                    expectedOutput: `
+                        package test
+
+                        class SomeClass
+                    `,
+                },
+                {
+                    uri: mainUri,
+                    originalContent: `
+                        package test2
+
+                        from test import MyClass as MyClass
+
+                        fun f(p: MyClass)
+                    `,
+                    expectedOutput: `
+                        package test2
+
+                        from test import SomeClass as MyClass
+
+                        fun f(p: MyClass)
+                    `,
+                },
+            ],
+        },
+        {
+            testName: 'implicit + explicit import',
+            descriptions: [
+                {
+                    uri: resourceUri,
+                    originalContent: `
+                        package test
+
+                        class MyClass
+                    `,
+                    expectedOutput: `
+                        package test
+
+                        class SomeClass
+                    `,
+                },
+                {
+                    uri: mainUri,
+                    originalContent: `
+                        package test
+
+                        from test import MyClass as MyClass2
+
+                        fun f(p: MyClass)
+                    `,
+                    expectedOutput: `
+                        package test
+
+                        from test import SomeClass as MyClass2
+
+                        fun f(p: SomeClass)
+                    `,
+                },
+            ],
+        },
+    ];
+
+    afterEach(() => {
+        clearDocuments(services);
+    });
+
+    it.each(testCases)('$testName', async ({ descriptions }) => {
+        if (descriptions.length === 0) {
+            throw new Error('No documents to rename.');
+        }
+
+        // Add documents to workspace
+        const documents = descriptions.map((description) => {
+            const document = langiumDocumentFactory.fromString(description.originalContent, URI.parse(description.uri));
+            langiumDocuments.addDocument(document);
+            return document;
+        });
+        await documentBuilder.build(documents);
+
+        // Get the element to rename
+        const firstDocument = documents[0]!;
+        const firstModule = firstDocument.parseResult.value as SdsModule;
+        const firstMember = getModuleMembers(firstModule)[0];
+        if (!firstMember) {
+            throw new Error('No member to rename.');
+        }
+
+        // Rename the element
+        const position = nameProvider.getNameNode(firstMember)!.range.start;
+        const changes =
+            (
+                await renameProvider.rename(firstDocument, {
+                    textDocument: { uri: firstDocument.uri.toString() },
+                    position,
+                    newName: 'SomeClass',
+                })
+            )?.changes ?? {};
+
+        // Check the results
+        for (const description of descriptions) {
+            const document = langiumDocuments.getOrCreateDocument(URI.parse(description.uri));
+            const edits = changes[description.uri] ?? [];
+            const actualOutput = TextDocument.applyEdits(document.textDocument, edits);
+
+            expect(actualOutput).toStrictEqual(description.expectedOutput);
+        }
+    });
+});
+
+/**
+ * A description of a test case for the rename provider. We rename the first member of the first document.
+ */
+interface RenameProviderTest {
+    /**
+     * A short description of the test case.
+     */
+    testName: string;
+
+    /**
+     * The documents to rename.
+     */
+    descriptions: DocumentDescription[];
+}
+
+/**
+ * A document with a URI and content.
+ */
+interface DocumentDescription {
+    /**
+     * The URI of the document.
+     */
+    uri: string;
+
+    /**
+     * The original content of the document.
+     */
+    originalContent: string;
+
+    /**
+     * The expected content of the document after renaming.
+     */
+    expectedOutput: string;
+}


### PR DESCRIPTION
Closes #635

### Summary of Changes

Declarations that are imported under an alias are now correctly ignored during renaming. The renaming behavior is always the same, no matter whether it is triggered on a declaration or any reference. An alias can only be changed manually.