### PR TITLE
feat: consider nullability of upper type parameter bound in various checks

### DIFF
--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
@@ -376,6 +376,21 @@ export class SafeDsTypeChecker {
     };
 
     /**
+     * Returns whether {@link type} can be `null`. Compared to {@link Type.isNullable}, this method also considers the
+     * upper bound of type parameter types.
+     */
+    canBeNull = (type: Type): boolean => {
+        if (type.isNullable) {
+            return true;
+        } else if (type instanceof TypeParameterType) {
+            const upperBound = this.typeComputer().computeUpperBound(type);
+            return upperBound.isNullable;
+        } else {
+            return false;
+        }
+    };
+
+    /**
      * Checks whether {@link type} is allowed as the type of a constant parameter.
      */
     canBeTypeOfConstantParameter = (type: Type): boolean => {

--- a/packages/safe-ds-lang/src/language/validation/other/expressions/chainedExpressions.ts
+++ b/packages/safe-ds-lang/src/language/validation/other/expressions/chainedExpressions.ts
@@ -15,25 +15,21 @@ export const chainedExpressionsMustBeNullSafeIfReceiverIsNullable = (services: S
         }
 
         const receiverType = typeComputer.computeType(node.receiver);
-        if (receiverType === UnknownType) {
+        if (receiverType === UnknownType || !typeChecker.canBeNull(receiverType)) {
             return;
         }
 
-        if (isSdsCall(node) && receiverType.isNullable && typeChecker.canBeCalled(receiverType)) {
+        if (isSdsCall(node) && typeChecker.canBeCalled(receiverType)) {
             accept('error', 'The receiver can be null so a null-safe call must be used.', {
                 node,
                 code: CODE_CHAINED_EXPRESSION_MISSING_NULL_SAFETY,
             });
-        } else if (
-            isSdsIndexedAccess(node) &&
-            receiverType.isNullable &&
-            typeChecker.canBeAccessedByIndex(receiverType)
-        ) {
+        } else if (isSdsIndexedAccess(node) && typeChecker.canBeAccessedByIndex(receiverType)) {
             accept('error', 'The receiver can be null so a null-safe indexed access must be used.', {
                 node,
                 code: CODE_CHAINED_EXPRESSION_MISSING_NULL_SAFETY,
             });
-        } else if (isSdsMemberAccess(node) && receiverType.isNullable) {
+        } else if (isSdsMemberAccess(node)) {
             accept('error', 'The receiver can be null so a null-safe member access must be used.', {
                 node,
                 code: CODE_CHAINED_EXPRESSION_MISSING_NULL_SAFETY,

--- a/packages/safe-ds-lang/src/language/validation/style.ts
+++ b/packages/safe-ds-lang/src/language/validation/style.ts
@@ -323,14 +323,14 @@ export const chainedExpressionNullSafetyShouldBeNeeded = (services: SafeDsServic
         }
 
         const receiverType = typeComputer.computeType(node.receiver);
-        if (receiverType === UnknownType) {
+        if (receiverType === UnknownType || typeChecker.canBeNull(receiverType)) {
             return;
         }
 
         if (
-            (isSdsCall(node) && !receiverType.isNullable && typeChecker.canBeCalled(receiverType)) ||
-            (isSdsIndexedAccess(node) && !receiverType.isNullable && typeChecker.canBeAccessedByIndex(receiverType)) ||
-            (isSdsMemberAccess(node) && !receiverType.isNullable)
+            (isSdsCall(node) && typeChecker.canBeCalled(receiverType)) ||
+            (isSdsIndexedAccess(node) && typeChecker.canBeAccessedByIndex(receiverType)) ||
+            isSdsMemberAccess(node)
         ) {
             accept('info', 'The receiver is never null, so null-safety is unnecessary.', {
                 node,

--- a/packages/safe-ds-lang/src/language/validation/style.ts
+++ b/packages/safe-ds-lang/src/language/validation/style.ts
@@ -222,6 +222,7 @@ export const constraintListShouldNotBeEmpty = (services: SafeDsServices) => {
 export const elvisOperatorShouldBeNeeded = (services: SafeDsServices) => {
     const partialEvaluator = services.evaluation.PartialEvaluator;
     const settingsProvider = services.workspace.SettingsProvider;
+    const typeChecker = services.types.TypeChecker;
     const typeComputer = services.types.TypeComputer;
 
     return async (node: SdsInfixOperation, accept: ValidationAcceptor) => {
@@ -235,7 +236,7 @@ export const elvisOperatorShouldBeNeeded = (services: SafeDsServices) => {
         }
 
         const leftType = typeComputer.computeType(node.leftOperand);
-        if (!leftType.isNullable) {
+        if (!typeChecker.canBeNull(leftType)) {
             accept(
                 'info',
                 'The left operand is never null, so the elvis operator is unnecessary (keep the left operand).',

--- a/packages/safe-ds-lang/tests/resources/validation/other/expressions/chained expression/missing null safety/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/other/expressions/chained expression/missing null safety/main.sdstest
@@ -93,6 +93,24 @@ segment indexedAccess(
     »unresolved?[0]«;
 }
 
+class IndexedAccess<Nullable, NonNullable>(
+    nullable: Nullable,
+    nonNullable: NonNullable,
+
+    // $TEST$ error "The receiver can be null so a null-safe indexed access must be used."
+    p1: Any? = »nullable[0]«,
+    // $TEST$ no error "The receiver can be null so a null-safe indexed access must be used."
+    p2: Any? = »nonNullable[0]«,
+
+    // $TEST$ no error "The receiver can be null so a null-safe indexed access must be used."
+    p3: Any? = »nullable?[0]«,
+    // $TEST$ no error "The receiver can be null so a null-safe indexed access must be used."
+    p4: Any? = »nonNullable?[0]«,
+) where {
+    Nullable sub List<Int>?,
+    NonNullable sub List<Int>
+}
+
 segment memberAccess(
     myClass: MyClass,
     myClassOrNull: MyClass?,
@@ -127,4 +145,22 @@ segment memberAccess(
 
     // $TEST$ no error "The receiver can be null so a null-safe member access must be used."
     »unresolved?.a«;
+}
+
+class MemberAccess<Nullable, NonNullable>(
+    nullable: Nullable,
+    nonNullable: NonNullable,
+
+    // $TEST$ error "The receiver can be null so a null-safe member access must be used."
+    p1: Any? = »nullable.a«,
+    // $TEST$ no error "The receiver can be null so a null-safe member access must be used."
+    p2: Any? = »nonNullable.a«,
+
+    // $TEST$ no error "The receiver can be null so a null-safe member access must be used."
+    p3: Any? = »nullable?.a«,
+    // $TEST$ no error "The receiver can be null so a null-safe member access must be used."
+    p4: Any? = »nonNullable?.a«,
+) where {
+    Nullable sub MyClass?,
+    NonNullable sub MyClass
 }

--- a/packages/safe-ds-lang/tests/resources/validation/style/unnecessary elvis operator/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/style/unnecessary elvis operator/main.sdstest
@@ -1,6 +1,6 @@
 package validation.style.unnecessaryElvisOperator
 
-fun f() -> result: Any?
+@Pure fun f() -> result: Any?
 
 pipeline test {
 
@@ -39,4 +39,20 @@ pipeline test {
     »null ?: 2«;
     // $TEST$ info "Both operands are always null, so the elvis operator is unnecessary (replace it with null)."
     »null ?: null«;
+}
+
+class TestsForTypeParameters<Nullable, NonNullable>(
+    nullable: Nullable,
+    nonNullable: NonNullable,
+
+    // $TEST$ no info "The left operand is never null, so the elvis operator is unnecessary (keep the left operand)."
+    p1: Any? = »nullable ?: 2«,
+    // $TEST$ no info "The left operand is never null, so the elvis operator is unnecessary (keep the left operand)."
+    p2: Any? = »nullable ?: null«,
+    // $TEST$ info "The left operand is never null, so the elvis operator is unnecessary (keep the left operand)."
+    p3: Any? = »nonNullable ?: 2«,
+    // $TEST$ info "The left operand is never null, so the elvis operator is unnecessary (keep the left operand)."
+    p4: Any? = »nonNullable ?: null«,
+) where {
+    NonNullable sub Any
 }

--- a/packages/safe-ds-lang/tests/resources/validation/style/unnecessary null safety/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/style/unnecessary null safety/main.sdstest
@@ -93,6 +93,24 @@ segment indexedAccess(
     »unresolved?[0]«;
 }
 
+class IndexedAccess<Nullable, NonNullable>(
+    nullable: Nullable,
+    nonNullable: NonNullable,
+
+    // $TEST$ no info "The receiver is never null, so null-safety is unnecessary."
+    p1: Any? = »nullable[0]«,
+    // $TEST$ no info "The receiver is never null, so null-safety is unnecessary."
+    p2: Any? = »nonNullable[0]«,
+
+    // $TEST$ no info "The receiver is never null, so null-safety is unnecessary."
+    p3: Any? = »nullable?[0]«,
+    // $TEST$ info "The receiver is never null, so null-safety is unnecessary."
+    p4: Any? = »nonNullable?[0]«,
+) where {
+    Nullable sub List<Int>?,
+    NonNullable sub List<Int>
+}
+
 segment memberAccess(
     myClass: MyClass,
     myClassOrNull: MyClass?,
@@ -127,4 +145,22 @@ segment memberAccess(
 
     // $TEST$ no info "The receiver is never null, so null-safety is unnecessary."
     »unresolved?.a«;
+}
+
+class MemberAccess<Nullable, NonNullable>(
+    nullable: Nullable,
+    nonNullable: NonNullable,
+
+    // $TEST$ no info "The receiver is never null, so null-safety is unnecessary."
+    p1: Any? = »nullable.a«,
+    // $TEST$ no info "The receiver is never null, so null-safety is unnecessary."
+    p2: Any? = »nonNullable.a«,
+
+    // $TEST$ no info "The receiver is never null, so null-safety is unnecessary."
+    p3: Any? = »nullable?.a«,
+    // $TEST$ info "The receiver is never null, so null-safety is unnecessary."
+    p4: Any? = »nonNullable?.a«,
+) where {
+    Nullable sub MyClass?,
+    NonNullable sub MyClass
 }


### PR DESCRIPTION
### Summary of Changes

Type parameter types can be nullable in two different way:
1. They are explicitly declared as nullable using a `?`.
2. They have a nullable upper bound.

This PR now updates various checks to also consider the 2. option:
* Info: Elvis operator is unnecessary, because its left operand is never `null`.
* Info: Null-safe index access/member access is unnecessary, because the receiver is never `null`.
* Error: Index access/member access must be null-safe, because the receiver can be `null`.
