### PR TITLE
feat: escape characters in string conversion of string constants

### DIFF
--- a/packages/safe-ds-lang/src/language/grammar/safe-ds-value-converter.ts
+++ b/packages/safe-ds-lang/src/language/grammar/safe-ds-value-converter.ts
@@ -75,3 +75,31 @@ const handleEscapeSequence = (input: string, index: number, endIndex: number): [
 
     return [current, index + 1];
 };
+
+const replacements = new Map([
+    ['\b', '\\b'],
+    ['\f', '\\f'],
+    ['\n', '\\n'],
+    ['\r', '\\r'],
+    ['\t', '\\t'],
+    ['\v', '\\v'],
+    ['\0', '\\0'],
+    ['"', '\\"'],
+    ['{', '\\{'],
+    ['\\', '\\\\'],
+]);
+
+/**
+ * Escape a string.
+ */
+export const escapeString = (input: string): string => {
+    let result = '';
+
+    for (let i = 0; i < input.length; i++) {
+        const current = input.charAt(i);
+        const replacement = replacements.get(current);
+        result += replacement ? replacement : current;
+    }
+
+    return result;
+};

--- a/packages/safe-ds-lang/src/language/partialEvaluation/model.ts
+++ b/packages/safe-ds-lang/src/language/partialEvaluation/model.ts
@@ -11,6 +11,7 @@ import {
     type SdsParameter,
 } from '../generated/ast.js';
 import { getParameters, streamBlockLambdaResults } from '../helpers/nodeProperties.js';
+import { escapeString } from '../grammar/safe-ds-value-converter.js';
 
 export type ParameterSubstitutions = Map<SdsParameter, EvaluatedNode>;
 export type ResultSubstitutions = Map<SdsAbstractResult, EvaluatedNode>;
@@ -131,11 +132,11 @@ export class StringConstant extends Constant {
     }
 
     override toString(): string {
-        return `"${this.value}"`;
+        return `"${escapeString(this.value)}"`;
     }
 
     override toInterpolationString(): string {
-        return this.value;
+        return escapeString(this.value);
     }
 }
 

--- a/packages/safe-ds-lang/tests/language/grammar/safe-ds-value-converter.test.ts
+++ b/packages/safe-ds-lang/tests/language/grammar/safe-ds-value-converter.test.ts
@@ -11,6 +11,7 @@ import {
     isSdsTemplateStringInner,
     isSdsTemplateStringStart,
 } from '../../../src/language/generated/ast.js';
+import { escapeString } from '../../../src/language/grammar/safe-ds-value-converter.js';
 
 const services = createSafeDsServices(EmptyFileSystem).SafeDs;
 
@@ -213,5 +214,24 @@ describe('runConverter', () => {
             const firstTemplateStringEnd = await getNodeOfType(services, code, isSdsTemplateStringEnd);
             expect(firstTemplateStringEnd.value).toBe(unescaped);
         });
+    });
+});
+
+describe('escapeString', () => {
+    const tests = [
+        { unescaped: '\b', escaped: '\\b' },
+        { unescaped: '\f', escaped: '\\f' },
+        { unescaped: '\n', escaped: '\\n' },
+        { unescaped: '\r', escaped: '\\r' },
+        { unescaped: '\t', escaped: '\\t' },
+        { unescaped: '\v', escaped: '\\v' },
+        { unescaped: '\0', escaped: '\\0' },
+        { unescaped: '"', escaped: '\\"' },
+        { unescaped: '{', escaped: '\\{' },
+        { unescaped: '\\', escaped: '\\\\' },
+    ];
+
+    it.each(tests)('should escape $unescaped', ({ escaped, unescaped }) => {
+        expect(escapeString(unescaped)).toBe(escaped);
     });
 });

--- a/packages/safe-ds-lang/tests/resources/partial evaluation/base cases/string literals (without interpolation)/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/partial evaluation/base cases/string literals (without interpolation)/main.sdstest
@@ -4,6 +4,6 @@ pipeline test {
     // $TEST$ serialization "test"
     »"test"«;
 
-    // $TEST$ serialization "test	"
+    // $TEST$ serialization "test\t"
     »"test\t"«;
 }

--- a/packages/safe-ds-lang/tests/resources/partial evaluation/recursive cases/template strings/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/partial evaluation/recursive cases/template strings/main.sdstest
@@ -4,7 +4,7 @@ pipeline test {
     // $TEST$ serialization "start 1 inner1 true inner2 test end"
     »"start {{ 1 }} inner1 {{ true }} inner2 {{ "test" }} end"«;
 
-    // $TEST$ serialization "start	1 inner1	true inner2	test end	"
+    // $TEST$ serialization "start\\t1 inner1\\ttrue inner2\\ttest end\\t"
     »"start\t{{ 1 }} inner1\t{{ true }} inner2\t{{ "test" }} end\t"«;
 
     // $TEST$ serialization ?


### PR DESCRIPTION
Closes #904

### Summary of Changes

Newlines, tabs, etc. now get escaped when converting a string constant to a string. This affects inlay hints for literal types, for example.
