### PR TITLE
feat: check whether lower and upper bounds of a type parameter are compatible

### DIFF
--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -782,11 +782,18 @@ export class SafeDsTypeComputer {
     // -----------------------------------------------------------------------------------------------------------------
 
     /**
-     * Returns the lower bound for the given type parameter type. If no lower bound is specified explicitly, the result
-     * is `Nothing`. If invalid lower bounds are specified (e.g. because of an unresolved reference or a cycle),
-     * `$unknown` is returned. The result is simplified as much as possible.
+     * Returns the lower bound for the given input. If no lower bound is specified explicitly, the result is `Nothing`.
+     * If invalid lower bounds are specified (e.g. because of an unresolved reference or a cycle), `$unknown` is
+     * returned. The result is simplified as much as possible.
      */
-    computeLowerBound(type: TypeParameterType): Type {
+    computeLowerBound(nodeOrType: SdsTypeParameter | TypeParameterType): Type {
+        let type: TypeParameterType;
+        if (nodeOrType instanceof TypeParameterType) {
+            type = nodeOrType;
+        } else {
+            type = this.computeType(nodeOrType) as TypeParameterType;
+        }
+
         return this.doComputeLowerBound(type, new Set());
     }
 
@@ -821,11 +828,18 @@ export class SafeDsTypeComputer {
     }
 
     /**
-     * Returns the upper bound for the given type parameter type. If no upper bound is specified explicitly, the result
-     * is `Any?`. If invalid upper bounds are specified, but are invalid (e.g. because of an unresolved reference or a
-     * cycle), `$unknown` is returned. The result is simplified as much as possible.
+     * Returns the upper bound for the given input. If no upper bound is specified explicitly, the result is `Any?`. If
+     * invalid upper bounds are specified, but are invalid (e.g. because of an unresolved reference or a cycle),
+     * `$unknown` is returned. The result is simplified as much as possible.
      */
-    computeUpperBound(type: TypeParameterType): Type {
+    computeUpperBound(nodeOrType: SdsTypeParameter | TypeParameterType): Type {
+        let type: TypeParameterType;
+        if (nodeOrType instanceof TypeParameterType) {
+            type = nodeOrType;
+        } else {
+            type = this.computeType(nodeOrType) as TypeParameterType;
+        }
+
         const result = this.doComputeUpperBound(type, new Set());
         return result.updateNullability(result.isNullable || type.isNullable);
     }

--- a/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
+++ b/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
@@ -80,9 +80,10 @@ import {
 } from './other/declarations/segments.js';
 import { typeParameterBoundLeftOperandMustBeOwnTypeParameter } from './other/declarations/typeParameterBounds.js';
 import {
+    typeParameterBoundsMustBeCompatible,
     typeParameterMustBeUsedInCorrectPosition,
+    typeParameterMustHaveOneValidLowerAndUpperBound,
     typeParameterMustHaveSufficientContext,
-    typeParameterMustNotHaveMultipleBounds,
     typeParameterMustOnlyBeVariantOnClass,
 } from './other/declarations/typeParameters.js';
 import { callArgumentMustBeConstantIfParameterIsConstant, callMustNotBeRecursive } from './other/expressions/calls.js';
@@ -348,9 +349,10 @@ export const registerValidationChecks = function (services: SafeDsServices) {
         SdsTemplateString: [templateStringMustHaveExpressionBetweenTwoStringParts],
         SdsTypeCast: [typeCastExpressionMustHaveUnknownType(services)],
         SdsTypeParameter: [
-            typeParameterMustHaveSufficientContext,
+            typeParameterBoundsMustBeCompatible(services),
             typeParameterMustBeUsedInCorrectPosition(services),
-            typeParameterMustNotHaveMultipleBounds(services),
+            typeParameterMustHaveSufficientContext,
+            typeParameterMustHaveOneValidLowerAndUpperBound(services),
             typeParameterMustOnlyBeVariantOnClass,
         ],
         SdsTypeParameterBound: [typeParameterBoundLeftOperandMustBeOwnTypeParameter],

--- a/packages/safe-ds-lang/tests/resources/validation/other/declarations/type parameters/lower bound must be assignable to upper bound/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/other/declarations/type parameters/lower bound must be assignable to upper bound/main.sdstest
@@ -1,0 +1,28 @@
+package tests.validation.other.declarations.typeParameters.lowerBoundMustBeAssignableToUpperBound
+
+class C<
+    // $TEST$ no error r"The lower bound .* is not assignable to the upper bound .*\."
+    »OnlyLowerBound«,
+    // $TEST$ no error r"The lower bound .* is not assignable to the upper bound .*\."
+    »OnlyUpperBound«,
+    // $TEST$ no error r"The lower bound .* is not assignable to the upper bound .*\."
+    »CompatibleBounds«,
+    // $TEST$ error "The lower bound 'Number' is not assignable to the upper bound 'String'."
+    »IncompatibleBounds«,
+    // $TEST$ no error r"The lower bound .* is not assignable to the upper bound .*\."
+    »UnresolvedLowerBound«,
+    // $TEST$ no error r"The lower bound .* is not assignable to the upper bound .*\."
+    »UnresolvedUpperBound«,
+> where {
+    OnlyLowerBound super Number,
+    OnlyUpperBound sub Number,
+
+    CompatibleBounds super Number,
+    CompatibleBounds sub Number,
+
+    IncompatibleBounds super Number,
+    IncompatibleBounds sub String,
+
+    UnresolvedLowerBound super unknown,
+    UnresolvedUpperBound sub unknown,
+}


### PR DESCRIPTION
Closes #875

### Summary of Changes

Show an error if the lower bound of a type parameter is not assignable to its upper bound. In this case, there is no valid substitution for the type parameter.
