### PR TITLE
fix: lenient type checking involving type parameter types

### DIFF
--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
@@ -345,8 +345,14 @@ export class SafeDsTypeChecker {
     }
 
     private typeParameterTypeIsSubtypeOf(type: TypeParameterType, other: Type, options: TypeCheckOptions): boolean {
-        const upperBound = this.typeComputer().computeUpperBound(type);
-        return this.isSubtypeOf(upperBound, other, options);
+        if (options.strictTypeParameterTypeCheck) {
+            const upperBound = this.typeComputer().computeUpperBound(type);
+            return this.isSubtypeOf(upperBound, other, options);
+        } else {
+            // We need to check whether `type` is assignable to `other` after substituting `type` with its lower bound.
+            // Since this bound is `Nothing`, which is a subtype of everything, it boils down to a nullability check.
+            return !type.isExplicitlyNullable || other.isExplicitlyNullable;
+        }
     }
 
     private unionTypeIsSubtypeOf(type: UnionType, other: Type, options: TypeCheckOptions): boolean {

--- a/packages/safe-ds-lang/tests/language/typing/type checker/isSubOrSupertypeOf.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/type checker/isSubOrSupertypeOf.test.ts
@@ -1076,7 +1076,7 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
         {
             type1: unbounded,
             type2: upperBound,
-            expected: false,
+            expected: true,
         },
         {
             type1: upperBound,
@@ -1091,7 +1091,7 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
         {
             type1: unresolved,
             type2: upperBound,
-            expected: false,
+            expected: true,
         },
         {
             type1: coreTypes.AnyOrNull,
@@ -1157,7 +1157,7 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
         {
             type1: unbounded,
             type2: coreTypes.Any,
-            expected: false,
+            expected: true,
         },
         {
             type1: unbounded,


### PR DESCRIPTION
Related to #915

### Summary of Changes

As described in #915, the code

```
fun f<T>(p: (a: T) -> b: String)

pipeline myPipeline {
    // Expected type '(a: T) -> (b: String)' but got '(a: String) -> (result: String)'
    f((a: Int) -> a);
}
```

currently shows an error due to a parameter mismatch (contravariant context). In a covariant context (e.g. for results), however, no such error is shown. That's because when checking whether a type `T1` can be assigned to a type `T2`, we used to replace a type parameter type as `T1` with its **upper** bound (strict) and as `T2` with its upper bound (lenient).

We now instead replace a type parameter as `T1` with its **lower** bound (lenient). This simply checks whether there are any substitutions for `T1` that could let the subtype relation become true.
