### PR TITLE
refactor: improve type model

### DIFF
--- a/packages/safe-ds-eda/package.json
+++ b/packages/safe-ds-eda/package.json
@@ -4,6 +4,7 @@
     "private": true,
     "type": "module",
     "scripts": {
+        "clean": "shx rm -rf dist lib *.tsbuildinfo",
         "dev": "vite",
         "watch": "vite build --watch",
         "build": "vite build",

--- a/packages/safe-ds-lang/src/language/safe-ds-module.ts
+++ b/packages/safe-ds-lang/src/language/safe-ds-module.ts
@@ -44,6 +44,7 @@ import { SafeDsPurityComputer } from './purity/safe-ds-purity-computer.js';
 import { SafeDsSettingsProvider } from './workspace/safe-ds-settings-provider.js';
 import { SafeDsRenameProvider } from './lsp/safe-ds-rename-provider.js';
 import { SafeDsRunner } from './runner/safe-ds-runner.js';
+import { SafeDsTypeFactory } from './typing/safe-ds-type-factory.js';
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -79,6 +80,7 @@ export type SafeDsAddedServices = {
         CoreTypes: SafeDsCoreTypes;
         TypeChecker: SafeDsTypeChecker;
         TypeComputer: SafeDsTypeComputer;
+        TypeFactory: SafeDsTypeFactory;
     };
     workspace: {
         PackageManager: SafeDsPackageManager;
@@ -149,6 +151,7 @@ export const SafeDsModule: Module<SafeDsServices, PartialLangiumServices & SafeD
         CoreTypes: (services) => new SafeDsCoreTypes(services),
         TypeChecker: (services) => new SafeDsTypeChecker(services),
         TypeComputer: (services) => new SafeDsTypeComputer(services),
+        TypeFactory: (services) => new SafeDsTypeFactory(services),
     },
     workspace: {
         PackageManager: (services) => new SafeDsPackageManager(services),

--- a/packages/safe-ds-lang/src/language/typing/model.ts
+++ b/packages/safe-ds-lang/src/language/typing/model.ts
@@ -54,7 +54,7 @@ export abstract class Type {
     /**
      * Returns a copy of this type with the given nullability.
      */
-    abstract updateExplicitNullability(isExplicitlyNullable: boolean): Type;
+    abstract withExplicitNullability(isExplicitlyNullable: boolean): Type;
 }
 
 export class CallableType extends Type {
@@ -125,7 +125,7 @@ export class CallableType extends Type {
         );
     }
 
-    override updateExplicitNullability(isExplicitlyNullable: boolean): Type {
+    override withExplicitNullability(isExplicitlyNullable: boolean): Type {
         if (!isExplicitlyNullable) {
             return this;
         }
@@ -201,15 +201,15 @@ export class IntersectionType extends Type {
         return this.factory.createIntersectionType(...newTypes);
     }
 
-    override updateExplicitNullability(isExplicitlyNullable: boolean): Type {
+    override withExplicitNullability(isExplicitlyNullable: boolean): Type {
         if (isEmpty(this.types)) {
-            return this.coreTypes.Any.updateExplicitNullability(isExplicitlyNullable);
+            return this.coreTypes.Any.withExplicitNullability(isExplicitlyNullable);
         }
 
         if (this.isExplicitlyNullable && !isExplicitlyNullable) {
-            return this.factory.createIntersectionType(...this.types.map((it) => it.updateExplicitNullability(false)));
+            return this.factory.createIntersectionType(...this.types.map((it) => it.withExplicitNullability(false)));
         } else if (!this.isExplicitlyNullable && isExplicitlyNullable) {
-            return this.factory.createIntersectionType(...this.types.map((it) => it.updateExplicitNullability(true)));
+            return this.factory.createIntersectionType(...this.types.map((it) => it.withExplicitNullability(true)));
         } else {
             return this;
         }
@@ -263,7 +263,7 @@ export class LiteralType extends Type {
         return this;
     }
 
-    override updateExplicitNullability(isExplicitlyNullable: boolean): LiteralType {
+    override withExplicitNullability(isExplicitlyNullable: boolean): LiteralType {
         if (this.isExplicitlyNullable && !isExplicitlyNullable) {
             return this.factory.createLiteralType(...this.constants.filter((it) => it !== NullConstant));
         } else if (!this.isExplicitlyNullable && isExplicitlyNullable) {
@@ -338,7 +338,7 @@ export class NamedTupleType<T extends SdsDeclaration> extends Type {
         return this.factory.createNamedTupleType(...this.entries.map((it) => it.unwrap()));
     }
 
-    override updateExplicitNullability(isExplicitlyNullable: boolean): Type {
+    override withExplicitNullability(isExplicitlyNullable: boolean): Type {
         if (!isExplicitlyNullable) {
             return this;
         }
@@ -397,7 +397,7 @@ export abstract class NamedType<T extends SdsDeclaration> extends Type {
         }
     }
 
-    abstract override updateExplicitNullability(isExplicitlyNullable: boolean): NamedType<T>;
+    abstract override withExplicitNullability(isExplicitlyNullable: boolean): NamedType<T>;
 
     simplify(): NamedType<T> {
         return this;
@@ -469,7 +469,7 @@ export class ClassType extends NamedType<SdsClass> {
         return new ClassType(this.declaration, newSubstitutions, this.isExplicitlyNullable);
     }
 
-    override updateExplicitNullability(isExplicitlyNullable: boolean): ClassType {
+    override withExplicitNullability(isExplicitlyNullable: boolean): ClassType {
         if (this.isExplicitlyNullable === isExplicitlyNullable) {
             return this;
         }
@@ -500,7 +500,7 @@ export class EnumType extends NamedType<SdsEnum> {
         return this;
     }
 
-    override updateExplicitNullability(isExplicitlyNullable: boolean): EnumType {
+    override withExplicitNullability(isExplicitlyNullable: boolean): EnumType {
         if (this.isExplicitlyNullable === isExplicitlyNullable) {
             return this;
         }
@@ -531,7 +531,7 @@ export class EnumVariantType extends NamedType<SdsEnumVariant> {
         return this;
     }
 
-    override updateExplicitNullability(isExplicitlyNullable: boolean): EnumVariantType {
+    override withExplicitNullability(isExplicitlyNullable: boolean): EnumVariantType {
         if (this.isExplicitlyNullable === isExplicitlyNullable) {
             return this;
         }
@@ -564,13 +564,13 @@ export class TypeParameterType extends NamedType<SdsTypeParameter> {
         if (!substitution) {
             return this;
         } else if (this.isExplicitlyNullable) {
-            return substitution.updateExplicitNullability(true);
+            return substitution.withExplicitNullability(true);
         } else {
             return substitution;
         }
     }
 
-    override updateExplicitNullability(isExplicitlyNullable: boolean): TypeParameterType {
+    override withExplicitNullability(isExplicitlyNullable: boolean): TypeParameterType {
         if (this.isExplicitlyNullable === isExplicitlyNullable) {
             return this;
         }
@@ -620,7 +620,7 @@ export class StaticType extends Type {
         return this;
     }
 
-    override updateExplicitNullability(isExplicitlyNullable: boolean): Type {
+    override withExplicitNullability(isExplicitlyNullable: boolean): Type {
         if (!isExplicitlyNullable) {
             return this;
         }
@@ -694,15 +694,15 @@ export class UnionType extends Type {
         return this.factory.createUnionType(...newTypes);
     }
 
-    override updateExplicitNullability(isExplicitlyNullable: boolean): Type {
+    override withExplicitNullability(isExplicitlyNullable: boolean): Type {
         if (isEmpty(this.types)) {
-            return this.coreTypes.Nothing.updateExplicitNullability(isExplicitlyNullable);
+            return this.coreTypes.Nothing.withExplicitNullability(isExplicitlyNullable);
         }
 
         if (this.isExplicitlyNullable && !isExplicitlyNullable) {
-            return this.factory.createUnionType(...this.types.map((it) => it.updateExplicitNullability(false)));
+            return this.factory.createUnionType(...this.types.map((it) => it.withExplicitNullability(false)));
         } else if (!this.isExplicitlyNullable && isExplicitlyNullable) {
-            return this.factory.createUnionType(...this.types.map((it) => it.updateExplicitNullability(true)));
+            return this.factory.createUnionType(...this.types.map((it) => it.withExplicitNullability(true)));
         } else {
             return this;
         }
@@ -728,7 +728,7 @@ class UnknownTypeClass extends Type {
         return this;
     }
 
-    override updateExplicitNullability(_isExplicitlyNullable: boolean): Type {
+    override withExplicitNullability(_isExplicitlyNullable: boolean): Type {
         return this;
     }
 }

--- a/packages/safe-ds-lang/src/language/typing/model.ts
+++ b/packages/safe-ds-lang/src/language/typing/model.ts
@@ -200,14 +200,12 @@ export class IntersectionType extends Type {
     }
 
     override updateExplicitNullability(isExplicitlyNullable: boolean): Type {
+        if (isEmpty(this.types)) {
+            return this.coreTypes.Any.updateExplicitNullability(isExplicitlyNullable);
+        }
+
         if (this.isExplicitlyNullable && !isExplicitlyNullable) {
-            if (isEmpty(this.types)) {
-                return this.coreTypes.Any;
-            } else {
-                return this.factory.createIntersectionType(
-                    ...this.types.map((it) => it.updateExplicitNullability(false)),
-                );
-            }
+            return this.factory.createIntersectionType(...this.types.map((it) => it.updateExplicitNullability(false)));
         } else if (!this.isExplicitlyNullable && isExplicitlyNullable) {
             return this.factory.createIntersectionType(...this.types.map((it) => it.updateExplicitNullability(true)));
         } else {
@@ -217,7 +215,6 @@ export class IntersectionType extends Type {
 }
 
 export class LiteralType extends Type {
-    private readonly coreTypes: SafeDsCoreTypes;
     private readonly factory: SafeDsTypeFactory;
 
     readonly constants: Constant[];
@@ -226,7 +223,6 @@ export class LiteralType extends Type {
     constructor(services: SafeDsServices, constants: Constant[]) {
         super();
 
-        this.coreTypes = services.types.CoreTypes;
         this.factory = services.types.TypeFactory;
 
         this.constants = constants;
@@ -697,14 +693,14 @@ export class UnionType extends Type {
     }
 
     override updateExplicitNullability(isExplicitlyNullable: boolean): Type {
+        if (isEmpty(this.types)) {
+            return this.coreTypes.Nothing.updateExplicitNullability(isExplicitlyNullable);
+        }
+
         if (this.isExplicitlyNullable && !isExplicitlyNullable) {
             return this.factory.createUnionType(...this.types.map((it) => it.updateExplicitNullability(false)));
         } else if (!this.isExplicitlyNullable && isExplicitlyNullable) {
-            if (isEmpty(this.types)) {
-                return this.coreTypes.NothingOrNull;
-            } else {
-                return this.factory.createUnionType(...this.types.map((it) => it.updateExplicitNullability(true)));
-            }
+            return this.factory.createUnionType(...this.types.map((it) => it.updateExplicitNullability(true)));
         } else {
             return this;
         }

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
@@ -29,17 +29,20 @@ import { SafeDsClassHierarchy } from './safe-ds-class-hierarchy.js';
 import { SafeDsCoreTypes } from './safe-ds-core-types.js';
 import type { SafeDsTypeComputer } from './safe-ds-type-computer.js';
 import { isEmpty } from '../../helpers/collections.js';
+import { SafeDsTypeFactory } from './safe-ds-type-factory.js';
 
 export class SafeDsTypeChecker {
     private readonly builtinClasses: SafeDsClasses;
     private readonly classHierarchy: SafeDsClassHierarchy;
     private readonly coreTypes: SafeDsCoreTypes;
+    private readonly factory: SafeDsTypeFactory;
     private readonly typeComputer: () => SafeDsTypeComputer;
 
     constructor(services: SafeDsServices) {
         this.builtinClasses = services.builtins.Classes;
         this.classHierarchy = services.types.ClassHierarchy;
         this.coreTypes = services.types.CoreTypes;
+        this.factory = services.types.TypeFactory;
         this.typeComputer = () => services.types.TypeComputer;
     }
 
@@ -78,7 +81,7 @@ export class SafeDsTypeChecker {
                 this.isSubtypeOf(typeUpperBound, otherUpperBound, options)
             );
         } else if (other instanceof UnionType) {
-            return other.possibleTypes.some((it) => this.isSubtypeOf(type, it, options));
+            return other.types.some((it) => this.isSubtypeOf(type, it, options));
         }
 
         if (type instanceof CallableType) {
@@ -305,29 +308,29 @@ export class SafeDsTypeChecker {
                 return UnknownType;
             }
 
-            const parameterEntries = new NamedTupleType(
+            const parameterEntries = this.factory.createNamedTupleType(
                 ...getParameters(declaration).map(
                     (it) => new NamedTupleEntry(it, it.name, this.typeComputer().computeType(it)),
                 ),
             );
-            const resultEntries = new NamedTupleType(
+            const resultEntries = this.factory.createNamedTupleType(
                 new NamedTupleEntry<SdsAbstractResult>(undefined, 'instance', instanceType),
             );
 
-            return new CallableType(declaration, undefined, parameterEntries, resultEntries);
+            return this.factory.createCallableType(declaration, undefined, parameterEntries, resultEntries);
         } else if (instanceType instanceof EnumVariantType) {
             const declaration = instanceType.declaration;
 
-            const parameterEntries = new NamedTupleType(
+            const parameterEntries = this.factory.createNamedTupleType(
                 ...getParameters(declaration).map(
                     (it) => new NamedTupleEntry(it, it.name, this.typeComputer().computeType(it)),
                 ),
             );
-            const resultEntries = new NamedTupleType(
+            const resultEntries = this.factory.createNamedTupleType(
                 new NamedTupleEntry<SdsAbstractResult>(undefined, 'instance', instanceType),
             );
 
-            return new CallableType(declaration, undefined, parameterEntries, resultEntries);
+            return this.factory.createCallableType(declaration, undefined, parameterEntries, resultEntries);
         } else {
             return UnknownType;
         }
@@ -339,7 +342,7 @@ export class SafeDsTypeChecker {
     }
 
     private unionTypeIsSubtypeOf(type: UnionType, other: Type, options: TypeCheckOptions): boolean {
-        return type.possibleTypes.every((it) => this.isSubtypeOf(it, other, options));
+        return type.types.every((it) => this.isSubtypeOf(it, other, options));
     }
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
@@ -252,7 +252,7 @@ export class SafeDsTypeChecker {
         }
 
         if (other instanceof ClassType) {
-            if (other.equals(this.coreTypes.Any.updateExplicitNullability(type.isExplicitlyNullable))) {
+            if (other.equals(this.coreTypes.Any.withExplicitNullability(type.isExplicitlyNullable))) {
                 return true;
             }
 
@@ -420,7 +420,7 @@ export class SafeDsTypeChecker {
      * Checks whether {@link type} is some kind of list (with any element type).
      */
     isList(type: Type): type is ClassType | TypeParameterType {
-        const listOrNull = this.coreTypes.List(UnknownType).updateExplicitNullability(true);
+        const listOrNull = this.coreTypes.List(UnknownType).withExplicitNullability(true);
 
         return (
             !type.equals(this.coreTypes.Nothing) &&
@@ -435,7 +435,7 @@ export class SafeDsTypeChecker {
      * Checks whether {@link type} is some kind of map (with any key/value types).
      */
     isMap(type: Type): type is ClassType | TypeParameterType {
-        const mapOrNull = this.coreTypes.Map(UnknownType, UnknownType).updateExplicitNullability(true);
+        const mapOrNull = this.coreTypes.Map(UnknownType, UnknownType).withExplicitNullability(true);
 
         return (
             !type.equals(this.coreTypes.Nothing) &&

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -659,7 +659,7 @@ export class SafeDsTypeComputer {
      * already simplified, so this method is mainly useful for types that are constructed or modified manually.
      */
     simplifyType(type: Type): Type {
-        const unwrappedType = type.unwrap();
+        const unwrappedType = type.simplify();
 
         if (unwrappedType instanceof LiteralType) {
             return this.simplifyLiteralType(unwrappedType);

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -659,43 +659,12 @@ export class SafeDsTypeComputer {
      * already simplified, so this method is mainly useful for types that are constructed or modified manually.
      */
     simplifyType(type: Type): Type {
-        const unwrappedType = type.simplify();
+        const simplifiedType = type.simplify();
 
-        if (unwrappedType instanceof LiteralType) {
-            return this.simplifyLiteralType(unwrappedType);
-        } else if (unwrappedType instanceof UnionType) {
-            return this.simplifyUnionType(unwrappedType);
+        if (simplifiedType instanceof UnionType) {
+            return this.simplifyUnionType(simplifiedType);
         } else {
-            return unwrappedType;
-        }
-    }
-
-    private simplifyLiteralType(type: LiteralType): Type {
-        // Handle empty literal types
-        if (isEmpty(type.constants)) {
-            return this.coreTypes.Nothing;
-        }
-
-        // Remove duplicate constants
-        const uniqueConstants: Constant[] = [];
-        const knownConstants = new Set<String>();
-
-        for (const constant of type.constants) {
-            let key = constant.toString();
-
-            if (!knownConstants.has(key)) {
-                uniqueConstants.push(constant);
-                knownConstants.add(key);
-            }
-        }
-
-        // Apply other simplifications
-        if (uniqueConstants.length === 1 && uniqueConstants[0] === NullConstant) {
-            return this.coreTypes.NothingOrNull;
-        } else if (uniqueConstants.length < type.constants.length) {
-            return this.factory.createLiteralType(...uniqueConstants);
-        } else {
-            return type;
+            return simplifiedType;
         }
     }
 

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -465,7 +465,7 @@ export class SafeDsTypeComputer {
         }
 
         // Update nullability
-        return result.updateExplicitNullability(receiverType.isExplicitlyNullable && node.isNullSafe);
+        return result.withExplicitNullability(receiverType.isExplicitlyNullable && node.isNullSafe);
     }
 
     private computeTypeOfExpressionLambda(node: SdsExpressionLambda): Type {
@@ -495,7 +495,7 @@ export class SafeDsTypeComputer {
         if (listType) {
             return listType
                 .getTypeParameterTypeByIndex(0)
-                .updateExplicitNullability(listType.isExplicitlyNullable && node.isNullSafe);
+                .withExplicitNullability(listType.isExplicitlyNullable && node.isNullSafe);
         }
 
         // Receiver is a map
@@ -503,7 +503,7 @@ export class SafeDsTypeComputer {
         if (mapType) {
             return mapType
                 .getTypeParameterTypeByIndex(1)
-                .updateExplicitNullability(mapType.isExplicitlyNullable && node.isNullSafe);
+                .withExplicitNullability(mapType.isExplicitlyNullable && node.isNullSafe);
         }
 
         return UnknownType;
@@ -527,7 +527,7 @@ export class SafeDsTypeComputer {
         const leftOperandType = this.computeType(node.leftOperand);
         if (leftOperandType.isExplicitlyNullable) {
             const rightOperandType = this.computeType(node.rightOperand);
-            return this.lowestCommonSupertype([leftOperandType.updateExplicitNullability(false), rightOperandType]);
+            return this.lowestCommonSupertype([leftOperandType.withExplicitNullability(false), rightOperandType]);
         } else {
             return leftOperandType;
         }
@@ -559,7 +559,7 @@ export class SafeDsTypeComputer {
         }
 
         // Update nullability
-        return result.updateExplicitNullability(
+        return result.withExplicitNullability(
             (receiverType.isExplicitlyNullable && node.isNullSafe) || result.isExplicitlyNullable,
         );
     }
@@ -579,7 +579,7 @@ export class SafeDsTypeComputer {
         const instanceType = this.computeType(target);
 
         if (isSdsNamedTypeDeclaration(target) && instanceType instanceof NamedType) {
-            return this.factory.createStaticType(instanceType.updateExplicitNullability(false));
+            return this.factory.createStaticType(instanceType.withExplicitNullability(false));
         } else {
             return instanceType;
         }
@@ -614,7 +614,7 @@ export class SafeDsTypeComputer {
     }
 
     private computeTypeOfNamedType(node: SdsNamedType) {
-        const unparameterizedType = this.computeType(node.declaration?.ref).updateExplicitNullability(node.isNullable);
+        const unparameterizedType = this.computeType(node.declaration?.ref).withExplicitNullability(node.isNullable);
         if (!(unparameterizedType instanceof ClassType)) {
             return unparameterizedType;
         }
@@ -745,7 +745,7 @@ export class SafeDsTypeComputer {
                 // subtype relation between `currentType` and `otherType` in both directions. We always keep the type
                 // parameter type in this case for consistency, since it can be narrower if it has a lower bound.
                 if (currentType instanceof TypeParameterType) {
-                    const candidateType = currentType.updateExplicitNullability(
+                    const candidateType = currentType.withExplicitNullability(
                         currentType.isExplicitlyNullable || otherType.isExplicitlyNullable,
                     );
 
@@ -756,7 +756,7 @@ export class SafeDsTypeComputer {
                     }
                 }
 
-                const candidateType = otherType.updateExplicitNullability(
+                const candidateType = otherType.withExplicitNullability(
                     currentType.isExplicitlyNullable || otherType.isExplicitlyNullable,
                 );
                 if (this.typeChecker.isSubtypeOf(currentType, candidateType)) {
@@ -782,7 +782,7 @@ export class SafeDsTypeComputer {
      * Returns the non-nullable type for the given type. The result is simplified as much as possible.
      */
     computeNonNullableType(type: Type): Type {
-        return this.simplifyType(type.updateExplicitNullability(false));
+        return this.simplifyType(type.withExplicitNullability(false));
     }
 
     /**
@@ -879,7 +879,7 @@ export class SafeDsTypeComputer {
         }
 
         const result = this.doComputeUpperBound(type, new Set(), options);
-        return result.updateExplicitNullability(result.isExplicitlyNullable || type.isExplicitlyNullable);
+        return result.withExplicitNullability(result.isExplicitlyNullable || type.isExplicitlyNullable);
     }
 
     private doComputeUpperBound(
@@ -1021,7 +1021,7 @@ export class SafeDsTypeComputer {
         }
 
         // Find the class type that is compatible to all other types
-        const firstClassType = classTypes[0]!.updateExplicitNullability(isNullable);
+        const firstClassType = classTypes[0]!.withExplicitNullability(isNullable);
         const candidates = [firstClassType, ...this.streamProperSupertypes(firstClassType)];
         let other = [...classTypes.slice(1)];
 
@@ -1114,9 +1114,9 @@ export class SafeDsTypeComputer {
         const candidates: Type[] = [];
 
         if (!isEmpty(enumTypes)) {
-            candidates.push(enumTypes[0]!.updateExplicitNullability(isNullable));
+            candidates.push(enumTypes[0]!.withExplicitNullability(isNullable));
         } else if (!isEmpty(enumVariantTypes)) {
-            candidates.push(enumVariantTypes[0]!.updateExplicitNullability(isNullable));
+            candidates.push(enumVariantTypes[0]!.withExplicitNullability(isNullable));
 
             const containingEnum = getContainerOfType(enumVariantTypes[0]!.declaration, isSdsEnum);
             if (containingEnum) {
@@ -1218,7 +1218,7 @@ export class SafeDsTypeComputer {
             current = this.parentClassType(current);
         }
 
-        const Any = this.coreTypes.Any.updateExplicitNullability(type.isExplicitlyNullable);
+        const Any = this.coreTypes.Any.withExplicitNullability(type.isExplicitlyNullable);
         if (Any instanceof ClassType && !visited.has(Any.declaration)) {
             yield Any;
         }
@@ -1234,7 +1234,7 @@ export class SafeDsTypeComputer {
         const firstParentType = this.computeType(firstParentTypeNode, type.substitutions);
 
         if (firstParentType instanceof ClassType) {
-            return firstParentType.updateExplicitNullability(type.isExplicitlyNullable);
+            return firstParentType.withExplicitNullability(type.isExplicitlyNullable);
         }
         return undefined;
     }

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-factory.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-factory.ts
@@ -1,0 +1,81 @@
+import { SafeDsServices } from '../safe-ds-module.js';
+import {
+    CallableType,
+    ClassType,
+    EnumType,
+    EnumVariantType,
+    IntersectionType,
+    LiteralType,
+    NamedTupleEntry,
+    NamedTupleType,
+    NamedType,
+    StaticType,
+    Type,
+    TypeParameterSubstitutions,
+    TypeParameterType,
+    UnionType,
+} from './model.js';
+import { Constant } from '../partialEvaluation/model.js';
+import {
+    SdsAbstractResult,
+    SdsCallable,
+    SdsClass,
+    SdsDeclaration,
+    SdsEnum,
+    SdsEnumVariant,
+    SdsParameter,
+    SdsTypeParameter,
+} from '../generated/ast.js';
+
+export class SafeDsTypeFactory {
+    constructor(private readonly services: SafeDsServices) {}
+
+    createCallableType(
+        callable: SdsCallable,
+        parameter: SdsParameter | undefined,
+        inputType: NamedTupleType<SdsParameter>,
+        outputType: NamedTupleType<SdsAbstractResult>,
+    ): CallableType {
+        return new CallableType(this.services, callable, parameter, inputType, outputType);
+    }
+
+    createClassType(
+        declaration: SdsClass,
+        substitutions: TypeParameterSubstitutions,
+        isExplicitlyNullable: boolean,
+    ): ClassType {
+        return new ClassType(declaration, substitutions, isExplicitlyNullable);
+    }
+
+    createEnumType(declaration: SdsEnum, isExplicitlyNullable: boolean): EnumType {
+        return new EnumType(declaration, isExplicitlyNullable);
+    }
+
+    createEnumVariantType(declaration: SdsEnumVariant, isExplicitlyNullable: boolean): EnumVariantType {
+        return new EnumVariantType(declaration, isExplicitlyNullable);
+    }
+
+    createIntersectionType(...types: Type[]): IntersectionType {
+        return new IntersectionType(this.services, types);
+    }
+
+    createLiteralType(...constants: Constant[]): LiteralType {
+        return new LiteralType(this.services, constants);
+    }
+
+    createNamedTupleType<T extends SdsDeclaration>(...entries: NamedTupleEntry<T>[]): NamedTupleType<T> {
+        return new NamedTupleType(this.services, entries);
+    }
+
+    createStaticType(instanceType: NamedType<SdsDeclaration>): StaticType {
+        return new StaticType(this.services, instanceType);
+    }
+
+    createTypeParameterType(declaration: SdsTypeParameter, isExplicitlyNullable: boolean): TypeParameterType {
+        return new TypeParameterType(declaration, isExplicitlyNullable);
+    }
+
+    createUnionType(...types: Type[]): UnionType {
+        return new UnionType(this.services, types);
+    }
+}

--- a/packages/safe-ds-lang/tests/language/typing/model.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/model.test.ts
@@ -481,7 +481,7 @@ describe('type model', async () => {
         },
         {
             type: factory.createUnionType(),
-            expectedType: factory.createUnionType(),
+            expectedType: coreTypes.Nothing,
         },
         {
             type: factory.createUnionType(new ClassType(class1, new Map(), false)),

--- a/packages/safe-ds-lang/tests/language/typing/model.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/model.test.ts
@@ -518,7 +518,7 @@ describe('type model', async () => {
         });
     });
 
-    const updateExplicitNullabilityTests: UpdateExplicitNullabilityTest[] = [
+    const withExplicitNullabilityTests: WithExplicitNullabilityTest[] = [
         {
             type: factory.createCallableType(
                 callable1,
@@ -709,9 +709,9 @@ describe('type model', async () => {
             expectedType: UnknownType,
         },
     ];
-    describe.each(updateExplicitNullabilityTests)('updateExplicitNullability', ({ type, isNullable, expectedType }) => {
+    describe.each(withExplicitNullabilityTests)('withExplicitNullability', ({ type, isNullable, expectedType }) => {
         it(`should return the expected value (${type.constructor.name} -- ${type})`, () => {
-            const actual = type.updateExplicitNullability(isNullable);
+            const actual = type.withExplicitNullability(isNullable);
             expectEqualTypes(actual, expectedType);
         });
     });
@@ -827,9 +827,9 @@ interface UnwrapTest {
 }
 
 /**
- * Tests for {@link Type.updateExplicitNullability}.
+ * Tests for {@link Type.withExplicitNullability}.
  */
-interface UpdateExplicitNullabilityTest {
+interface WithExplicitNullabilityTest {
     /**
      * The type to test.
      */

--- a/packages/safe-ds-lang/tests/language/typing/model.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/model.test.ts
@@ -377,37 +377,7 @@ describe('type model', async () => {
         });
     });
 
-    const unwrapTests: UnwrapTest[] = [
-        {
-            type: factory.createCallableType(
-                callable1,
-                undefined,
-                factory.createNamedTupleType(),
-                factory.createNamedTupleType(),
-            ),
-            expectedType: factory.createCallableType(
-                callable1,
-                undefined,
-                factory.createNamedTupleType(),
-                factory.createNamedTupleType(),
-            ),
-        },
-        {
-            type: factory.createCallableType(
-                callable1,
-                undefined,
-                factory.createNamedTupleType(
-                    new NamedTupleEntry(parameter1, 'p1', factory.createUnionType(UnknownType)),
-                ),
-                factory.createNamedTupleType(new NamedTupleEntry(result, 'r', factory.createUnionType(UnknownType))),
-            ),
-            expectedType: factory.createCallableType(
-                callable1,
-                undefined,
-                factory.createNamedTupleType(new NamedTupleEntry(parameter1, 'p1', UnknownType)),
-                factory.createNamedTupleType(new NamedTupleEntry(result, 'r', UnknownType)),
-            ),
-        },
+    const simplifyTests: SimplifyTest[] = [
         {
             type: factory.createIntersectionType(),
             expectedType: factory.createIntersectionType(),
@@ -437,82 +407,9 @@ describe('type model', async () => {
                 new EnumVariantType(enumVariant1, false),
             ),
         },
-        {
-            type: factory.createLiteralType(new BooleanConstant(true)),
-            expectedType: factory.createLiteralType(new BooleanConstant(true)),
-        },
-        {
-            type: factory.createNamedTupleType(),
-            expectedType: factory.createNamedTupleType(),
-        },
-        {
-            type: factory.createNamedTupleType(
-                new NamedTupleEntry(parameter1, 'p1', factory.createUnionType(UnknownType)),
-                new NamedTupleEntry(parameter1, 'p1', factory.createUnionType(UnknownType)),
-            ),
-            expectedType: factory.createNamedTupleType(
-                new NamedTupleEntry(parameter1, 'p1', UnknownType),
-                new NamedTupleEntry(parameter1, 'p1', UnknownType),
-            ),
-        },
-        {
-            type: new ClassType(class1, new Map(), false),
-            expectedType: new ClassType(class1, new Map(), false),
-        },
-        {
-            type: new ClassType(class1, new Map([[typeParameter1, factory.createUnionType(UnknownType)]]), false),
-            expectedType: new ClassType(class1, new Map([[typeParameter1, UnknownType]]), false),
-        },
-        {
-            type: new EnumType(enum1, false),
-            expectedType: new EnumType(enum1, false),
-        },
-        {
-            type: new EnumVariantType(enumVariant1, false),
-            expectedType: new EnumVariantType(enumVariant1, false),
-        },
-        {
-            type: new TypeParameterType(typeParameter1, false),
-            expectedType: new TypeParameterType(typeParameter1, false),
-        },
-        {
-            type: factory.createStaticType(new ClassType(class1, new Map(), false)),
-            expectedType: factory.createStaticType(new ClassType(class1, new Map(), false)),
-        },
-        {
-            type: factory.createUnionType(),
-            expectedType: coreTypes.Nothing,
-        },
-        {
-            type: factory.createUnionType(new ClassType(class1, new Map(), false)),
-            expectedType: new ClassType(class1, new Map(), false),
-        },
-        {
-            type: factory.createUnionType(factory.createUnionType(new ClassType(class1, new Map(), false))),
-            expectedType: new ClassType(class1, new Map(), false),
-        },
-        {
-            type: factory.createUnionType(
-                factory.createUnionType(
-                    new ClassType(class1, new Map(), false),
-                    new ClassType(class2, new Map(), false),
-                ),
-                factory.createUnionType(new EnumType(enum1, false), new EnumVariantType(enumVariant1, false)),
-            ),
-            expectedType: factory.createUnionType(
-                new ClassType(class1, new Map(), false),
-                new ClassType(class2, new Map(), false),
-                new EnumType(enum1, false),
-                new EnumVariantType(enumVariant1, false),
-            ),
-        },
-        {
-            type: UnknownType,
-            expectedType: UnknownType,
-        },
     ];
-    describe.each(unwrapTests)('unwrap', ({ type, expectedType }) => {
-        it(`should remove any unnecessary containers (${type.constructor.name} -- ${type})`, () => {
+    describe.each(simplifyTests)('simplify', ({ type, expectedType }) => {
+        it(`should simplify type (${type.constructor.name} -- ${type})`, () => {
             const actual = type.simplify();
             expectEqualTypes(actual, expectedType);
         });
@@ -814,7 +711,7 @@ interface SubstituteTypeParametersTest {
 /**
  * Tests for {@link Type.simplify}.
  */
-interface UnwrapTest {
+interface SimplifyTest {
     /**
      * The type to test.
      */

--- a/packages/safe-ds-lang/tests/language/typing/model.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/model.test.ts
@@ -73,6 +73,11 @@ describe('type model', async () => {
             valueOfOtherType: () => UnknownType,
         },
         {
+            value: () => factory.createIntersectionType(UnknownType),
+            unequalValueOfSameType: () => factory.createIntersectionType(),
+            valueOfOtherType: () => UnknownType,
+        },
+        {
             value: () => factory.createLiteralType(new BooleanConstant(true)),
             unequalValueOfSameType: () => factory.createLiteralType(new IntConstant(1n)),
             valueOfOtherType: () => UnknownType,
@@ -176,6 +181,10 @@ describe('type model', async () => {
             expectedString: '(p2?: $unknown) -> ()',
         },
         {
+            value: factory.createIntersectionType(UnknownType),
+            expectedString: '$intersection<$unknown>',
+        },
+        {
             value: factory.createLiteralType(new BooleanConstant(true)),
             expectedString: 'literal<true>',
         },
@@ -260,6 +269,19 @@ describe('type model', async () => {
                 ),
                 factory.createNamedTupleType(
                     new NamedTupleEntry(result, 'r', factory.createLiteralType(new IntConstant(1n))),
+                ),
+            ),
+        },
+        {
+            type: factory.createIntersectionType(
+                new ClassType(class1, new Map([[typeParameter2, new TypeParameterType(typeParameter1, false)]]), false),
+            ),
+            substitutions: substitutions1,
+            expectedType: factory.createIntersectionType(
+                new ClassType(
+                    class1,
+                    new Map([[typeParameter2, factory.createLiteralType(new IntConstant(1n))]]),
+                    false,
                 ),
             ),
         },
@@ -387,6 +409,35 @@ describe('type model', async () => {
             ),
         },
         {
+            type: factory.createIntersectionType(),
+            expectedType: factory.createIntersectionType(),
+        },
+        {
+            type: factory.createIntersectionType(new ClassType(class1, new Map(), false)),
+            expectedType: new ClassType(class1, new Map(), false),
+        },
+        {
+            type: factory.createIntersectionType(
+                factory.createIntersectionType(new ClassType(class1, new Map(), false)),
+            ),
+            expectedType: new ClassType(class1, new Map(), false),
+        },
+        {
+            type: factory.createIntersectionType(
+                factory.createIntersectionType(
+                    new ClassType(class1, new Map(), false),
+                    new ClassType(class2, new Map(), false),
+                ),
+                factory.createIntersectionType(new EnumType(enum1, false), new EnumVariantType(enumVariant1, false)),
+            ),
+            expectedType: factory.createIntersectionType(
+                new ClassType(class1, new Map(), false),
+                new ClassType(class2, new Map(), false),
+                new EnumType(enum1, false),
+                new EnumVariantType(enumVariant1, false),
+            ),
+        },
+        {
             type: factory.createLiteralType(new BooleanConstant(true)),
             expectedType: factory.createLiteralType(new BooleanConstant(true)),
         },
@@ -502,6 +553,36 @@ describe('type model', async () => {
             ),
         },
         {
+            type: factory.createIntersectionType(),
+            isNullable: true,
+            expectedType: coreTypes.AnyOrNull,
+        },
+        {
+            type: factory.createIntersectionType(),
+            isNullable: false,
+            expectedType: coreTypes.Any,
+        },
+        {
+            type: factory.createIntersectionType(new ClassType(class1, new Map(), false)),
+            isNullable: true,
+            expectedType: factory.createIntersectionType(new ClassType(class1, new Map(), true)),
+        },
+        {
+            type: factory.createIntersectionType(new ClassType(class1, new Map(), false)),
+            isNullable: false,
+            expectedType: factory.createIntersectionType(new ClassType(class1, new Map(), false)),
+        },
+        {
+            type: factory.createIntersectionType(new ClassType(class1, new Map(), true)),
+            isNullable: true,
+            expectedType: factory.createIntersectionType(new ClassType(class1, new Map(), true)),
+        },
+        {
+            type: factory.createIntersectionType(new ClassType(class1, new Map(), true)),
+            isNullable: false,
+            expectedType: factory.createIntersectionType(new ClassType(class1, new Map(), false)),
+        },
+        {
             type: factory.createLiteralType(new BooleanConstant(true)),
             isNullable: true,
             expectedType: factory.createLiteralType(new BooleanConstant(true), NullConstant),
@@ -595,7 +676,7 @@ describe('type model', async () => {
         {
             type: factory.createUnionType(),
             isNullable: false,
-            expectedType: factory.createUnionType(),
+            expectedType: coreTypes.Nothing,
         },
         {
             type: factory.createUnionType(new ClassType(class1, new Map(), false)),

--- a/packages/safe-ds-lang/tests/language/typing/model.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/model.test.ts
@@ -513,7 +513,7 @@ describe('type model', async () => {
     ];
     describe.each(unwrapTests)('unwrap', ({ type, expectedType }) => {
         it(`should remove any unnecessary containers (${type.constructor.name} -- ${type})`, () => {
-            const actual = type.unwrap();
+            const actual = type.simplify();
             expectEqualTypes(actual, expectedType);
         });
     });
@@ -812,7 +812,7 @@ interface SubstituteTypeParametersTest {
 }
 
 /**
- * Tests for {@link Type.unwrap}.
+ * Tests for {@link Type.simplify}.
  */
 interface UnwrapTest {
     /**

--- a/packages/safe-ds-lang/tests/language/typing/type checker/canBeTypeOfConstantParameter.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/type checker/canBeTypeOfConstantParameter.test.ts
@@ -106,8 +106,8 @@ describe('SafeDsTypeChecker', async () => {
             expect(typeChecker.canBeTypeOfConstantParameter(type)).toBe(expected);
         });
 
-        it(type.updateExplicitNullability(true).toString, () => {
-            expect(typeChecker.canBeTypeOfConstantParameter(type.updateExplicitNullability(true))).toBe(expected);
+        it(type.withExplicitNullability(true).toString, () => {
+            expect(typeChecker.canBeTypeOfConstantParameter(type.withExplicitNullability(true))).toBe(expected);
         });
     });
 });

--- a/packages/safe-ds-lang/tests/language/typing/type checker/canBeTypeOfConstantParameter.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/type checker/canBeTypeOfConstantParameter.test.ts
@@ -2,18 +2,12 @@ import { NodeFileSystem } from 'langium/node';
 import { describe, expect, it } from 'vitest';
 import { isSdsClass, isSdsEnum, isSdsModule } from '../../../../src/language/generated/ast.js';
 import { createSafeDsServicesWithBuiltins, getEnumVariants, getModuleMembers } from '../../../../src/language/index.js';
-import {
-    ClassType,
-    EnumType,
-    EnumVariantType,
-    LiteralType,
-    Type,
-    UnknownType,
-} from '../../../../src/language/typing/model.js';
+import { ClassType, EnumType, EnumVariantType, Type, UnknownType } from '../../../../src/language/typing/model.js';
 import { getNodeOfType } from '../../../helpers/nodeFinder.js';
 
 const services = (await createSafeDsServicesWithBuiltins(NodeFileSystem)).SafeDs;
 const coreTypes = services.types.CoreTypes;
+const factory = services.types.TypeFactory;
 const typeChecker = services.types.TypeChecker;
 const typeComputer = services.types.TypeComputer;
 
@@ -98,7 +92,7 @@ describe('SafeDsTypeChecker', async () => {
             expected: false,
         },
         {
-            type: new LiteralType(),
+            type: factory.createLiteralType(),
             expected: true,
         },
         {

--- a/packages/safe-ds-lang/tests/language/typing/type checker/isSubOrSupertypeOf.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/type checker/isSubOrSupertypeOf.test.ts
@@ -222,13 +222,13 @@ const basic = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             expected: true,
         },
         {
-            type1: classType2.updateExplicitNullability(true),
+            type1: classType2.withExplicitNullability(true),
             type2: classType1,
             expected: false,
         },
         {
-            type1: classType2.updateExplicitNullability(true),
-            type2: classType1.updateExplicitNullability(true),
+            type1: classType2.withExplicitNullability(true),
+            type2: classType1.withExplicitNullability(true),
             expected: true,
         },
         // Class type to union type
@@ -260,12 +260,12 @@ const basic = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             expected: true,
         },
         {
-            type1: enumType1.updateExplicitNullability(true),
+            type1: enumType1.withExplicitNullability(true),
             type2: coreTypes.Any,
             expected: false,
         },
         {
-            type1: enumType1.updateExplicitNullability(true),
+            type1: enumType1.withExplicitNullability(true),
             type2: coreTypes.AnyOrNull,
             expected: true,
         },
@@ -281,13 +281,13 @@ const basic = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             expected: false,
         },
         {
-            type1: enumType1.updateExplicitNullability(true),
+            type1: enumType1.withExplicitNullability(true),
             type2: enumType1,
             expected: false,
         },
         {
-            type1: enumType1.updateExplicitNullability(true),
-            type2: enumType1.updateExplicitNullability(true),
+            type1: enumType1.withExplicitNullability(true),
+            type2: enumType1.withExplicitNullability(true),
             expected: true,
         },
         // Enum type to union type
@@ -319,12 +319,12 @@ const basic = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             expected: true,
         },
         {
-            type1: enumVariantType1.updateExplicitNullability(true),
+            type1: enumVariantType1.withExplicitNullability(true),
             type2: coreTypes.Any,
             expected: false,
         },
         {
-            type1: enumVariantType1.updateExplicitNullability(true),
+            type1: enumVariantType1.withExplicitNullability(true),
             type2: coreTypes.AnyOrNull,
             expected: true,
         },
@@ -340,13 +340,13 @@ const basic = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             expected: false,
         },
         {
-            type1: enumVariantType1.updateExplicitNullability(true),
+            type1: enumVariantType1.withExplicitNullability(true),
             type2: enumType1,
             expected: false,
         },
         {
-            type1: enumVariantType1.updateExplicitNullability(true),
-            type2: enumType1.updateExplicitNullability(true),
+            type1: enumVariantType1.withExplicitNullability(true),
+            type2: enumType1.withExplicitNullability(true),
             expected: true,
         },
         // Enum variant type to enum variant type
@@ -361,13 +361,13 @@ const basic = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             expected: false,
         },
         {
-            type1: enumVariantType1.updateExplicitNullability(true),
+            type1: enumVariantType1.withExplicitNullability(true),
             type2: enumVariantType1,
             expected: false,
         },
         {
-            type1: enumVariantType1.updateExplicitNullability(true),
-            type2: enumVariantType1.updateExplicitNullability(true),
+            type1: enumVariantType1.withExplicitNullability(true),
+            type2: enumVariantType1.withExplicitNullability(true),
             expected: true,
         },
         // Enum variant type to union type
@@ -430,7 +430,7 @@ const basic = async (): Promise<IsSubOrSupertypeOfTest[]> => {
         },
         {
             type1: factory.createLiteralType(new IntConstant(1n), NullConstant),
-            type2: coreTypes.Int.updateExplicitNullability(true),
+            type2: coreTypes.Int.withExplicitNullability(true),
             expected: true,
         },
         {
@@ -513,12 +513,12 @@ const basic = async (): Promise<IsSubOrSupertypeOfTest[]> => {
         },
         {
             type1: factory.createLiteralType(NullConstant),
-            type2: enumType1.updateExplicitNullability(true),
+            type2: enumType1.withExplicitNullability(true),
             expected: true,
         },
         {
             type1: factory.createLiteralType(NullConstant, NullConstant),
-            type2: enumType1.updateExplicitNullability(true),
+            type2: enumType1.withExplicitNullability(true),
             expected: true,
         },
         {
@@ -643,13 +643,13 @@ const basic = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             expected: false,
         },
         {
-            type1: factory.createUnionType(classType1.updateExplicitNullability(true)),
+            type1: factory.createUnionType(classType1.withExplicitNullability(true)),
             type2: classType1,
             expected: false,
         },
         {
-            type1: factory.createUnionType(classType1.updateExplicitNullability(true)),
-            type2: classType1.updateExplicitNullability(true),
+            type1: factory.createUnionType(classType1.withExplicitNullability(true)),
+            type2: classType1.withExplicitNullability(true),
             expected: true,
         },
         // Unknown to X
@@ -1121,7 +1121,7 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             expected: true,
         },
         {
-            type1: coreTypes.Number.updateExplicitNullability(true),
+            type1: coreTypes.Number.withExplicitNullability(true),
             type2: lowerBound,
             expected: true,
         },
@@ -1183,13 +1183,13 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             expected: true,
         },
         {
-            type1: coreTypes.Number.updateExplicitNullability(true),
+            type1: coreTypes.Number.withExplicitNullability(true),
             type2: upperBound,
             expected: false,
         },
         {
-            type1: coreTypes.Number.updateExplicitNullability(true),
-            type2: upperBound.updateExplicitNullability(true),
+            type1: coreTypes.Number.withExplicitNullability(true),
+            type2: upperBound.withExplicitNullability(true),
             expected: true,
         },
         {
@@ -1250,13 +1250,13 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             expected: true,
         },
         {
-            type1: coreTypes.Number.updateExplicitNullability(true),
+            type1: coreTypes.Number.withExplicitNullability(true),
             type2: bothBounds,
             expected: false,
         },
         {
-            type1: coreTypes.Number.updateExplicitNullability(true),
-            type2: bothBounds.updateExplicitNullability(true),
+            type1: coreTypes.Number.withExplicitNullability(true),
+            type2: bothBounds.withExplicitNullability(true),
             expected: true,
         },
         {
@@ -1265,13 +1265,13 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             expected: true,
         },
         {
-            type1: coreTypes.Int.updateExplicitNullability(true),
+            type1: coreTypes.Int.withExplicitNullability(true),
             type2: bothBounds,
             expected: false,
         },
         {
-            type1: coreTypes.Int.updateExplicitNullability(true),
-            type2: bothBounds.updateExplicitNullability(true),
+            type1: coreTypes.Int.withExplicitNullability(true),
+            type2: bothBounds.withExplicitNullability(true),
             expected: true,
         },
         {
@@ -1360,12 +1360,12 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             expected: true,
         },
         {
-            type1: unbounded.updateExplicitNullability(true),
+            type1: unbounded.withExplicitNullability(true),
             type2: coreTypes.Any,
             expected: false,
         },
         {
-            type1: unbounded.updateExplicitNullability(true),
+            type1: unbounded.withExplicitNullability(true),
             type2: coreTypes.AnyOrNull,
             expected: true,
         },
@@ -1380,12 +1380,12 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             expected: true,
         },
         {
-            type1: lowerBound.updateExplicitNullability(true),
+            type1: lowerBound.withExplicitNullability(true),
             type2: coreTypes.Any,
             expected: false,
         },
         {
-            type1: lowerBound.updateExplicitNullability(true),
+            type1: lowerBound.withExplicitNullability(true),
             type2: coreTypes.AnyOrNull,
             expected: true,
         },
@@ -1395,7 +1395,7 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             expected: true,
         },
         {
-            type1: upperBound.updateExplicitNullability(true),
+            type1: upperBound.withExplicitNullability(true),
             type2: coreTypes.AnyOrNull,
             expected: true,
         },
@@ -1405,17 +1405,17 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             expected: true,
         },
         {
-            type1: upperBound.updateExplicitNullability(true),
+            type1: upperBound.withExplicitNullability(true),
             type2: coreTypes.Any,
             expected: false,
         },
         {
-            type1: upperBound.updateExplicitNullability(true),
+            type1: upperBound.withExplicitNullability(true),
             type2: coreTypes.AnyOrNull,
             expected: true,
         },
         {
-            type1: upperBound.updateExplicitNullability(true),
+            type1: upperBound.withExplicitNullability(true),
             type2: coreTypes.Number,
             expected: false,
         },
@@ -1425,7 +1425,7 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             expected: true,
         },
         {
-            type1: bothBounds.updateExplicitNullability(true),
+            type1: bothBounds.withExplicitNullability(true),
             type2: coreTypes.AnyOrNull,
             expected: true,
         },
@@ -1435,17 +1435,17 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             expected: true,
         },
         {
-            type1: bothBounds.updateExplicitNullability(true),
+            type1: bothBounds.withExplicitNullability(true),
             type2: coreTypes.Any,
             expected: false,
         },
         {
-            type1: bothBounds.updateExplicitNullability(true),
+            type1: bothBounds.withExplicitNullability(true),
             type2: coreTypes.AnyOrNull,
             expected: true,
         },
         {
-            type1: bothBounds.updateExplicitNullability(true),
+            type1: bothBounds.withExplicitNullability(true),
             type2: coreTypes.Number,
             expected: false,
         },

--- a/packages/safe-ds-lang/tests/language/typing/type checker/isSubOrSupertypeOf.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/type checker/isSubOrSupertypeOf.test.ts
@@ -28,18 +28,15 @@ import {
     ClassType,
     EnumType,
     EnumVariantType,
-    LiteralType,
     NamedTupleEntry,
-    NamedTupleType,
-    StaticType,
     Type,
-    UnionType,
     UnknownType,
 } from '../../../../src/language/typing/model.js';
 import { getNodeOfType } from '../../../helpers/nodeFinder.js';
 
 const services = (await createSafeDsServicesWithBuiltins(NodeFileSystem)).SafeDs;
 const coreTypes = services.types.CoreTypes;
+const factory = services.types.TypeFactory;
 const typeChecker = services.types.TypeChecker;
 const typeComputer = services.types.TypeComputer;
 
@@ -237,12 +234,12 @@ const basic = async (): Promise<IsSubOrSupertypeOfTest[]> => {
         // Class type to union type
         {
             type1: classType1,
-            type2: new UnionType(classType1),
+            type2: factory.createUnionType(classType1),
             expected: true,
         },
         {
             type1: classType1,
-            type2: new UnionType(classType3),
+            type2: factory.createUnionType(classType3),
             expected: false,
         },
         // Class type to other
@@ -296,18 +293,18 @@ const basic = async (): Promise<IsSubOrSupertypeOfTest[]> => {
         // Enum type to union type
         {
             type1: enumType1,
-            type2: new UnionType(enumType1),
+            type2: factory.createUnionType(enumType1),
             expected: true,
         },
         {
             type1: enumType1,
-            type2: new UnionType(enumType2),
+            type2: factory.createUnionType(enumType2),
             expected: false,
         },
         // Enum type to other
         {
             type1: enumType1,
-            type2: new LiteralType(),
+            type2: factory.createLiteralType(),
             expected: false,
         },
         // Enum variant type to class type
@@ -376,282 +373,282 @@ const basic = async (): Promise<IsSubOrSupertypeOfTest[]> => {
         // Enum variant type to union type
         {
             type1: enumVariantType1,
-            type2: new UnionType(enumType1),
+            type2: factory.createUnionType(enumType1),
             expected: true,
         },
         {
             type1: enumVariantType1,
-            type2: new UnionType(enumType2),
+            type2: factory.createUnionType(enumType2),
             expected: false,
         },
         // Enum variant type to other
         {
             type1: enumVariantType1,
-            type2: new LiteralType(),
+            type2: factory.createLiteralType(),
             expected: false,
         },
         // Literal type to class type
         {
-            type1: new LiteralType(),
+            type1: factory.createLiteralType(),
             type2: classType1,
             expected: true,
         },
         {
-            type1: new LiteralType(new BooleanConstant(true)),
+            type1: factory.createLiteralType(new BooleanConstant(true)),
             type2: coreTypes.Boolean,
             expected: true,
         },
         {
-            type1: new LiteralType(new FloatConstant(1.5)),
+            type1: factory.createLiteralType(new FloatConstant(1.5)),
             type2: coreTypes.Float,
             expected: true,
         },
         {
-            type1: new LiteralType(new IntConstant(1n)),
+            type1: factory.createLiteralType(new IntConstant(1n)),
             type2: coreTypes.Int,
             expected: true,
         },
         {
-            type1: new LiteralType(NullConstant),
+            type1: factory.createLiteralType(NullConstant),
             type2: coreTypes.NothingOrNull,
             expected: true,
         },
         {
-            type1: new LiteralType(new StringConstant('')),
+            type1: factory.createLiteralType(new StringConstant('')),
             type2: coreTypes.String,
             expected: true,
         },
         {
-            type1: new LiteralType(new IntConstant(1n)),
+            type1: factory.createLiteralType(new IntConstant(1n)),
             type2: coreTypes.Any,
             expected: true,
         },
         {
-            type1: new LiteralType(new IntConstant(1n)),
+            type1: factory.createLiteralType(new IntConstant(1n)),
             type2: coreTypes.String,
             expected: false,
         },
         {
-            type1: new LiteralType(new IntConstant(1n), NullConstant),
+            type1: factory.createLiteralType(new IntConstant(1n), NullConstant),
             type2: coreTypes.Int.updateExplicitNullability(true),
             expected: true,
         },
         {
-            type1: new LiteralType(new IntConstant(1n), NullConstant),
+            type1: factory.createLiteralType(new IntConstant(1n), NullConstant),
             type2: coreTypes.Int,
             expected: false,
         },
         {
-            type1: new LiteralType(new IntConstant(1n), new StringConstant('')),
+            type1: factory.createLiteralType(new IntConstant(1n), new StringConstant('')),
             type2: coreTypes.Int,
             expected: false,
         },
         {
-            type1: new LiteralType(new IntConstant(1n), new StringConstant('')),
+            type1: factory.createLiteralType(new IntConstant(1n), new StringConstant('')),
             type2: coreTypes.String,
             expected: false,
         },
         {
-            type1: new LiteralType(new IntConstant(1n), new StringConstant('')),
+            type1: factory.createLiteralType(new IntConstant(1n), new StringConstant('')),
             type2: coreTypes.Any,
             expected: true,
         },
         {
-            type1: new LiteralType(new IntConstant(1n), new StringConstant(''), NullConstant),
+            type1: factory.createLiteralType(new IntConstant(1n), new StringConstant(''), NullConstant),
             type2: coreTypes.AnyOrNull,
             expected: true,
         },
         // Literal type to literal type
         {
-            type1: new LiteralType(),
-            type2: new LiteralType(),
+            type1: factory.createLiteralType(),
+            type2: factory.createLiteralType(),
             expected: true,
         },
         {
-            type1: new LiteralType(new BooleanConstant(true)),
-            type2: new LiteralType(new BooleanConstant(true)),
+            type1: factory.createLiteralType(new BooleanConstant(true)),
+            type2: factory.createLiteralType(new BooleanConstant(true)),
             expected: true,
         },
         {
-            type1: new LiteralType(new BooleanConstant(true)),
-            type2: new LiteralType(new BooleanConstant(false)),
+            type1: factory.createLiteralType(new BooleanConstant(true)),
+            type2: factory.createLiteralType(new BooleanConstant(false)),
             expected: false,
         },
         {
-            type1: new LiteralType(new BooleanConstant(true)),
-            type2: new LiteralType(new FloatConstant(1.5)),
+            type1: factory.createLiteralType(new BooleanConstant(true)),
+            type2: factory.createLiteralType(new FloatConstant(1.5)),
             expected: false,
         },
         {
-            type1: new LiteralType(new BooleanConstant(true), NullConstant),
-            type2: new LiteralType(new BooleanConstant(true), NullConstant),
+            type1: factory.createLiteralType(new BooleanConstant(true), NullConstant),
+            type2: factory.createLiteralType(new BooleanConstant(true), NullConstant),
             expected: true,
         },
         {
-            type1: new LiteralType(new BooleanConstant(true), NullConstant),
-            type2: new LiteralType(new BooleanConstant(true)),
+            type1: factory.createLiteralType(new BooleanConstant(true), NullConstant),
+            type2: factory.createLiteralType(new BooleanConstant(true)),
             expected: false,
         },
         // Literal type to union type
         {
-            type1: new LiteralType(new IntConstant(1n)),
-            type2: new UnionType(coreTypes.Any),
+            type1: factory.createLiteralType(new IntConstant(1n)),
+            type2: factory.createUnionType(coreTypes.Any),
             expected: true,
         },
         {
-            type1: new LiteralType(new IntConstant(1n)),
-            type2: new UnionType(coreTypes.String),
+            type1: factory.createLiteralType(new IntConstant(1n)),
+            type2: factory.createUnionType(coreTypes.String),
             expected: false,
         },
         // Literal type to other
         {
-            type1: new LiteralType(), // Empty literal type
+            type1: factory.createLiteralType(), // Empty literal type
             type2: enumType1,
             expected: true,
         },
         {
-            type1: new LiteralType(NullConstant),
+            type1: factory.createLiteralType(NullConstant),
             type2: enumType1,
             expected: false,
         },
         {
-            type1: new LiteralType(NullConstant),
+            type1: factory.createLiteralType(NullConstant),
             type2: enumType1.updateExplicitNullability(true),
             expected: true,
         },
         {
-            type1: new LiteralType(NullConstant, NullConstant),
+            type1: factory.createLiteralType(NullConstant, NullConstant),
             type2: enumType1.updateExplicitNullability(true),
             expected: true,
         },
         {
-            type1: new LiteralType(new IntConstant(1n)),
+            type1: factory.createLiteralType(new IntConstant(1n)),
             type2: enumType1,
             expected: false,
         },
         // Named tuple type to named tuple type
         {
-            type1: new NamedTupleType(),
-            type2: new NamedTupleType(),
+            type1: factory.createNamedTupleType(),
+            type2: factory.createNamedTupleType(),
             expected: true,
         },
         {
-            type1: new NamedTupleType(new NamedTupleEntry(undefined, 'a', coreTypes.Int)),
-            type2: new NamedTupleType(new NamedTupleEntry(undefined, 'a', coreTypes.Int)),
+            type1: factory.createNamedTupleType(new NamedTupleEntry(undefined, 'a', coreTypes.Int)),
+            type2: factory.createNamedTupleType(new NamedTupleEntry(undefined, 'a', coreTypes.Int)),
             expected: true,
         },
         {
-            type1: new NamedTupleType(new NamedTupleEntry(class1, 'a', coreTypes.Int)),
-            type2: new NamedTupleType(new NamedTupleEntry(class2, 'a', coreTypes.Int)),
+            type1: factory.createNamedTupleType(new NamedTupleEntry(class1, 'a', coreTypes.Int)),
+            type2: factory.createNamedTupleType(new NamedTupleEntry(class2, 'a', coreTypes.Int)),
             expected: true,
         },
         {
-            type1: new NamedTupleType(new NamedTupleEntry(undefined, 'a', coreTypes.Int)),
-            type2: new NamedTupleType(new NamedTupleEntry(undefined, 'a', coreTypes.Any)),
+            type1: factory.createNamedTupleType(new NamedTupleEntry(undefined, 'a', coreTypes.Int)),
+            type2: factory.createNamedTupleType(new NamedTupleEntry(undefined, 'a', coreTypes.Any)),
             expected: true,
         },
         {
-            type1: new NamedTupleType(new NamedTupleEntry(undefined, 'a', coreTypes.Any)),
-            type2: new NamedTupleType(new NamedTupleEntry(undefined, 'a', coreTypes.Int)),
+            type1: factory.createNamedTupleType(new NamedTupleEntry(undefined, 'a', coreTypes.Any)),
+            type2: factory.createNamedTupleType(new NamedTupleEntry(undefined, 'a', coreTypes.Int)),
             expected: false,
         },
         {
-            type1: new NamedTupleType(new NamedTupleEntry(undefined, 'a', coreTypes.Int)),
-            type2: new NamedTupleType(new NamedTupleEntry(undefined, 'b', coreTypes.Int)),
+            type1: factory.createNamedTupleType(new NamedTupleEntry(undefined, 'a', coreTypes.Int)),
+            type2: factory.createNamedTupleType(new NamedTupleEntry(undefined, 'b', coreTypes.Int)),
             expected: false,
         },
         // Named tuple type to other
         {
-            type1: new NamedTupleType(),
+            type1: factory.createNamedTupleType(),
             type2: enumType1,
             expected: false,
         },
         // Static type to callable type
         {
-            type1: new StaticType(classType1),
+            type1: factory.createStaticType(classType1),
             type2: callableType1,
             expected: false,
         },
         {
-            type1: new StaticType(classType1),
+            type1: factory.createStaticType(classType1),
             type2: callableType3,
             expected: true,
         },
         {
-            type1: new StaticType(classType2),
+            type1: factory.createStaticType(classType2),
             type2: callableType11,
             expected: true,
         },
         {
-            type1: new StaticType(classType3),
+            type1: factory.createStaticType(classType3),
             type2: callableType1,
             expected: false,
         },
         {
-            type1: new StaticType(enumType1),
+            type1: factory.createStaticType(enumType1),
             type2: callableType1,
             expected: false,
         },
         {
-            type1: new StaticType(enumVariantType1),
+            type1: factory.createStaticType(enumVariantType1),
             type2: callableType1,
             expected: false,
         },
         {
-            type1: new StaticType(enumVariantType1),
+            type1: factory.createStaticType(enumVariantType1),
             type2: callableType3,
             expected: true,
         },
         {
-            type1: new StaticType(enumVariantType2),
+            type1: factory.createStaticType(enumVariantType2),
             type2: callableType12,
             expected: true,
         },
         // Static type to static type
         {
-            type1: new StaticType(classType1),
-            type2: new StaticType(classType1),
+            type1: factory.createStaticType(classType1),
+            type2: factory.createStaticType(classType1),
             expected: true,
         },
         {
-            type1: new StaticType(classType1),
-            type2: new StaticType(classType2),
+            type1: factory.createStaticType(classType1),
+            type2: factory.createStaticType(classType2),
             expected: false,
         },
         // Static type to other
         {
-            type1: new StaticType(classType1),
+            type1: factory.createStaticType(classType1),
             type2: enumType1,
             expected: false,
         },
         // Union type to X
         {
-            type1: new UnionType(),
+            type1: factory.createUnionType(),
             type2: classType1,
             expected: true,
         },
         {
-            type1: new UnionType(classType1),
+            type1: factory.createUnionType(classType1),
             type2: classType1,
             expected: true,
         },
         {
-            type1: new UnionType(classType1, classType2),
+            type1: factory.createUnionType(classType1, classType2),
             type2: classType1,
             expected: true,
         },
         {
-            type1: new UnionType(classType1, classType3),
+            type1: factory.createUnionType(classType1, classType3),
             type2: classType1,
             expected: false,
         },
         {
-            type1: new UnionType(classType1.updateExplicitNullability(true)),
+            type1: factory.createUnionType(classType1.updateExplicitNullability(true)),
             type2: classType1,
             expected: false,
         },
         {
-            type1: new UnionType(classType1.updateExplicitNullability(true)),
+            type1: factory.createUnionType(classType1.updateExplicitNullability(true)),
             type2: classType1.updateExplicitNullability(true),
             expected: true,
         },

--- a/packages/safe-ds-lang/tests/language/typing/type computer/computeClassTypeForLiteralType.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/type computer/computeClassTypeForLiteralType.test.ts
@@ -13,74 +13,75 @@ import { expectEqualTypes } from '../../../helpers/testAssertions.js';
 
 const services = (await createSafeDsServicesWithBuiltins(NodeFileSystem)).SafeDs;
 const coreTypes = services.types.CoreTypes;
+const factory = services.types.TypeFactory;
 const typeComputer = services.types.TypeComputer;
 
 const tests: ComputeClassTypeForLiteralTypeTest[] = [
     // Base cases
     {
-        literalType: new LiteralType(),
+        literalType: factory.createLiteralType(),
         expected: coreTypes.Nothing,
     },
     {
-        literalType: new LiteralType(new BooleanConstant(false)),
+        literalType: factory.createLiteralType(new BooleanConstant(false)),
         expected: coreTypes.Boolean,
     },
     {
-        literalType: new LiteralType(new FloatConstant(1.5)),
+        literalType: factory.createLiteralType(new FloatConstant(1.5)),
         expected: coreTypes.Float,
     },
     {
-        literalType: new LiteralType(new IntConstant(1n)),
+        literalType: factory.createLiteralType(new IntConstant(1n)),
         expected: coreTypes.Int,
     },
     {
-        literalType: new LiteralType(NullConstant),
+        literalType: factory.createLiteralType(NullConstant),
         expected: coreTypes.NothingOrNull,
     },
     {
-        literalType: new LiteralType(new StringConstant('')),
+        literalType: factory.createLiteralType(new StringConstant('')),
         expected: coreTypes.String,
     },
     // Nullable types
     {
-        literalType: new LiteralType(new BooleanConstant(false), NullConstant),
+        literalType: factory.createLiteralType(new BooleanConstant(false), NullConstant),
         expected: coreTypes.Boolean.updateExplicitNullability(true),
     },
     {
-        literalType: new LiteralType(new FloatConstant(1.5), NullConstant),
+        literalType: factory.createLiteralType(new FloatConstant(1.5), NullConstant),
         expected: coreTypes.Float.updateExplicitNullability(true),
     },
     {
-        literalType: new LiteralType(new IntConstant(1n), NullConstant),
+        literalType: factory.createLiteralType(new IntConstant(1n), NullConstant),
         expected: coreTypes.Int.updateExplicitNullability(true),
     },
     {
-        literalType: new LiteralType(new StringConstant(''), NullConstant),
+        literalType: factory.createLiteralType(new StringConstant(''), NullConstant),
         expected: coreTypes.String.updateExplicitNullability(true),
     },
     // Other combinations
     {
-        literalType: new LiteralType(new BooleanConstant(false), new FloatConstant(1.5)),
+        literalType: factory.createLiteralType(new BooleanConstant(false), new FloatConstant(1.5)),
         expected: coreTypes.Any,
     },
     {
-        literalType: new LiteralType(new FloatConstant(1.5), new IntConstant(1n)),
+        literalType: factory.createLiteralType(new FloatConstant(1.5), new IntConstant(1n)),
         expected: coreTypes.Number,
     },
     {
-        literalType: new LiteralType(new IntConstant(1n), new StringConstant('')),
+        literalType: factory.createLiteralType(new IntConstant(1n), new StringConstant('')),
         expected: coreTypes.Any,
     },
     {
-        literalType: new LiteralType(new BooleanConstant(false), new FloatConstant(1.5), NullConstant),
+        literalType: factory.createLiteralType(new BooleanConstant(false), new FloatConstant(1.5), NullConstant),
         expected: coreTypes.AnyOrNull,
     },
     {
-        literalType: new LiteralType(new FloatConstant(1.5), new IntConstant(1n), NullConstant),
+        literalType: factory.createLiteralType(new FloatConstant(1.5), new IntConstant(1n), NullConstant),
         expected: coreTypes.Number.updateExplicitNullability(true),
     },
     {
-        literalType: new LiteralType(new IntConstant(1n), new StringConstant(''), NullConstant),
+        literalType: factory.createLiteralType(new IntConstant(1n), new StringConstant(''), NullConstant),
         expected: coreTypes.AnyOrNull,
     },
 ];

--- a/packages/safe-ds-lang/tests/language/typing/type computer/computeClassTypeForLiteralType.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/type computer/computeClassTypeForLiteralType.test.ts
@@ -45,19 +45,19 @@ const tests: ComputeClassTypeForLiteralTypeTest[] = [
     // Nullable types
     {
         literalType: factory.createLiteralType(new BooleanConstant(false), NullConstant),
-        expected: coreTypes.Boolean.updateExplicitNullability(true),
+        expected: coreTypes.Boolean.withExplicitNullability(true),
     },
     {
         literalType: factory.createLiteralType(new FloatConstant(1.5), NullConstant),
-        expected: coreTypes.Float.updateExplicitNullability(true),
+        expected: coreTypes.Float.withExplicitNullability(true),
     },
     {
         literalType: factory.createLiteralType(new IntConstant(1n), NullConstant),
-        expected: coreTypes.Int.updateExplicitNullability(true),
+        expected: coreTypes.Int.withExplicitNullability(true),
     },
     {
         literalType: factory.createLiteralType(new StringConstant(''), NullConstant),
-        expected: coreTypes.String.updateExplicitNullability(true),
+        expected: coreTypes.String.withExplicitNullability(true),
     },
     // Other combinations
     {
@@ -78,7 +78,7 @@ const tests: ComputeClassTypeForLiteralTypeTest[] = [
     },
     {
         literalType: factory.createLiteralType(new FloatConstant(1.5), new IntConstant(1n), NullConstant),
-        expected: coreTypes.Number.updateExplicitNullability(true),
+        expected: coreTypes.Number.withExplicitNullability(true),
     },
     {
         literalType: factory.createLiteralType(new IntConstant(1n), new StringConstant(''), NullConstant),

--- a/packages/safe-ds-lang/tests/resources/typing/simplification/unwrap/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/simplification/unwrap/main.sdstest
@@ -1,9 +1,46 @@
 package tests.typing.simplification.unwrap
 
-class C(
-    // $TEST$ serialization union<String, Int, Boolean>
-    p1: »union<union<String, Int>, Boolean>«,
+segment callableType(
+    // $TEST$ serialization () -> ()
+    f1: »() -> ()«,
+
+    // $TEST$ serialization (p: String) -> (r: String)
+    f2: »(p: union<union<String>>) -> (r: union<union<String>>)«
+) {}
+
+segment namedTupleType(
+    f1: () -> (),
+    f2: () -> (r: String),
+    f3: () -> (r1: union<union<String>>, r2: union<union<String>>)
+) {
+    // $TEST$ serialization ()
+    »f1()«;
 
     // $TEST$ serialization String
-    p2: »union<union<String>>«
-)
+    »f2()«;
+
+    // $TEST$ serialization (r1: String, r2: String)
+    »f3()«;
+}
+
+segment classType(
+    // $TEST$ serialization String
+    p1: »String«,
+
+    // $TEST$ serialization List<String>
+    p2: »List<String>«,
+
+    // $TEST$ serialization List<String>
+    p3: »List<union<union<String>>>«,
+) {}
+
+segment unionType(
+    // $TEST$ serialization String
+    p1: »union<String>«,
+
+    // $TEST$ serialization String
+    p2: »union<union<String>>«,
+
+    // $TEST$ serialization union<String, Int, Boolean>
+    p3: »union<union<String, Int>, Boolean>«,
+) {}


### PR DESCRIPTION
### Summary of Changes

* Inject services into type instances where needed.
* Add a factory service to create type instance using a similar interface to the previous constructors.
* Types can now simplify themselves.
* Add an intersection type.