### PR TITLE
feat: substitute type parameters when computing type of inherited members

### DIFF
--- a/packages/safe-ds-lang/tests/resources/typing/expressions/member accesses/on class with type parameters/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/member accesses/on class with type parameters/main.sdstest
@@ -6,9 +6,13 @@ class C<T> {
     @Pure fun method() -> r: T
 }
 
-@Pure fun nullableC() -> result: C<Int>?
+class D sub C<Int>
 
-segment mySegment(p: C<Int>) {
+@Pure fun nullableC() -> result: C<Int>?
+@Pure fun nullableD() -> result: D?
+
+// Accessing own members
+segment mySegment1(p: C<Int>) {
     // $TEST$ serialization Int
     »p.nonNullableMember«;
     // $TEST$ serialization Int?
@@ -37,4 +41,36 @@ segment mySegment(p: C<Int>) {
     »nullableC()?.nullableMember«;
     // $TEST$ serialization union<() -> (r: Int), literal<null>>
     »nullableC()?.method«;
+}
+
+// Accessing inherited members
+segment mySegment2(p: D) {
+    // $TEST$ serialization Int
+    »p.nonNullableMember«;
+    // $TEST$ serialization Int?
+    »p.nullableMember«;
+    // $TEST$ serialization () -> (r: Int)
+    »p.method«;
+
+    // $TEST$ serialization Int
+    »p?.nonNullableMember«;
+    // $TEST$ serialization Int?
+    »p?.nullableMember«;
+    // $TEST$ serialization () -> (r: Int)
+    »p?.method«;
+
+
+    // $TEST$ serialization Int
+    »nullableD().nonNullableMember«;
+    // $TEST$ serialization Int?
+    »nullableD().nullableMember«;
+    // $TEST$ serialization () -> (r: Int)
+    »nullableD().method«;
+
+    // $TEST$ serialization Int?
+    »nullableD()?.nonNullableMember«;
+    // $TEST$ serialization Int?
+    »nullableD()?.nullableMember«;
+    // $TEST$ serialization union<() -> (r: Int), literal<null>>
+    »nullableD()?.method«;
 }


### PR DESCRIPTION
Closes #863

### Summary of Changes

We now also substitute type parameters when computing the type for inherited members in a member access. Example:

```
class C<T> {
    attr member: T
}

class D sub C<Int>

segment mySegment(p: D) {
    val a = p.member;
}
```

`a` now get the correct type `Int` (previously it was `T`).