### PR TITLE
feat: handle invariant/covariant type parameters when computing lowest common supertype

### DIFF
--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -1077,14 +1077,14 @@ export class SafeDsTypeComputer {
                     typeParameter,
                     this.lowestCommonSupertype([candidateSubstitution, ...otherSubstitutions]),
                 );
-            } else if (TypeParameter.isContravariant(typeParameter)) {
+            } /* c8 ignore start */ else if (TypeParameter.isContravariant(typeParameter)) {
                 // Compute the highest common subtype for substitutions
                 const otherSubstitutions = others.map((it) => it.substitutions.get(typeParameter) ?? UnknownType);
                 substitutions.set(
                     typeParameter,
                     this.highestCommonSubtype([candidateSubstitution, ...otherSubstitutions]),
                 );
-            } else {
+            } /* c8 ignore stop */ else {
                 substitutions.set(typeParameter, candidateSubstitution);
             }
         }
@@ -1141,10 +1141,12 @@ export class SafeDsTypeComputer {
     // Highest common subtype
     // -----------------------------------------------------------------------------------------------------------------
 
+    /* c8 ignore start */
     private highestCommonSubtype(_types: Type[]): Type {
         // TODO(lr): Implement
         return this.coreTypes.Nothing;
     }
+    /* c8 ignore stop */
 
     // -----------------------------------------------------------------------------------------------------------------
     // Supertypes

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -1015,9 +1015,6 @@ export class SafeDsTypeComputer {
         const candidates = [firstClassType, ...this.streamProperSupertypes(firstClassType)];
         let other = [...classTypes.slice(1)];
 
-        this.logTypes(candidates);
-        this.logTypes(other);
-
         for (const candidate of candidates) {
             if (this.isCommonSupertypeIgnoringTypeParameters(candidate, other)) {
                 // If the class has no type parameters, we are done
@@ -1028,7 +1025,6 @@ export class SafeDsTypeComputer {
 
                 // Check whether all substitutions of invariant type parameters are equal
                 other = other.map((it) => this.computeMatchingSupertype(it, candidate.declaration)!);
-                this.logTypes(other);
 
                 if (!this.substitutionsForInvariantTypeParametersAreEqual(typeParameters, candidate, other)) {
                     continue;
@@ -1241,10 +1237,6 @@ export class SafeDsTypeComputer {
 
     private Nothing(isNullable: boolean): Type {
         return isNullable ? this.coreTypes.NothingOrNull : this.coreTypes.Nothing;
-    }
-
-    private logTypes(types: Type[]): void {
-        console.log(types.map((it) => it?.toString()));
     }
 }
 

--- a/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/class type and class type/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/class type and class type/main.sdstest
@@ -4,7 +4,7 @@ class C
 class D sub C
 class E
 
-segment mySegment(
+segment mySegment1(
     c: C,
     cOrNull: C?,
     d: D,

--- a/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/class type and class type/with type parameters.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/class type and class type/with type parameters.sdstest
@@ -6,6 +6,8 @@ class FloatCovariant sub Covariant<Float>
 class Invariant<T>
 class FloatInvariant sub Invariant<Float>
 
+class Multiple<T1, out T2>
+
 segment covariant(
     coNumber: Covariant<Number>,
     coInt: Covariant<Int>,
@@ -70,4 +72,17 @@ segment invariant(
 
     // $TEST$ serialization List<FloatInvariant>
     »[invFloat, invFloat]«;
+}
+
+segment multiple(
+    multipleNumberInt: Multiple<Number, Int>,
+    multipleNumberFloat: Multiple<Number, Float>,
+) {
+    // $TEST$ serialization List<Multiple<Number, Int>>
+    »[multipleNumberInt, multipleNumberInt]«;
+    // $TEST$ serialization List<Multiple<Number, Number>>
+    »[multipleNumberInt, multipleNumberFloat]«;
+
+    // $TEST$ serialization List<Multiple<Number, Float>>
+    »[multipleNumberFloat, multipleNumberFloat]«;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/class type and class type/with type parameters.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/class type and class type/with type parameters.sdstest
@@ -1,0 +1,73 @@
+package tests.typing.lowestCommonSupertype.classTypeAndClassType
+
+class Covariant<out T>
+class FloatCovariant sub Covariant<Float>
+
+class Invariant<T>
+class FloatInvariant sub Invariant<Float>
+
+segment covariant(
+    coNumber: Covariant<Number>,
+    coInt: Covariant<Int>,
+    coString: Covariant<String>,
+    coFloat: FloatCovariant,
+) {
+    // $TEST$ serialization List<Covariant<Number>>
+    »[coNumber, coNumber]«;
+    // $TEST$ serialization List<Covariant<Number>>
+    »[coNumber, coInt]«;
+    // $TEST$ serialization List<Covariant<Any>>
+    »[coNumber, coString]«;
+    // $TEST$ serialization List<Covariant<Number>>
+    »[coNumber, coFloat]«;
+
+    // $TEST$ serialization List<Covariant<Int>>
+    »[coInt, coInt]«;
+    // $TEST$ serialization List<Covariant<Any>>
+    »[coInt, coString]«;
+    // $TEST$ serialization List<Covariant<Number>>
+    »[coInt, coFloat]«;
+
+    // $TEST$ serialization List<Covariant<String>>
+    »[coString, coString]«;
+    // $TEST$ serialization List<Covariant<Any>>
+    »[coString, coFloat]«;
+
+    // $TEST$ serialization List<FloatCovariant>
+    »[coFloat, coFloat]«;
+}
+
+segment contravariant() {
+    // Tests are in the "highest common subtype" folder
+}
+
+segment invariant(
+    invNumber: Invariant<Number>,
+    invInt: Invariant<Int>,
+    invString: Invariant<String>,
+    invFloat: FloatInvariant
+) {
+    // $TEST$ serialization List<Invariant<Number>>
+    »[invNumber, invNumber]«;
+    // $TEST$ serialization List<Any>
+    »[invNumber, invInt]«;
+    // $TEST$ serialization List<Any>
+    »[invNumber, invString]«;
+    // $TEST$ serialization List<Any>
+    »[invNumber, invFloat]«;
+
+    // $TEST$ serialization List<Invariant<Int>>
+    »[invInt, invInt]«;
+    // $TEST$ serialization List<Any>
+    »[invInt, invString]«;
+    // $TEST$ serialization List<Any>
+    »[invInt, invFloat]«;
+
+    // $TEST$ serialization List<Invariant<String>>
+    »[invString, invString]«;
+    // $TEST$ serialization List<Any>
+    »[invString, invFloat]«;
+
+    // $TEST$ serialization List<FloatInvariant>
+    »[invFloat, invFloat]«;
+}

--- a/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/class type and type parameter type/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/class type and type parameter type/main.sdstest
@@ -1,0 +1,29 @@
+package tests.typing.lowestCommonSupertype.classTypeAndTypeParameterType
+
+class C
+class D
+
+class Test<Unbounded, BoundedByC, BoundedByD, BoundedByDOrNull>(
+    c: C,
+
+    unbounded: Unbounded,
+    unboundedOrNull: Unbounded?,
+    boundedByC: BoundedByC,
+    boundedByD: BoundedByD,
+    boundedByDOrNull: BoundedByDOrNull,
+
+    // $TEST$ serialization List<Unbounded>
+    p1: Any = »[c, unbounded]«,
+    // $TEST$ serialization List<Unbounded?>
+    p2: Any = »[c, unboundedOrNull]«,
+    // $TEST$ serialization List<BoundedByC>
+    p3: Any = »[c, boundedByC]«,
+    // $TEST$ serialization List<Any>
+    p4: Any = »[c, boundedByD]«,
+    // $TEST$ serialization List<Any?>
+    p5: Any = »[c, boundedByDOrNull]«,
+) where {
+    BoundedByC sub C,
+    BoundedByD sub D,
+    BoundedByDOrNull sub D?,
+}

--- a/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/enum type and type parameter type/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/enum type and type parameter type/main.sdstest
@@ -1,0 +1,36 @@
+package tests.typing.lowestCommonSupertype.enumTypeAndTypeParameterType
+
+enum E {
+    V
+}
+
+enum F
+
+class Test<Unbounded, BoundedByEnum, BoundedByEnumVariant, BoundedByOtherEnum, BoundedByOtherEnumOrNull>(
+    e: E,
+
+    unbounded: Unbounded,
+    unboundedOrNull: Unbounded?,
+    boundedByEnum: BoundedByEnum,
+    boundedByEnumVariant: BoundedByEnumVariant,
+    boundedByOtherEnum: BoundedByOtherEnum,
+    boundedByOtherEnumOrNull: BoundedByOtherEnumOrNull,
+
+    // $TEST$ serialization List<Unbounded>
+    p1: Any = »[e, unbounded]«,
+    // $TEST$ serialization List<Unbounded?>
+    p2: Any = »[e, unboundedOrNull]«,
+    // $TEST$ serialization List<BoundedByEnum>
+    p3: Any = »[e, boundedByEnum]«,
+    // $TEST$ serialization List<E>
+    p4: Any = »[e, boundedByEnumVariant]«,
+    // $TEST$ serialization List<Any>
+    p5: Any = »[e, boundedByOtherEnum]«,
+    // $TEST$ serialization List<Any?>
+    p6: Any = »[e, boundedByOtherEnumOrNull]«,
+) where {
+    BoundedByEnum sub E,
+    BoundedByEnumVariant sub E.V,
+    BoundedByOtherEnum sub F,
+    BoundedByOtherEnumOrNull sub F?,
+}

--- a/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/enum variant type and type parameter type/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/enum variant type and type parameter type/main.sdstest
@@ -1,0 +1,31 @@
+package tests.typing.lowestCommonSupertype.enumVariantTypeAndTypeParameterType
+
+enum E {
+    V1
+    V2
+}
+
+class D<Unbounded, BoundedByEnumVariant, BoundedByOtherEnumVariant, BoundedByOtherEnumVariantOrNull>(
+    v: E.V1,
+
+    unbounded: Unbounded,
+    unboundedOrNull: Unbounded?,
+    boundedByEnumVariant: BoundedByEnumVariant,
+    boundedByOtherEnumVariant: BoundedByOtherEnumVariant,
+    boundedByOtherEnumVariantOrNull: BoundedByOtherEnumVariantOrNull,
+
+    // $TEST$ serialization List<Unbounded>
+    p1: Any = »[v, unbounded]«,
+    // $TEST$ serialization List<Unbounded?>
+    p2: Any = »[v, unboundedOrNull]«,
+    // $TEST$ serialization List<BoundedByEnumVariant>
+    p3: Any = »[v, boundedByEnumVariant]«,
+    // $TEST$ serialization List<E>
+    p4: Any = »[v, boundedByOtherEnumVariant]«,
+    // $TEST$ serialization List<E?>
+    p5: Any = »[v, boundedByOtherEnumVariantOrNull]«,
+) where {
+    BoundedByEnumVariant sub E.V1,
+    BoundedByOtherEnumVariant sub E.V2,
+    BoundedByOtherEnumVariantOrNull sub E.V2?
+}

--- a/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/literal type and type parameter type/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/literal type and type parameter type/main.sdstest
@@ -1,0 +1,24 @@
+package tests.typing.lowestCommonSupertype.literalTypeAndTypeParameterType
+
+class Test<Unbounded, BoundedByInt, BoundedByString, BoundedByStringOrNull>(
+    unbounded: Unbounded,
+    unboundedOrNull: Unbounded?,
+    boundedByInt: BoundedByInt,
+    boundedByString: BoundedByString,
+    boundedByStringOrNull: BoundedByStringOrNull,
+
+    // $TEST$ serialization List<Unbounded>
+    p1: Any = »[1, unbounded]«,
+    // $TEST$ serialization List<Unbounded?>
+    p2: Any = »[1, unboundedOrNull]«,
+    // $TEST$ serialization List<BoundedByInt>
+    p3: Any = »[1, boundedByInt]«,
+    // $TEST$ serialization List<Any>
+    p4: Any = »[1, boundedByString]«,
+    // $TEST$ serialization List<Any?>
+    p5: Any = »[1, boundedByStringOrNull]«,
+) where {
+    BoundedByInt sub Int,
+    BoundedByString sub String,
+    BoundedByStringOrNull sub String?,
+}

--- a/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/type parameter type and type parameter type/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/type parameter type and type parameter type/main.sdstest
@@ -1,0 +1,54 @@
+package tests.typing.lowestCommonSupertype.typeParameterTypeAndTypeParameterType
+
+class C
+class D sub C
+class E sub C
+
+class Test<NothingToAnyOrNull, NothingToD, NothingToE, DToAnyOrNull, DToC>(
+    nothingToAnyOrNull: NothingToAnyOrNull,
+    nothingToD: NothingToD,
+    nothingToE: NothingToE,
+    dToAnyOrNull: DToAnyOrNull,
+    dToC: DToC,
+
+    // $TEST$ serialization List<NothingToAnyOrNull>
+    a1: Any = »[nothingToAnyOrNull, nothingToAnyOrNull]«,
+    // $TEST$ serialization List<NothingToAnyOrNull>
+    a2: Any = »[nothingToAnyOrNull, nothingToD]«,
+    // $TEST$ serialization List<NothingToAnyOrNull>
+    a3: Any = »[nothingToAnyOrNull, nothingToE]«,
+    // $TEST$ serialization List<NothingToAnyOrNull>
+    a4: Any = »[nothingToAnyOrNull, dToAnyOrNull]«,
+    // $TEST$ serialization List<NothingToAnyOrNull>
+    a5: Any = »[nothingToAnyOrNull, dToC]«,
+
+    // $TEST$ serialization List<NothingToD>
+    b1: Any = »[nothingToD, nothingToD]«,
+    // $TEST$ serialization List<C>
+    b2: Any = »[nothingToD, nothingToE]«,
+    // $TEST$ serialization List<Any?>
+    b3: Any = »[nothingToD, dToAnyOrNull]«,
+    // $TEST$ serialization List<C>
+    b4: Any = »[nothingToD, dToC]«,
+
+    // $TEST$ serialization List<NothingToE>
+    c1: Any = »[nothingToE, nothingToE]«,
+    // $TEST$ serialization List<Any?>
+    c2: Any = »[nothingToE, dToAnyOrNull]«,
+    // $TEST$ serialization List<C>
+    c3: Any = »[nothingToE, dToC]«,
+
+    // $TEST$ serialization List<DToAnyOrNull>
+    d1: Any = »[dToAnyOrNull, dToAnyOrNull]«,
+    // $TEST$ serialization List<DToAnyOrNull>
+    d2: Any = »[dToAnyOrNull, dToC]«,
+
+    // $TEST$ serialization List<DToC>
+    e1: Any = »[dToC, dToC]«,
+) where {
+    NothingToD sub D,
+    NothingToE sub E,
+    DToAnyOrNull super D,
+    DToC super D,
+    DToC sub C,
+}


### PR DESCRIPTION
Closes partially #860

### Summary of Changes

Invariant/covariant type parameters are now handled when computing the lowest common supertype of a list of types. This functionality is used to compute the type of
* lists (based on their elements)
* maps (based on their keys and values)
* elvis operator (based on their operands).

It's also needed later for #861. Contravariant type parameters need a means to compute the highest common subtype, which will be tackled in a future PR.
