### PR TITLE
feat: improve type simplification

### DIFF
--- a/packages/safe-ds-lang/src/language/typing/model.ts
+++ b/packages/safe-ds-lang/src/language/typing/model.ts
@@ -125,13 +125,20 @@ export class CallableType extends Type {
 
 export class LiteralType extends Type {
     readonly constants: Constant[];
-    override readonly isNullable: boolean;
+    private _isNullable: boolean | undefined;
 
     constructor(...constants: Constant[]) {
         super();
 
         this.constants = constants;
-        this.isNullable = constants.some((it) => it === NullConstant);
+    }
+
+    override get isNullable(): boolean {
+        if (this._isNullable === undefined) {
+            this._isNullable = this.constants.some((it) => it === NullConstant);
+        }
+
+        return this._isNullable;
     }
 
     override equals(other: unknown): boolean {
@@ -516,13 +523,20 @@ export class StaticType extends Type {
 
 export class UnionType extends Type {
     readonly possibleTypes: Type[];
-    override readonly isNullable: boolean;
+    private _isNullable: boolean | undefined;
 
     constructor(...possibleTypes: Type[]) {
         super();
 
         this.possibleTypes = possibleTypes;
-        this.isNullable = possibleTypes.some((it) => it.isNullable);
+    }
+
+    override get isNullable(): boolean {
+        if (this._isNullable === undefined) {
+            this._isNullable = this.possibleTypes.some((it) => it.isNullable);
+        }
+
+        return this._isNullable;
     }
 
     override equals(other: unknown): boolean {

--- a/packages/safe-ds-lang/src/language/typing/model.ts
+++ b/packages/safe-ds-lang/src/language/typing/model.ts
@@ -356,6 +356,11 @@ export class ClassType extends NamedType<SdsClass> {
         return new ClassType(this.declaration, newSubstitutions, this.isNullable);
     }
 
+    override unwrap(): ClassType {
+        const newSubstitutions = new Map(stream(this.substitutions).map(([key, value]) => [key, value.unwrap()]));
+        return new ClassType(this.declaration, newSubstitutions, this.isNullable);
+    }
+
     override updateNullability(isNullable: boolean): ClassType {
         if (this.isNullable === isNullable) {
             return this;

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
@@ -146,12 +146,12 @@ export class SafeDsTypeChecker {
     private classTypeIsAssignableTo(type: ClassType, other: Type, ignoreTypeParameters: boolean): boolean {
         if (type.isNullable && !other.isNullable) {
             return false;
+        } else if (type.declaration === this.builtinClasses.Nothing) {
+            return true;
         }
 
         if (other instanceof ClassType) {
-            if (type.declaration === this.builtinClasses.Nothing) {
-                return true;
-            } else if (!this.classHierarchy.isEqualToOrSubclassOf(type.declaration, other.declaration)) {
+            if (!this.classHierarchy.isEqualToOrSubclassOf(type.declaration, other.declaration)) {
                 return false;
             }
 

--- a/packages/safe-ds-lang/tests/language/typing/model.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/model.test.ts
@@ -377,6 +377,10 @@ describe('type model', async () => {
             expectedType: new ClassType(class1, new Map(), false),
         },
         {
+            type: new ClassType(class1, new Map([[typeParameter1, new UnionType(UnknownType)]]), false),
+            expectedType: new ClassType(class1, new Map([[typeParameter1, UnknownType]]), false),
+        },
+        {
             type: new EnumType(enum1, false),
             expectedType: new EnumType(enum1, false),
         },

--- a/packages/safe-ds-lang/tests/resources/typing/simplification/merge literal types in union types/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/simplification/merge literal types in union types/main.sdstest
@@ -1,0 +1,18 @@
+package tests.typing.simplification.mergeLiteralTypesInUnionTypes
+
+class C(
+    // $TEST$ serialization literal<1>
+    p1: »union<literal<1, 1>, literal<1, 1>>«,
+
+    // $TEST$ serialization literal<1, 2>
+    p2: »union<literal<1, 1>, literal<1, 2>>«,
+
+    // $TEST$ serialization literal<1, 2, 3>
+    p3: »union<literal<1, 2>, literal<2, 3>>«,
+
+    // $TEST$ serialization literal<1, 2, 3>
+    p4: »union<literal<1>, literal<2>, literal<3>>«,
+
+    // $TEST$ serialization union<literal<1, 2, 3>, String>
+    p5: »union<literal<1, 1>, String, literal<2, 3>>«,
+)

--- a/packages/safe-ds-lang/tests/resources/typing/simplification/remove unneeded entries from union types/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/simplification/remove unneeded entries from union types/main.sdstest
@@ -51,3 +51,23 @@ class C(
     // $TEST$ serialization Any?
     p16: »union<Any, String?, Int>«,
 )
+
+class TestsInvolvingNothing(
+    // $TEST$ serialization Any
+    p1: »union<Any, Nothing>«,
+
+    // $TEST$ serialization Any?
+    p2: »union<Any, Nothing?>«,
+
+    // $TEST$ serialization literal<1>
+    p3: »union<literal<1>, Nothing>«,
+
+    // $TEST$ serialization literal<1, null>
+    p4: »union<literal<1>, Nothing?>«,
+
+    // $TEST$ serialization () -> ()
+    p5: »union<() -> (), Nothing>«,
+
+    // $TEST$ serialization union<() -> (), Nothing?>
+    p6: »union<() -> (), Nothing?>«,
+)

--- a/packages/safe-ds-lang/tests/resources/typing/simplification/replace literals types that allow only null with NothingOrNull/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/simplification/replace literals types that allow only null with NothingOrNull/main.sdstest
@@ -1,4 +1,4 @@
-package tests.typing.simplification.replaceLiteralTypesThatAllowOnlyNullWithNothingNullable
+package tests.typing.simplification.replaceLiteralTypesThatAllowOnlyNullWithNothingOrNull
 
 class C(
     // $TEST$ serialization Nothing?


### PR DESCRIPTION
### Summary of Changes

* Merge literal types in union types (`union<literal<1>, literal<2>` becomes `literal<1, 2>`).
* Unwrap type parameter substitutions in class type (`C<union<Int>>` becomes `C<Int>`).