### PR TITLE
feat: shorter message if runner is started but files have errors

### DIFF
--- a/packages/safe-ds-vscode/src/extension/mainClient.ts
+++ b/packages/safe-ds-vscode/src/extension/mainClient.ts
@@ -2,7 +2,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node.js';
 import { LanguageClient, TransportKind } from 'vscode-languageclient/node.js';
-import { ast, createSafeDsServicesWithBuiltins, SafeDsServices, messages } from '@safe-ds/lang';
+import { ast, createSafeDsServicesWithBuiltins, messages, SafeDsServices } from '@safe-ds/lang';
 import { NodeFileSystem } from 'langium/node';
 import { getSafeDSOutputChannel, initializeLog, logError, logOutput, printOutputMessage } from './output.js';
 import crypto from 'crypto';
@@ -372,9 +372,7 @@ const validateDocuments = async function (
                 );
             }
         }
-        return `As file(s) ${errors
-            .map((validationInfo) => validationInfo.validatedDocument.uri.toString())
-            .join(', ')} has errors, the main pipeline cannot be run.`;
+        return 'Cannot run the main pipeline, because some files have errors.';
     }
     return undefined;
 };


### PR DESCRIPTION
Closes #910

### Summary of Changes

Shorten the message in the error popup if some files in the workspace have errors and the runner is started:

![image](https://github.com/Safe-DS/DSL/assets/2501322/8df4e167-5b13-4bfc-84c6-be586e1428bb)
