### PR TITLE
feat: simplify computed types

### DIFF
--- a/packages/safe-ds-lang/src/language/partialEvaluation/model.ts
+++ b/packages/safe-ds-lang/src/language/partialEvaluation/model.ts
@@ -85,7 +85,13 @@ export class FloatConstant extends NumberConstant {
     }
 
     override toString(): string {
-        return this.value.toString();
+        const string = this.value.toString();
+
+        if (!string.includes('.')) {
+            return `${string}.0`;
+        } else {
+            return string;
+        }
     }
 }
 

--- a/packages/safe-ds-lang/src/language/typing/model.ts
+++ b/packages/safe-ds-lang/src/language/typing/model.ts
@@ -357,6 +357,10 @@ export class ClassType extends NamedType<SdsClass> {
     }
 
     override updateNullability(isNullable: boolean): ClassType {
+        if (this.isNullable === isNullable) {
+            return this;
+        }
+
         return new ClassType(this.declaration, this.substitutions, isNullable);
     }
 }
@@ -384,6 +388,10 @@ export class EnumType extends NamedType<SdsEnum> {
     }
 
     override updateNullability(isNullable: boolean): EnumType {
+        if (this.isNullable === isNullable) {
+            return this;
+        }
+
         return new EnumType(this.declaration, isNullable);
     }
 }
@@ -411,6 +419,10 @@ export class EnumVariantType extends NamedType<SdsEnumVariant> {
     }
 
     override updateNullability(isNullable: boolean): EnumVariantType {
+        if (this.isNullable === isNullable) {
+            return this;
+        }
+
         return new EnumVariantType(this.declaration, isNullable);
     }
 }
@@ -446,6 +458,10 @@ export class TypeParameterType extends NamedType<SdsTypeParameter> {
     }
 
     override updateNullability(isNullable: boolean): TypeParameterType {
+        if (this.isNullable === isNullable) {
+            return this;
+        }
+
         return new TypeParameterType(this.declaration, isNullable);
     }
 }
@@ -534,6 +550,7 @@ export class UnionType extends Type {
             return this.possibleTypes[0]!.unwrap();
         }
 
+        // TODO: flatten nested unions
         return new UnionType(...this.possibleTypes.map((it) => it.unwrap()));
     }
 

--- a/packages/safe-ds-lang/src/language/typing/model.ts
+++ b/packages/safe-ds-lang/src/language/typing/model.ts
@@ -546,12 +546,22 @@ export class UnionType extends Type {
     }
 
     override unwrap(): Type {
-        if (this.possibleTypes.length === 1) {
-            return this.possibleTypes[0]!.unwrap();
+        // Flatten nested unions
+        const newPossibleTypes = this.possibleTypes.flatMap((type) => {
+            const unwrappedType = type.unwrap();
+            if (unwrappedType instanceof UnionType) {
+                return unwrappedType.possibleTypes;
+            } else {
+                return unwrappedType;
+            }
+        });
+
+        // Remove the outer union if there's only one type left
+        if (newPossibleTypes.length === 1) {
+            return newPossibleTypes[0]!;
         }
 
-        // TODO: flatten nested unions
-        return new UnionType(...this.possibleTypes.map((it) => it.unwrap()));
+        return new UnionType(...newPossibleTypes);
     }
 
     override updateNullability(isNullable: boolean): Type {

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
@@ -9,7 +9,7 @@ import {
     Parameter,
     TypeParameter,
 } from '../helpers/nodeProperties.js';
-import { Constant } from '../partialEvaluation/model.js';
+import { Constant, NullConstant } from '../partialEvaluation/model.js';
 import { SafeDsServices } from '../safe-ds-module.js';
 import {
     CallableType,
@@ -223,12 +223,15 @@ export class SafeDsTypeChecker {
         if (type.isNullable && !other.isNullable) {
             return false;
         } else if (type.constants.length === 0) {
-            // Empty literal types are equivalent to `Nothing` and, thus, assignable to any type
+            // Empty literal types are equivalent to `Nothing` and assignable to any type
             return true;
+        } else if (type.constants.every((it) => it === NullConstant)) {
+            // Literal types containing only `null` are equivalent to `Nothing?` and assignable to any nullable type
+            return other.isNullable;
         }
 
         if (other instanceof ClassType) {
-            if (other.equals(this.coreTypes.AnyOrNull)) {
+            if (other.equals(this.coreTypes.Any.updateNullability(type.isNullable))) {
                 return true;
             }
 

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
@@ -222,6 +222,9 @@ export class SafeDsTypeChecker {
     private literalTypeIsAssignableTo(type: LiteralType, other: Type): boolean {
         if (type.isNullable && !other.isNullable) {
             return false;
+        } else if (type.constants.length === 0) {
+            // Empty literal types are equivalent to `Nothing` and, thus, assignable to any type
+            return true;
         }
 
         if (other instanceof ClassType) {

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -620,17 +620,27 @@ export class SafeDsTypeComputer {
 
         if (unwrappedType instanceof LiteralType) {
             return this.simplifyLiteralType(unwrappedType);
+        } else if (unwrappedType instanceof UnionType) {
+            return this.simplifyUnionType(unwrappedType);
+        } else {
+            return unwrappedType;
         }
-
-        return unwrappedType;
     }
 
     private simplifyLiteralType(type: LiteralType): Type {
         if (isEmpty(type.constants)) {
             return this.coreTypes.Nothing;
+        } else {
+            return type;
         }
+    }
 
-        return type;
+    private simplifyUnionType(type: UnionType): Type {
+        if (isEmpty(type.possibleTypes)) {
+            return this.coreTypes.Nothing;
+        } else {
+            return type;
+        }
     }
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -616,7 +616,21 @@ export class SafeDsTypeComputer {
     // -----------------------------------------------------------------------------------------------------------------
 
     private simplifyType(type: Type): Type {
-        return type.unwrap();
+        const unwrappedType = type.unwrap();
+
+        if (unwrappedType instanceof LiteralType) {
+            return this.simplifyLiteralType(unwrappedType);
+        }
+
+        return unwrappedType;
+    }
+
+    private simplifyLiteralType(type: LiteralType): Type {
+        if (isEmpty(type.constants)) {
+            return this.coreTypes.Nothing;
+        }
+
+        return type;
     }
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -150,7 +150,9 @@ export class SafeDsTypeComputer {
             return UnknownType;
         }
 
-        const unsubstitutedType = this.nodeTypeCache.get(this.getNodeId(node), () => this.doComputeType(node).unwrap());
+        const unsubstitutedType = this.nodeTypeCache.get(this.getNodeId(node), () =>
+            this.simplifyType(this.doComputeType(node)),
+        );
         return unsubstitutedType.substituteTypeParameters(substitutions);
     }
 
@@ -607,6 +609,14 @@ export class SafeDsTypeComputer {
         }
 
         return result;
+    }
+
+    // -----------------------------------------------------------------------------------------------------------------
+    // Simplify type
+    // -----------------------------------------------------------------------------------------------------------------
+
+    private simplifyType(type: Type): Type {
+        return type.unwrap();
     }
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -628,8 +628,29 @@ export class SafeDsTypeComputer {
     }
 
     private simplifyLiteralType(type: LiteralType): Type {
+        // Handle empty literal types
         if (isEmpty(type.constants)) {
             return this.coreTypes.Nothing;
+        }
+
+        // Remove duplicate constants
+        const uniqueConstants: Constant[] = [];
+        const knownConstants = new Set<String>();
+
+        for (const constant of type.constants) {
+            let key = constant.toString();
+
+            if (!knownConstants.has(key)) {
+                uniqueConstants.push(constant);
+                knownConstants.add(key);
+            }
+        }
+
+        // Apply other simplifications
+        if (uniqueConstants.length === 1 && uniqueConstants[0] === NullConstant) {
+            return this.coreTypes.NothingOrNull;
+        } else if (uniqueConstants.length < type.constants.length) {
+            return new LiteralType(...uniqueConstants);
         } else {
             return type;
         }

--- a/packages/safe-ds-lang/tests/language/typing/model.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/model.test.ts
@@ -405,6 +405,18 @@ describe('type model', async () => {
             expectedType: new ClassType(class1, new Map(), false),
         },
         {
+            type: new UnionType(
+                new UnionType(new ClassType(class1, new Map(), false), new ClassType(class2, new Map(), false)),
+                new UnionType(new EnumType(enum1, false), new EnumVariantType(enumVariant1, false)),
+            ),
+            expectedType: new UnionType(
+                new ClassType(class1, new Map(), false),
+                new ClassType(class2, new Map(), false),
+                new EnumType(enum1, false),
+                new EnumVariantType(enumVariant1, false),
+            ),
+        },
+        {
             type: UnknownType,
             expectedType: UnknownType,
         },

--- a/packages/safe-ds-lang/tests/language/typing/type checker/isAssignableTo.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/type checker/isAssignableTo.test.ts
@@ -506,6 +506,21 @@ describe('SafeDsTypeChecker', async () => {
                 expected: true,
             },
             {
+                type1: new LiteralType(NullConstant),
+                type2: enumType1,
+                expected: false,
+            },
+            {
+                type1: new LiteralType(NullConstant),
+                type2: enumType1.updateNullability(true),
+                expected: true,
+            },
+            {
+                type1: new LiteralType(NullConstant, NullConstant),
+                type2: enumType1.updateNullability(true),
+                expected: true,
+            },
+            {
                 type1: new LiteralType(new IntConstant(1n)),
                 type2: enumType1,
                 expected: false,

--- a/packages/safe-ds-lang/tests/language/typing/type checker/isAssignableTo.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/type checker/isAssignableTo.test.ts
@@ -501,6 +501,11 @@ describe('SafeDsTypeChecker', async () => {
             },
             // Literal type to other
             {
+                type1: new LiteralType(), // Empty literal type
+                type2: enumType1,
+                expected: true,
+            },
+            {
                 type1: new LiteralType(new IntConstant(1n)),
                 type2: enumType1,
                 expected: false,

--- a/packages/safe-ds-lang/tests/language/typing/type computer/lowestCommonSupertype.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/type computer/lowestCommonSupertype.test.ts
@@ -8,8 +8,7 @@ import {
     isSdsFunction,
     isSdsModule,
 } from '../../../../src/language/generated/ast.js';
-import { getModuleMembers } from '../../../../src/language/helpers/nodeProperties.js';
-import { createSafeDsServicesWithBuiltins } from '../../../../src/language/index.js';
+import { createSafeDsServicesWithBuiltins, getModuleMembers } from '../../../../src/language/index.js';
 import { BooleanConstant, IntConstant, NullConstant } from '../../../../src/language/partialEvaluation/model.js';
 import {
     ClassType,

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/literals/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/literals/main.sdstest
@@ -11,7 +11,7 @@ pipeline myPipeline {
     // $TEST$ serialization literal<1>
     val intLiteral = »1«;
 
-    // $TEST$ serialization literal<null>
+    // $TEST$ serialization Nothing?
     val nullLiteral = »null«;
 
     // $TEST$ serialization literal<"myString">

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/member accesses/on class with type parameters/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/member accesses/on class with type parameters/main.sdstest
@@ -39,7 +39,7 @@ segment mySegment1(p: C<Int>) {
     »nullableC()?.nonNullableMember«;
     // $TEST$ serialization Int?
     »nullableC()?.nullableMember«;
-    // $TEST$ serialization union<() -> (r: Int), literal<null>>
+    // $TEST$ serialization union<() -> (r: Int), Nothing?>
     »nullableC()?.method«;
 }
 
@@ -71,6 +71,6 @@ segment mySegment2(p: D) {
     »nullableD()?.nonNullableMember«;
     // $TEST$ serialization Int?
     »nullableD()?.nullableMember«;
-    // $TEST$ serialization union<() -> (r: Int), literal<null>>
+    // $TEST$ serialization union<() -> (r: Int), Nothing?>
     »nullableD()?.method«;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/member accesses/to other/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/member accesses/to other/main.sdstest
@@ -40,6 +40,6 @@ pipeline myPipeline {
     »nullableC()?.nonNullableMember«;
     // $TEST$ equivalence_class nullableMember
     »nullableC()?.nullableMember«;
-    // $TEST$ serialization union<() -> (r: Int), literal<null>>
+    // $TEST$ serialization union<() -> (r: Int), Nothing?>
     »nullableC()?.method«;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/simplification/remove duplicate constants from literal types/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/simplification/remove duplicate constants from literal types/main.sdstest
@@ -1,0 +1,12 @@
+package tests.typing.simplification.removeDuplicateConstantsFromLiteralTypes
+
+class C(
+    // $TEST$ serialization literal<1>
+    p1: »literal<1, 1>«,
+
+    // $TEST$ serialization literal<1, 2>
+    p2: »literal<1, 2>«,
+
+    // $TEST$ serialization literal<1, 1.0>
+    p3: »literal<1, 1.0>«,
+)

--- a/packages/safe-ds-lang/tests/resources/typing/simplification/remove unneeded entries from union types/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/simplification/remove unneeded entries from union types/main.sdstest
@@ -1,0 +1,53 @@
+package tests.typing.simplification.removeUnneededEntriesFromUnionTypes
+
+class C(
+    // $TEST$ serialization Int
+    p1: »union<Int, Int>«,
+
+    // $TEST$ serialization union<Int, String>
+    p2: »union<Int, String, Int>«,
+
+
+    // $TEST$ serialization Number
+    p3: »union<Int, Number>«,
+
+    // $TEST$ serialization Number
+    p4: »union<Number, Int>«,
+
+    // $TEST$ serialization Number?
+    p5: »union<Number, Int?>«,
+
+    // $TEST$ serialization Any
+    p6: »union<Int, Number, Any>«,
+
+    // $TEST$ serialization Any
+    p7: »union<Any, Number, Int>«,
+
+    // $TEST$ serialization Any?
+    p8: »union<Int, Number?, Any>«,
+
+
+    // $TEST$ serialization union<Int, String>
+    p9: »union<Int, String>«,
+
+    // $TEST$ serialization union<Int, String?>
+    p10: »union<Int, String?>«,
+
+    // $TEST$ serialization union<Number, String>
+    p11: »union<Int, Number, String>«,
+
+    // $TEST$ serialization union<Number, String>
+    p12: »union<Number, Int, String>«,
+
+    // $TEST$ serialization Any
+    p13: »union<Int, String, Any>«,
+
+    // $TEST$ serialization Any?
+    p14: »union<Int, String?, Any>«,
+
+    // $TEST$ serialization Any
+    p15: »union<Any, String, Int>«,
+
+    // $TEST$ serialization Any?
+    p16: »union<Any, String?, Int>«,
+)

--- a/packages/safe-ds-lang/tests/resources/typing/simplification/replace empty literal types with Nothing/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/simplification/replace empty literal types with Nothing/main.sdstest
@@ -1,0 +1,6 @@
+package tests.typing.simplification.replaceEmptyLiteralTypesWithNothing
+
+class C(
+    // $TEST$ serialization Nothing
+    p1: »literal<>«
+)

--- a/packages/safe-ds-lang/tests/resources/typing/simplification/replace empty union types with Nothing/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/simplification/replace empty union types with Nothing/main.sdstest
@@ -1,0 +1,6 @@
+package tests.typing.simplification.replaceEmptyUnionTypesWithNothing
+
+class C(
+    // $TEST$ serialization Nothing
+    p1: »union<>«
+)

--- a/packages/safe-ds-lang/tests/resources/typing/simplification/replace literals types that allow only null with NothingNullable/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/simplification/replace literals types that allow only null with NothingNullable/main.sdstest
@@ -1,0 +1,9 @@
+package tests.typing.simplification.replaceLiteralTypesThatAllowOnlyNullWithNothingNullable
+
+class C(
+    // $TEST$ serialization Nothing?
+    p1: »literal<null>«,
+
+    // $TEST$ serialization Nothing?
+    p2: »literal<null, null>«
+)

--- a/packages/safe-ds-lang/tests/resources/typing/simplification/unwrap/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/simplification/unwrap/main.sdstest
@@ -2,5 +2,8 @@ package tests.typing.simplification.unwrap
 
 class C(
     // $TEST$ serialization union<String, Int, Boolean>
-    p1: »union<union<String, Int>, Boolean>«
+    p1: »union<union<String, Int>, Boolean>«,
+
+    // $TEST$ serialization String
+    p2: »union<union<String>>«
 )

--- a/packages/safe-ds-lang/tests/resources/typing/simplification/unwrap/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/simplification/unwrap/main.sdstest
@@ -1,0 +1,6 @@
+package tests.typing.simplification.unwrap
+
+class C(
+    // $TEST$ serialization union<String, Int, Boolean>
+    p1: »union<union<String, Int>, Boolean>«
+)

--- a/packages/safe-ds-lang/tests/resources/typing/types/literal types/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/types/literal types/main.sdstest
@@ -1,6 +1,6 @@
 package tests.typing.types.literalTypes
 
-// $TEST$ serialization literal<>
+// $TEST$ serialization Nothing
 fun myFunction1(f: »literal<>«)
 
 // $TEST$ serialization literal<1, 2>

--- a/packages/safe-ds-lang/tests/resources/typing/types/union types/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/types/union types/main.sdstest
@@ -1,6 +1,6 @@
 package tests.typing.types.unionTypes
 
-// $TEST$ serialization union<>
+// $TEST$ serialization Nothing
 fun myFunction(a: »union<>«)
 
 // $TEST$ serialization union<Int, String>


### PR DESCRIPTION
### Summary of Changes

Apply various simplification rules to computed type to improve their readability:

* Replace `literal<>` with `Nothing`
* Replace `literal<null>` with `Nothing?`
* Remove duplicate entries from literal types
* Replace `union<>` with `Nothing`
* Remove entries from union types that are a subtype of another entry
* Flatten nested union types