### PR TITLE
feat: substitute type parameters when checking assignability of overriding members

### DIFF
--- a/packages/safe-ds-lang/tests/resources/validation/inheritance/overriding method must match overridden method/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/inheritance/overriding method must match overridden method/main.sdstest
@@ -1,14 +1,14 @@
 package tests.validation.inheritance.overridingMethodMustMatchOverriddenMethod
 
-class MySuperClass {
+class MySuperClass1 {
     attr myInstanceAttribute: Number
     static attr myStaticAttribute: Number
 
-    fun myInstanceMethod(a: Number = 0) -> r: Number
-    static fun myStaticMethod(a: Number = 0) -> r: Number
+    @Pure fun myInstanceMethod(a: Number = 0) -> r: Number
+    @Pure static fun myStaticMethod(a: Number = 0) -> r: Number
 }
 
-class MyClass1 sub MySuperClass {
+class MyClass1 sub MySuperClass1 {
     // $TEST$ no error r"Overriding member does not match the overridden member:.*"
     attr »myInstanceAttribute«: Int
     // $TEST$ no error r"Overriding member does not match the overridden member:.*"
@@ -26,22 +26,22 @@ class MyClass1 sub MySuperClass {
 
 
     // $TEST$ no error r"Overriding member does not match the overridden member:.*"
-    fun »myInstanceMethod«(a: Any = 0) -> r: Int
+    @Pure fun »myInstanceMethod«(a: Any = 0) -> r: Int
     // $TEST$ no error r"Overriding member does not match the overridden member:.*"
-    static fun »myStaticMethod«(a: Any = 0) -> r: Int
+    @Pure static fun »myStaticMethod«(a: Any = 0) -> r: Int
 
     // $TEST$ no error r"Overriding member does not match the overridden member:.*"
-    fun »myInstanceMethod«() -> r: Int
+    @Pure fun »myInstanceMethod«() -> r: Int
     // $TEST$ no error r"Overriding member does not match the overridden member:.*"
-    static fun »myStaticMethod«() -> r: Int
+    @Pure static fun »myStaticMethod«() -> r: Int
 
     // $TEST$ no error r"Overriding member does not match the overridden member:.*"
-    fun »myOwnInstanceMethod«(a: Any = 0) -> r: Int
+    @Pure fun »myOwnInstanceMethod«(a: Any = 0) -> r: Int
     // $TEST$ no error r"Overriding member does not match the overridden member:.*"
-    static fun »myOwnStaticMethod«(a: Any = 0) -> r: Int
+    @Pure static fun »myOwnStaticMethod«(a: Any = 0) -> r: Int
 }
 
-class MyClass2 sub MySuperClass {
+class MyClass2 sub MySuperClass1 {
     // $TEST$ error r"Overriding member does not match the overridden member:.*"
     attr »myInstanceAttribute«: Any
     // $TEST$ no error r"Overriding member does not match the overridden member:.*"
@@ -49,7 +49,7 @@ class MyClass2 sub MySuperClass {
 
 
     // $TEST$ error r"Overriding member does not match the overridden member:.*"
-    fun »myInstanceMethod«(a: Number = 0) -> r: Any
+    @Pure fun »myInstanceMethod«(a: Number = 0) -> r: Any
     // $TEST$ no error r"Overriding member does not match the overridden member:.*"
-    static fun »myStaticMethod«(a: Number = 0) -> r: Any
+    @Pure static fun »myStaticMethod«(a: Number = 0) -> r: Any
 }

--- a/packages/safe-ds-lang/tests/resources/validation/inheritance/overriding method must match overridden method/type parameters.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/inheritance/overriding method must match overridden method/type parameters.sdstest
@@ -1,0 +1,20 @@
+package tests.validation.inheritance.overridingMethodMustMatchOverriddenMethod
+
+class MySuperClass2<T> {
+    attr myInstanceAttribute: T
+    @Pure fun myInstanceMethod(a: T = 0) -> r: T
+}
+
+class MyClass3 sub MySuperClass2<Number> {
+    // $TEST$ no error r"Overriding member does not match the overridden member:.*"
+    attr »myInstanceAttribute«: Int
+    // $TEST$ no error r"Overriding member does not match the overridden member:.*"
+    @Pure fun »myInstanceMethod«(a: Any = 0) -> r: Int
+}
+
+class MyClass4 sub MySuperClass2<Number> {
+    // $TEST$ error r"Overriding member does not match the overridden member:.*"
+    attr »myInstanceAttribute«: Any
+    // $TEST$ error r"Overriding member does not match the overridden member:.*"
+    @Pure fun »myInstanceMethod«(a: Number = 0) -> r: Any
+}

--- a/packages/safe-ds-lang/tests/resources/validation/inheritance/overriding method should differ from overridden method/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/inheritance/overriding method should differ from overridden method/main.sdstest
@@ -1,14 +1,14 @@
 package tests.validation.inheritance.overridingMethodShouldDifferFromOverriddenMethod
 
-class MySuperClass {
+class MySuperClass1 {
     attr myInstanceAttribute: Number
     static attr myStaticAttribute: Number
 
-    fun myInstanceMethod(a: Number = 0) -> r: Number
-    static fun myStaticMethod(a: Number = 0) -> r: Number
+    @Pure fun myInstanceMethod(a: Number = 0) -> r: Number
+    @Pure static fun myStaticMethod(a: Number = 0) -> r: Number
 }
 
-class MyClass1 sub MySuperClass {
+class MyClass1 sub MySuperClass1 {
     // $TEST$ info "Overriding member is identical to overridden member and can be removed."
     attr »myInstanceAttribute«: Number
     // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
@@ -26,22 +26,22 @@ class MyClass1 sub MySuperClass {
 
 
     // $TEST$ info "Overriding member is identical to overridden member and can be removed."
-    fun »myInstanceMethod«(a: Number = 0) -> r: Number
+    @Pure fun »myInstanceMethod«(a: Number = 0) -> r: Number
     // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
-    static fun »myStaticMethod«(a: Number = 0) -> r: Number
+    @Pure static fun »myStaticMethod«(a: Number = 0) -> r: Number
 
     // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
-    fun »myInstanceMethod«() -> r: Number
+    @Pure fun »myInstanceMethod«() -> r: Number
     // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
-    static fun »myStaticMethod«() -> r: Number
+    @Pure static fun »myStaticMethod«() -> r: Number
 
     // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
-    fun »myOwnInstanceMethod«(a: Number = 0) -> r: Number
+    @Pure fun »myOwnInstanceMethod«(a: Number = 0) -> r: Number
     // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
-    static fun »myOwnStaticMethod«(a: Number = 0) -> r: Number
+    @Pure static fun »myOwnStaticMethod«(a: Number = 0) -> r: Number
 }
 
-class MyClass2 sub MySuperClass {
+class MyClass2 sub MySuperClass1 {
     // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
     attr »myInstanceAttribute«: Int
     // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
@@ -49,7 +49,7 @@ class MyClass2 sub MySuperClass {
 
 
     // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
-    fun »myInstanceMethod«(a: Number = 0) -> r: Int
+    @Pure fun »myInstanceMethod«(a: Number = 0) -> r: Int
     // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
-    static fun »myStaticMethod«(a: Number = 0) -> r: Int
+    @Pure static fun »myStaticMethod«(a: Number = 0) -> r: Int
 }

--- a/packages/safe-ds-lang/tests/resources/validation/inheritance/overriding method should differ from overridden method/purity.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/inheritance/overriding method should differ from overridden method/purity.sdstest
@@ -1,13 +1,13 @@
 package tests.validation.inheritance.overridingMethodShouldDifferFromOverriddenMethod
 
-class MySuperClass {
+class MySuperClass2 {
     @Impure([ImpurityReason.Other])
     fun myInstanceMethod(a: Number = 0) -> r: Number
     @Impure([ImpurityReason.Other])
     static fun myStaticMethod(a: Number = 0) -> r: Number
 }
 
-class MyClass1 sub MySuperClass {
+class MyClass3 sub MySuperClass2 {
     // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
     @Pure
     fun »myInstanceMethod«(a: Number = 0) -> r: Number
@@ -16,7 +16,7 @@ class MyClass1 sub MySuperClass {
     static fun »myStaticMethod«(a: Number = 0) -> r: Number
 }
 
-class MyClass2 sub MySuperClass {
+class MyClass4 sub MySuperClass2 {
     // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
     @Impure([])
     fun »myInstanceMethod«(a: Number = 0) -> r: Number

--- a/packages/safe-ds-lang/tests/resources/validation/inheritance/overriding method should differ from overridden method/type parameters.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/inheritance/overriding method should differ from overridden method/type parameters.sdstest
@@ -1,0 +1,20 @@
+package tests.validation.inheritance.overridingMethodShouldDifferFromOverriddenMethod
+
+class MySuperClass3<T> {
+    attr myInstanceAttribute: T
+    @Pure fun myInstanceMethod(a: T = 0) -> r: T
+}
+
+class MyClass5 sub MySuperClass3<Number> {
+    // $TEST$ info "Overriding member is identical to overridden member and can be removed."
+    attr »myInstanceAttribute«: Number
+    // $TEST$ info "Overriding member is identical to overridden member and can be removed."
+    @Pure fun »myInstanceMethod«(a: Number = 0) -> r: Number
+}
+
+class MyClass6 sub MySuperClass3<Number> {
+    // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
+    attr »myInstanceAttribute«: Int
+    // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
+    @Pure fun »myInstanceMethod«(a: Number = 0) -> r: Int
+}


### PR DESCRIPTION
Closes #862

### Summary of Changes

We now substitute type parameter when checking whether a class member gets overridden properly and whether the overriding is actually necessary. Example:

```
class MySuperClass<T> {
    attr member: T
}

class MyClass1 sub MySuperClass<Number> {
    attr member: Int // OK
}

class MyClass2 sub MySuperClass<Number> {
    attr member: String // Not OK
}

class MyClass3 sub MySuperClass<Number> {
    attr member: Number // Unnecessary
}
```