### PR TITLE
feat: include enum name in string conversion of enum variant types

### DIFF
--- a/packages/safe-ds-lang/src/language/typing/model.ts
+++ b/packages/safe-ds-lang/src/language/typing/model.ts
@@ -1,5 +1,6 @@
 import { isEmpty } from '../../helpers/collections.js';
 import {
+    isSdsEnum,
     SdsAbstractResult,
     SdsCallable,
     SdsClass,
@@ -11,7 +12,7 @@ import {
 } from '../generated/ast.js';
 import { getTypeParameters, Parameter } from '../helpers/nodeProperties.js';
 import { Constant, NullConstant } from '../partialEvaluation/model.js';
-import { stream } from 'langium';
+import { getContainerOfType, stream } from 'langium';
 import { SafeDsCoreTypes } from './safe-ds-core-types.js';
 import { SafeDsServices } from '../safe-ds-module.js';
 import { SafeDsTypeFactory } from './safe-ds-type-factory.js';
@@ -510,6 +511,16 @@ export class EnumVariantType extends NamedType<SdsEnumVariant> {
 
     override substituteTypeParameters(_substitutions: TypeParameterSubstitutions): Type {
         return this;
+    }
+
+    override toString(): string {
+        const containingEnum = getContainerOfType(this.declaration, isSdsEnum);
+        if (containingEnum) {
+            return `${containingEnum.name}.${super.toString()}`;
+        } else {
+            /* c8 ignore next 2 */
+            return super.toString();
+        }
     }
 
     override withExplicitNullability(isExplicitlyNullable: boolean): EnumVariantType {

--- a/packages/safe-ds-lang/tests/language/typing/model.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/model.test.ts
@@ -205,11 +205,11 @@ describe('type model', async () => {
         },
         {
             value: new EnumVariantType(enumVariant1, false),
-            expectedString: 'MyEnumVariant1',
+            expectedString: 'MyEnum1.MyEnumVariant1',
         },
         {
             value: new EnumVariantType(enumVariant1, true),
-            expectedString: 'MyEnumVariant1?',
+            expectedString: 'MyEnum1.MyEnumVariant1?',
         },
         {
             value: new TypeParameterType(typeParameter1, false),

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/enum variants/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/enum variants/main.sdstest
@@ -1,9 +1,9 @@
 package tests.typing.declarations.enumVariants
 
 enum MyEnum {
-    // $TEST$ serialization MyEnumVariant1
+    // $TEST$ serialization MyEnum.MyEnumVariant1
     »MyEnumVariant1«
 
-    // $TEST$ serialization MyEnumVariant2
+    // $TEST$ serialization MyEnum.MyEnumVariant2
     »MyEnumVariant2«
 }

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/calls/of enum variants/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/calls/of enum variants/main.sdstest
@@ -7,14 +7,14 @@ enum MyEnum {
 }
 
 pipeline myPipeline {
-    // $TEST$ serialization MyEnumVariantWithoutParameterList
+    // $TEST$ serialization MyEnum.MyEnumVariantWithoutParameterList
     »MyEnum.MyEnumVariantWithoutParameterList()«;
 
     // $TEST$ serialization $unknown
     val alias1 = MyEnum.MyEnumVariantWithoutParameterList;
     »alias1()«;
 
-    // $TEST$ serialization MyEnumVariantWithoutParameters
+    // $TEST$ serialization MyEnum.MyEnumVariantWithoutParameters
     »MyEnum.MyEnumVariantWithoutParameters()«;
 
     // $TEST$ serialization $unknown
@@ -28,10 +28,10 @@ pipeline myPipeline {
     val alias3 = MyEnum.MyEnumVariantWithoutParameters();
     »alias3()«;
 
-    // $TEST$ serialization MyEnumVariantWithParameters
+    // $TEST$ serialization MyEnum.MyEnumVariantWithParameters
     »MyEnum.MyEnumVariantWithParameters(1)«;
 
-    // $TEST$ serialization MyEnumVariantWithParameters
+    // $TEST$ serialization MyEnum.MyEnumVariantWithParameters
     val alias4 = MyEnum.MyEnumVariantWithParameters;
     »alias4(1)«;
 
@@ -45,14 +45,14 @@ pipeline myPipeline {
 
     // Null-safe calls -------------------------------------------------------------------------------------------------
 
-    // $TEST$ serialization MyEnumVariantWithoutParameterList
+    // $TEST$ serialization MyEnum.MyEnumVariantWithoutParameterList
     »MyEnum.MyEnumVariantWithoutParameterList?()«;
 
     // $TEST$ serialization $unknown
     val alias1 = MyEnum.MyEnumVariantWithoutParameterList;
     »alias1?()«;
 
-    // $TEST$ serialization MyEnumVariantWithoutParameters
+    // $TEST$ serialization MyEnum.MyEnumVariantWithoutParameters
     »MyEnum.MyEnumVariantWithoutParameters?()«;
 
     // $TEST$ serialization $unknown
@@ -66,10 +66,10 @@ pipeline myPipeline {
     val alias3 = MyEnum.MyEnumVariantWithoutParameters?();
     »alias3?()«;
 
-    // $TEST$ serialization MyEnumVariantWithParameters
+    // $TEST$ serialization MyEnum.MyEnumVariantWithParameters
     »MyEnum.MyEnumVariantWithParameters(1)«;
 
-    // $TEST$ serialization MyEnumVariantWithParameters
+    // $TEST$ serialization MyEnum.MyEnumVariantWithParameters
     val alias4 = MyEnum.MyEnumVariantWithParameters;
     »alias4?(1)«;
 

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/member accesses/to enum variants/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/member accesses/to enum variants/main.sdstest
@@ -7,22 +7,22 @@ enum MyEnum {
 }
 
 pipeline myPipeline {
-    // $TEST$ serialization MyEnumVariantWithoutParameterList
+    // $TEST$ serialization MyEnum.MyEnumVariantWithoutParameterList
     »MyEnum.MyEnumVariantWithoutParameterList«;
 
-    // $TEST$ serialization MyEnumVariantWithoutParameters
+    // $TEST$ serialization MyEnum.MyEnumVariantWithoutParameters
     »MyEnum.MyEnumVariantWithoutParameters«;
 
-    // $TEST$ serialization $type<MyEnumVariantWithParameters>
+    // $TEST$ serialization $type<MyEnum.MyEnumVariantWithParameters>
     »MyEnum.MyEnumVariantWithParameters«;
 
 
-    // $TEST$ serialization MyEnumVariantWithoutParameterList
+    // $TEST$ serialization MyEnum.MyEnumVariantWithoutParameterList
     »MyEnum?.MyEnumVariantWithoutParameterList«;
 
-    // $TEST$ serialization MyEnumVariantWithoutParameters
+    // $TEST$ serialization MyEnum.MyEnumVariantWithoutParameters
     »MyEnum?.MyEnumVariantWithoutParameters«;
 
-    // $TEST$ serialization $type<MyEnumVariantWithParameters>
+    // $TEST$ serialization $type<MyEnum.MyEnumVariantWithParameters>
     »MyEnum?.MyEnumVariantWithParameters«;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/highest common subtype/class type and enum variant/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/highest common subtype/class type and enum variant/main.sdstest
@@ -16,13 +16,13 @@ segment mySegment(
     v: Contravariant<E.V>,
     vOrNull: Contravariant<E.V?>,
 ) {
-    // $TEST$ serialization List<Contravariant<V>>
+    // $TEST$ serialization List<Contravariant<E.V>>
     »[any, v]«;
-    // $TEST$ serialization List<Contravariant<V>>
+    // $TEST$ serialization List<Contravariant<E.V>>
     »[anyOrNull, v]«;
-    // $TEST$ serialization List<Contravariant<V>>
+    // $TEST$ serialization List<Contravariant<E.V>>
     »[any, vOrNull]«;
-    // $TEST$ serialization List<Contravariant<V?>>
+    // $TEST$ serialization List<Contravariant<E.V?>>
     »[anyOrNull, vOrNull]«;
 
     // $TEST$ serialization List<Contravariant<Nothing>>

--- a/packages/safe-ds-lang/tests/resources/typing/highest common subtype/enum type and enum variant type/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/highest common subtype/enum type and enum variant type/main.sdstest
@@ -17,13 +17,13 @@ segment mySegment(
     v2: Contravariant<E2.V2>,
     v2OrNull: Contravariant<E2.V2?>,
 ) {
-    // $TEST$ serialization List<Contravariant<V1>>
+    // $TEST$ serialization List<Contravariant<E1.V1>>
     »[e1, v1]«;
 
-    // $TEST$ serialization List<Contravariant<V1>>
+    // $TEST$ serialization List<Contravariant<E1.V1>>
     »[e1, v1OrNull]«;
 
-    // $TEST$ serialization List<Contravariant<V1?>>
+    // $TEST$ serialization List<Contravariant<E1.V1?>>
     »[e1OrNull, v1OrNull]«;
 
 

--- a/packages/safe-ds-lang/tests/resources/typing/highest common subtype/enum variant type and enum variant type/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/highest common subtype/enum variant type and enum variant type/main.sdstest
@@ -18,13 +18,13 @@ segment mySegment(
     v3: Contravariant<E3.V3>,
     v3OrNull: Contravariant<E3.V3?>
 ) {
-    // $TEST$ serialization List<Contravariant<V1>>
+    // $TEST$ serialization List<Contravariant<E1.V1>>
     »[v1, v1]«;
 
-    // $TEST$ serialization List<Contravariant<V1>>
+    // $TEST$ serialization List<Contravariant<E1.V1>>
     »[v1, v1OrNull]«;
 
-    // $TEST$ serialization List<Contravariant<V1?>>
+    // $TEST$ serialization List<Contravariant<E1.V1?>>
     »[v1OrNull, v1OrNull]«;
 
 

--- a/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/enum variant type and enum variant type/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/enum variant type and enum variant type/main.sdstest
@@ -16,10 +16,10 @@ segment mySegment(
     v3: E3.V3,
     v3OrNull: E3.V3?
 ) {
-    // $TEST$ serialization List<V1>
+    // $TEST$ serialization List<E1.V1>
     »[v1, v1]«;
 
-    // $TEST$ serialization List<V1?>
+    // $TEST$ serialization List<E1.V1?>
     »[v1, v1OrNull]«;
 
 

--- a/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/enum variant type and type parameter type/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/enum variant type and type parameter type/main.sdstest
@@ -23,7 +23,7 @@ class D<
     p1: Any = »[v, unbounded]«,
     // $TEST$ serialization List<Any?>
     p2: Any = »[v, unboundedOrNull]«,
-    // $TEST$ serialization List<V1>
+    // $TEST$ serialization List<E.V1>
     p3: Any = »[v, boundedByEnumVariant]«,
     // $TEST$ serialization List<E>
     p4: Any = »[v, boundedByOtherEnumVariant]«,

--- a/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/singular type after simplification/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/singular type after simplification/main.sdstest
@@ -25,7 +25,7 @@ segment mySegment(
     // $TEST$ serialization List<E>
     »[p1]«;
 
-    // $TEST$ serialization List<V>
+    // $TEST$ serialization List<E.V>
     »[E.V]«;
 
     // $TEST$ serialization List<$type<C>>

--- a/packages/safe-ds-lang/tests/resources/typing/types/member types/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/types/member types/main.sdstest
@@ -29,7 +29,7 @@ fun nullableMemberTypes(
     a: »MyClass.MyNestedClass?«,
     // $TEST$ serialization MyNestedEnum?
     b: »MyClass.MyNestedEnum?«,
-    // $TEST$ serialization MyEnumVariant?
+    // $TEST$ serialization MyEnum.MyEnumVariant?
     d: »MyEnum.MyEnumVariant?«,
     // $TEST$ serialization $unknown
     e: »MyEnum.unresolved?«,


### PR DESCRIPTION
Closes #902

### Summary of Changes

Given the code 

```
enum Kernel {
    Linear
    Poly(degree: Int)
}
```

calling `toString` on the type `Kernel.Linear` now also returns `Kernel.Linear`. Previously, it returned `Linear`, i.e. only the name of the enum variant.