### PR TITLE
feat: compute type parameters for calls

### DIFF
--- a/packages/safe-ds-lang/src/language/helpers/nodeProperties.ts
+++ b/packages/safe-ds-lang/src/language/helpers/nodeProperties.ts
@@ -339,7 +339,7 @@ export const getTypeArguments = (node: SdsTypeArgumentList | SdsNamedType | unde
 };
 
 export const getTypeParameters = (
-    node: SdsTypeParameterList | SdsNamedTypeDeclaration | undefined,
+    node: SdsTypeParameterList | SdsCallable | SdsNamedTypeDeclaration | undefined,
 ): SdsTypeParameter[] => {
     if (!node) {
         return [];
@@ -348,6 +348,8 @@ export const getTypeParameters = (
     if (isSdsTypeParameterList(node)) {
         return node.typeParameters;
     } else if (isSdsClass(node)) {
+        return getTypeParameters(node.typeParameterList);
+    } else if (isSdsFunction(node)) {
         return getTypeParameters(node.typeParameterList);
     } /* c8 ignore start */ else {
         return [];

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -862,9 +862,8 @@ export class SafeDsTypeComputer {
         currentVariance: Variance,
         state: ComputeTypeParameterSubstitutionsForParametersState,
     ) {
-        console.log(parameterType.toString(), argumentType.toString(), currentVariance);
-
-        if (argumentType instanceof TypeParameterType) {
+        if (argumentType instanceof TypeParameterType && state.substitutions.has(argumentType.declaration)) {
+            // Can happen for lambdas without manifest parameter types. We gain no information here.
             return;
         } else if (parameterType instanceof CallableType && argumentType instanceof CallableType) {
             // Compare parameters
@@ -917,6 +916,7 @@ export class SafeDsTypeComputer {
             }
 
             if (!matchingParameterType || !matchingArgumentType) {
+                /* c8 ignore next 2 */
                 return;
             }
 
@@ -925,6 +925,7 @@ export class SafeDsTypeComputer {
                 const argumentTypeSubstitutions = matchingParameterType.substitutions.get(typeParameter);
                 const parameterTypeSubstitutions = matchingArgumentType.substitutions.get(typeParameter);
                 if (!argumentTypeSubstitutions || !parameterTypeSubstitutions) {
+                    /* c8 ignore next 2 */
                     continue;
                 }
 
@@ -948,6 +949,7 @@ export class SafeDsTypeComputer {
             const currentSubstitution = state.substitutions.get(parameterType.declaration);
             const remainingVariance = state.remainingVariances.get(parameterType.declaration);
             if (!currentSubstitution) {
+                /* c8 ignore next 2 */
                 return;
             }
 
@@ -967,11 +969,11 @@ export class SafeDsTypeComputer {
     private flippedVariance(variance: Variance): Variance {
         if (variance === 'covariant') {
             return 'contravariant';
-        } else if (variance === 'contravariant') {
+        } /* c8 ignore start */ else if (variance === 'contravariant') {
             return 'covariant';
         } else {
             return variance;
-        }
+        } /* c8 ignore stop */
     }
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -55,6 +55,7 @@ import {
     SdsAssignee,
     type SdsBlockLambda,
     SdsCall,
+    SdsCallable,
     SdsCallableType,
     SdsClass,
     SdsDeclaration,
@@ -75,6 +76,7 @@ import {
     SdsTypeParameter,
 } from '../generated/ast.js';
 import {
+    getArguments,
     getAssignees,
     getLiterals,
     getParameters,
@@ -453,10 +455,31 @@ export class SafeDsTypeComputer {
             if (!isSdsAnnotation(nonNullableReceiverType.callable)) {
                 result = nonNullableReceiverType.outputType;
             }
+
+            // Substitute type parameters
+            if (isSdsFunction(nonNullableReceiverType.callable)) {
+                const substitutions = this.computeTypeParameterSubstitutionsForCallable(
+                    nonNullableReceiverType.callable,
+                    node,
+                );
+
+                result = result.substituteTypeParameters(substitutions);
+            }
         } else if (nonNullableReceiverType instanceof StaticType) {
             const instanceType = nonNullableReceiverType.instanceType;
             if (isSdsCallable(instanceType.declaration)) {
                 result = instanceType;
+            }
+
+            // Substitute type parameters
+            if (instanceType instanceof ClassType) {
+                const substitutions = this.computeTypeParameterSubstitutionsForCallable(instanceType.declaration, node);
+
+                result = this.factory.createClassType(
+                    instanceType.declaration,
+                    substitutions,
+                    instanceType.isExplicitlyNullable,
+                );
             }
         }
 
@@ -615,11 +638,14 @@ export class SafeDsTypeComputer {
             return unparameterizedType;
         }
 
-        const substitutions = this.getTypeParameterSubstitutionsForNamedType(node, unparameterizedType.declaration);
+        const substitutions = this.computeTypeParameterSubstitutionsForNamedType(node, unparameterizedType.declaration);
         return this.factory.createClassType(unparameterizedType.declaration, substitutions, node.isNullable);
     }
 
-    private getTypeParameterSubstitutionsForNamedType(node: SdsNamedType, clazz: SdsClass): TypeParameterSubstitutions {
+    private computeTypeParameterSubstitutionsForNamedType(
+        node: SdsNamedType,
+        clazz: SdsClass,
+    ): TypeParameterSubstitutions {
         const typeParameters = getTypeParameters(clazz);
         if (isEmpty(typeParameters)) {
             return NO_SUBSTITUTIONS;
@@ -683,6 +709,38 @@ export class SafeDsTypeComputer {
         } /* c8 ignore stop */
     }
 
+    computeCallableTypeForStaticType(type: StaticType): Type {
+        const instanceType = type.instanceType;
+        if (instanceType instanceof ClassType) {
+            const declaration = instanceType.declaration;
+            if (!declaration.parameterList) {
+                return UnknownType;
+            }
+
+            const parameterEntries = this.factory.createNamedTupleType(
+                ...getParameters(declaration).map((it) => new NamedTupleEntry(it, it.name, this.computeType(it))),
+            );
+            const resultEntries = this.factory.createNamedTupleType(
+                new NamedTupleEntry<SdsAbstractResult>(undefined, 'instance', instanceType),
+            );
+
+            return this.factory.createCallableType(declaration, undefined, parameterEntries, resultEntries);
+        } else if (instanceType instanceof EnumVariantType) {
+            const declaration = instanceType.declaration;
+
+            const parameterEntries = this.factory.createNamedTupleType(
+                ...getParameters(declaration).map((it) => new NamedTupleEntry(it, it.name, this.computeType(it))),
+            );
+            const resultEntries = this.factory.createNamedTupleType(
+                new NamedTupleEntry<SdsAbstractResult>(undefined, 'instance', instanceType),
+            );
+
+            return this.factory.createCallableType(declaration, undefined, parameterEntries, resultEntries);
+        } else {
+            return UnknownType;
+        }
+    }
+
     // -----------------------------------------------------------------------------------------------------------------
     // Type parameter bounds
     // -----------------------------------------------------------------------------------------------------------------
@@ -717,6 +775,202 @@ export class SafeDsTypeComputer {
             return boundType;
         } else {
             return this.doComputeUpperBound(boundType, options);
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------------------------------
+    // Type parameter substitutions
+    // -----------------------------------------------------------------------------------------------------------------
+
+    /**
+     * Computes substitutions for the type parameters of the given callable in the context of the given call.
+     *
+     * @param callable The callable with the type parameters to compute substitutions for.
+     * @param call The call to compute substitutions for.
+     * @returns The computed substitutions for the type parameters of the callable.
+     */
+    computeTypeParameterSubstitutionsForCallable(callable: SdsCallable, call: SdsCall): TypeParameterSubstitutions {
+        const typeParameters = getTypeParameters(callable);
+        if (isEmpty(typeParameters)) {
+            return NO_SUBSTITUTIONS;
+        }
+
+        const parameters = getParameters(callable);
+        const args = getArguments(call);
+
+        const parametersToArguments = this.nodeMapper.parametersToArguments(parameters, args);
+        const parameterTypesToArgumentTypes: [Type, Type][] = parameters.map((parameter) => {
+            const argument = parametersToArguments.get(parameter);
+            return [this.computeType(parameter.type), this.computeType(argument?.value ?? parameter.defaultValue)];
+        });
+
+        return this.computeTypeParameterSubstitutionsForParameters(typeParameters, parameterTypesToArgumentTypes);
+    }
+
+    /**
+     * Computes substitutions for the given type parameters in a list of parameter types based on the corresponding
+     * argument types.
+     *
+     * @param typeParameters The type parameters to compute substitutions for.
+     * @param parameterTypesToArgumentTypes Pairs of parameter types and the corresponding argument types.
+     * @returns The computed substitutions for the type parameters in the parameter types.
+     */
+    computeTypeParameterSubstitutionsForParameters(
+        typeParameters: SdsTypeParameter[],
+        parameterTypesToArgumentTypes: [Type, Type][],
+    ): TypeParameterSubstitutions {
+        // Build initial state
+        const state: ComputeTypeParameterSubstitutionsForParametersState = {
+            substitutions: new Map(typeParameters.map((it) => [it, UnknownType])),
+            remainingVariances: new Map(typeParameters.map((it) => [it, 'bivariant'])),
+        };
+
+        // Compute substitutions
+        for (const [parameterType, argumentType] of parameterTypesToArgumentTypes) {
+            this.computeTypeParameterSubstitutionsForParameter(parameterType, argumentType, 'covariant', state);
+        }
+
+        // Normalize substitutions
+        for (const [typeParameter, substitution] of state.substitutions) {
+            // Replace unknown types by default values or lower bound (Nothing)
+            if (substitution === UnknownType) {
+                const defaultValueType = this.computeType(typeParameter.defaultValue);
+                if (defaultValueType === UnknownType) {
+                    state.substitutions.set(typeParameter, this.coreTypes.Nothing);
+                } else {
+                    state.substitutions.set(typeParameter, defaultValueType);
+                }
+                continue;
+            }
+
+            // Clamp to upper bound
+            const upperBound = this.computeUpperBound(typeParameter, {
+                stopAtTypeParameterType: true,
+            }).substituteTypeParameters(state.substitutions);
+
+            if (!this.typeChecker.isSubtypeOf(substitution, upperBound)) {
+                state.substitutions.set(typeParameter, upperBound);
+            }
+        }
+
+        return state.substitutions;
+    }
+
+    private computeTypeParameterSubstitutionsForParameter(
+        parameterType: Type,
+        argumentType: Type,
+        currentVariance: Variance,
+        state: ComputeTypeParameterSubstitutionsForParametersState,
+    ) {
+        console.log(parameterType.toString(), argumentType.toString(), currentVariance);
+
+        if (argumentType instanceof TypeParameterType) {
+            return;
+        } else if (parameterType instanceof CallableType && argumentType instanceof CallableType) {
+            // Compare parameters
+            const parameterTypeParameters = parameterType.inputType.entries;
+            const argumentTypeParameters = argumentType.inputType.entries;
+            const minParametersLength = Math.min(parameterTypeParameters.length, argumentTypeParameters.length);
+            for (let i = 0; i < minParametersLength; i++) {
+                const parameterEntry = parameterTypeParameters[i]!;
+                const argumentEntry = argumentTypeParameters[i]!;
+                this.computeTypeParameterSubstitutionsForParameter(
+                    parameterEntry.type,
+                    argumentEntry.type,
+                    this.flippedVariance(currentVariance),
+                    state,
+                );
+            }
+
+            // Compare results
+            const parameterTypeResults = parameterType.outputType.entries;
+            const argumentTypeResults = argumentType.outputType.entries;
+            const minResultsLength = Math.min(parameterTypeResults.length, argumentTypeResults.length);
+            for (let i = 0; i < minResultsLength; i++) {
+                const parameterEntry = parameterTypeResults[i]!;
+                const argumentEntry = argumentTypeResults[i]!;
+                this.computeTypeParameterSubstitutionsForParameter(
+                    parameterEntry.type,
+                    argumentEntry.type,
+                    currentVariance,
+                    state,
+                );
+            }
+        } else if (parameterType instanceof CallableType && argumentType instanceof StaticType) {
+            if (currentVariance === 'covariant') {
+                const callableArgumentType = this.computeCallableTypeForStaticType(argumentType);
+                this.computeTypeParameterSubstitutionsForParameter(
+                    parameterType,
+                    callableArgumentType,
+                    currentVariance,
+                    state,
+                );
+            }
+        } else if (parameterType instanceof ClassType && argumentType instanceof ClassType) {
+            let matchingParameterType: ClassType | undefined = parameterType;
+            let matchingArgumentType: ClassType | undefined = argumentType;
+
+            if (currentVariance === 'covariant') {
+                matchingArgumentType = this.computeMatchingSupertype(argumentType, parameterType.declaration);
+            } else if (currentVariance === 'contravariant') {
+                matchingParameterType = this.computeMatchingSupertype(parameterType, argumentType.declaration);
+            }
+
+            if (!matchingParameterType || !matchingArgumentType) {
+                return;
+            }
+
+            const parameterTypeParameters = getTypeParameters(parameterType.declaration);
+            for (const typeParameter of parameterTypeParameters) {
+                const argumentTypeSubstitutions = matchingParameterType.substitutions.get(typeParameter);
+                const parameterTypeSubstitutions = matchingArgumentType.substitutions.get(typeParameter);
+                if (!argumentTypeSubstitutions || !parameterTypeSubstitutions) {
+                    continue;
+                }
+
+                if (TypeParameter.isCovariant(typeParameter)) {
+                    this.computeTypeParameterSubstitutionsForParameter(
+                        argumentTypeSubstitutions,
+                        parameterTypeSubstitutions,
+                        currentVariance,
+                        state,
+                    );
+                } else if (TypeParameter.isContravariant(typeParameter)) {
+                    this.computeTypeParameterSubstitutionsForParameter(
+                        argumentTypeSubstitutions,
+                        parameterTypeSubstitutions,
+                        this.flippedVariance(currentVariance),
+                        state,
+                    );
+                }
+            }
+        } else if (parameterType instanceof TypeParameterType) {
+            const currentSubstitution = state.substitutions.get(parameterType.declaration);
+            const remainingVariance = state.remainingVariances.get(parameterType.declaration);
+            if (!currentSubstitution) {
+                return;
+            }
+
+            if (remainingVariance === 'bivariant') {
+                state.substitutions.set(parameterType.declaration, argumentType);
+                state.remainingVariances.set(parameterType.declaration, currentVariance);
+            } else if (remainingVariance === 'covariant' && currentVariance === 'covariant') {
+                const lowestCommonSupertype = this.lowestCommonSupertype([currentSubstitution, argumentType]);
+                state.substitutions.set(parameterType.declaration, lowestCommonSupertype);
+            } else if (remainingVariance === 'contravariant' && currentVariance === 'contravariant') {
+                const highestCommonSubtype = this.highestCommonSubtype([currentSubstitution, argumentType]);
+                state.substitutions.set(parameterType.declaration, highestCommonSubtype);
+            }
+        }
+    }
+
+    private flippedVariance(variance: Variance): Variance {
+        if (variance === 'covariant') {
+            return 'contravariant';
+        } else if (variance === 'contravariant') {
+            return 'covariant';
+        } else {
+            return variance;
         }
     }
 
@@ -1333,6 +1587,13 @@ interface ComputeUpperBoundOptions {
      */
     stopAtTypeParameterType?: boolean;
 }
+
+interface ComputeTypeParameterSubstitutionsForParametersState {
+    substitutions: TypeParameterSubstitutions;
+    remainingVariances: Map<SdsTypeParameter, Variance | undefined>;
+}
+
+type Variance = 'bivariant' | 'covariant' | 'contravariant' | 'invariant';
 
 /**
  * Options for {@link lowestCommonSupertype}.

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/clamp to upper bound/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/clamp to upper bound/main.sdstest
@@ -1,0 +1,13 @@
+package tests.typing.expressions.calls.typeParameterInference.clampToUpperBound
+
+class C1<T sub Int>(p1: T)
+
+@Pure fun f1<T sub Int>(p1: T) -> r1: T
+
+pipeline myPipeline {
+    // $TEST$ serialization C1<Int>
+    »C1("")«;
+
+    // $TEST$ serialization Int
+    »f1("")«;
+}

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/deep nesting/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/deep nesting/main.sdstest
@@ -1,0 +1,40 @@
+package tests.typing.expressions.calls.typeParameterInference.deepNesting
+
+class Covariant<out T>
+class CovariantNumber sub Covariant<Number>
+class SomeCovariant<out T> sub Covariant<T>
+
+class Contravariant<in T>
+
+class C1<T>(p1: Contravariant<Covariant<T>>, p2: Contravariant<Covariant<T>>)
+@Pure fun f1<T>(p1: Contravariant<Covariant<T>>, p2: Contravariant<Covariant<T>>) -> r1: T
+
+segment mySegment(
+    a1: Contravariant<Covariant<Int>>,
+    a2: Contravariant<Covariant<Number>>,
+    a3: Contravariant<Covariant<Any?>>,
+    a4: Contravariant<CovariantNumber>,
+    a5: Contravariant<SomeCovariant<String?>>,
+) {
+    // $TEST$ serialization C1<Int>
+    »C1(a2, a1)«;
+    // $TEST$ serialization C1<Number>
+    »C1(a2, a2)«;
+    // $TEST$ serialization C1<Number>
+    »C1(a2, a3)«;
+    // $TEST$ serialization C1<Number>
+    »C1(a2, a4)«;
+    // $TEST$ serialization C1<Number>
+    »C1(a2, a5)«;
+
+    // $TEST$ serialization Int
+    »f1(a2, a1)«;
+    // $TEST$ serialization Number
+    »f1(a2, a2)«;
+    // $TEST$ serialization Number
+    »f1(a2, a3)«;
+    // $TEST$ serialization Number
+    »f1(a2, a4)«;
+    // $TEST$ serialization Number
+    »f1(a2, a5)«;
+}

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/default value of parameter/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/default value of parameter/main.sdstest
@@ -1,0 +1,13 @@
+package tests.typing.expressions.calls.typeParameterInference.defaultValueOfParameter
+
+class C1<T>(p1: T = 0)
+
+@Pure fun f1<T>(p1: T = 0) -> r1: T
+
+pipeline myPipeline {
+    // $TEST$ serialization C1<literal<0>>
+    »C1()«;
+
+    // $TEST$ serialization literal<0>
+    »f1()«;
+}

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/default value of type parameter/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/default value of type parameter/main.sdstest
@@ -1,0 +1,19 @@
+package tests.typing.expressions.calls.typeParameterInference.defaultValueOfTypeParameter
+
+class C1<T>()
+class C2<T = Int>()
+
+@Pure fun f1<T>() -> r1: T
+@Pure fun f2<T = Int>() -> r1: T
+
+pipeline myPipeline {
+    // $TEST$ serialization C1<Nothing>
+    »C1()«;
+    // $TEST$ serialization C1<Int>
+    »C2()«;
+
+    // $TEST$ serialization Nothing
+    »f1()«;
+    // $TEST$ serialization Int
+    »f2()«;
+}

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/default value of type parameter/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/default value of type parameter/main.sdstest
@@ -9,7 +9,7 @@ class C2<T = Int>()
 pipeline myPipeline {
     // $TEST$ serialization C1<Nothing>
     »C1()«;
-    // $TEST$ serialization C1<Int>
+    // $TEST$ serialization C2<Int>
     »C2()«;
 
     // $TEST$ serialization Nothing

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/differing variance/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/differing variance/main.sdstest
@@ -28,13 +28,13 @@ segment mySegment(
     // $TEST$ serialization C1<Number>
     »C1(b1, b2)«;
 
-    // $TEST$ serialization C1<Nothing>
+    // $TEST$ serialization C2<Nothing>
     »C2(a1, a3)«;
-    // $TEST$ serialization C1<Nothing>
+    // $TEST$ serialization C2<Nothing>
     »C2(a1, b3)«;
-    // $TEST$ serialization C1<Number>
+    // $TEST$ serialization C2<Number>
     »C2(b1, a3)«;
-    // $TEST$ serialization C1<Number>
+    // $TEST$ serialization C2<Number>
     »C2(b1, b3)«;
 
     // $TEST$ serialization Nothing

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/differing variance/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/differing variance/main.sdstest
@@ -1,0 +1,58 @@
+package tests.typing.expressions.calls.typeParameterInference.differingVariance
+
+class Contravariant<in T>
+class Invariant<T>
+class Covariant<out T>
+
+class C1<T>(p1: Contravariant<T>, p2: Invariant<T>)
+class C2<T>(p1: Contravariant<T>, p2: Covariant<T>)
+
+@Pure fun f1<T>(p1: Contravariant<T>, p2: Invariant<T>) -> r1: T
+@Pure fun f2<T>(p1: Contravariant<T>, p3: Covariant<T>) -> r1: T
+
+segment mySegment(
+    a1: Contravariant<Nothing>,
+    a2: Invariant<Nothing>,
+    a3: Covariant<Nothing>,
+
+    b1: Contravariant<Number>,
+    b2: Invariant<Number>,
+    b3: Covariant<Number>,
+) {
+    // $TEST$ serialization C1<Nothing>
+    »C1(a1, a2)«;
+    // $TEST$ serialization C1<Nothing>
+    »C1(a1, b2)«;
+    // $TEST$ serialization C1<Number>
+    »C1(b1, a2)«;
+    // $TEST$ serialization C1<Number>
+    »C1(b1, b2)«;
+
+    // $TEST$ serialization C1<Nothing>
+    »C2(a1, a3)«;
+    // $TEST$ serialization C1<Nothing>
+    »C2(a1, b3)«;
+    // $TEST$ serialization C1<Number>
+    »C2(b1, a3)«;
+    // $TEST$ serialization C1<Number>
+    »C2(b1, b3)«;
+
+    // $TEST$ serialization Nothing
+    »f1(a1, a2)«;
+    // $TEST$ serialization Nothing
+    »f1(a1, b2)«;
+    // $TEST$ serialization Number
+    »f1(b1, a2)«;
+    // $TEST$ serialization Number
+    »f1(b1, b2)«;
+
+    // $TEST$ serialization Nothing
+    »f2(a1, a3)«;
+    // $TEST$ serialization Nothing
+    »f2(a1, b3)«;
+    // $TEST$ serialization Number
+    »f2(b1, a3)«;
+    // $TEST$ serialization Number
+    »f2(b1, b3)«;
+
+}

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/multiple contravariant/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/multiple contravariant/main.sdstest
@@ -1,0 +1,46 @@
+package tests.typing.expressions.calls.typeParameterInference.multipleContravariant
+
+class Contravariant<in T>
+class ContravariantNumber sub Contravariant<Number>
+class SomeContravariant<in T> sub Contravariant<T>
+
+class C1<T>(p1: T, p2: Contravariant<T>, p3: (p1: T) -> ())
+@Pure fun f1<T>(p1: T, p2: Contravariant<T>, p3: (p1: T) -> ()) -> r1: T
+
+segment mySegment(
+    a1: Int,
+    a2: Number,
+    a3: Any?,
+
+    b1: Contravariant<Number>,
+    b2: ContravariantNumber,
+    b3: SomeContravariant<String?>,
+
+    c: (p1: Number) -> ()
+) {
+    // $TEST$ serialization C1<Int>
+    »C1(a1, b1, c)«;
+    // $TEST$ serialization C1<Number>
+    »C1(a2, b1, c)«;
+    // $TEST$ serialization C1<Number>
+    »C1(a3, b1, c)«;
+    // $TEST$ serialization C1<Int>
+    »C1(a1, b2, c)«;
+    // $TEST$ serialization C1<Nothing>
+    »C1(a1, b3, c)«;
+    // $TEST$ serialization C1<Int>
+    »C1(a1, b1, (p1) {})«;
+
+    // $TEST$ serialization Int
+    »f1(a1, b1, c)«;
+    // $TEST$ serialization Number
+    »f1(a2, b1, c)«;
+    // $TEST$ serialization Number
+    »f1(a3, b1, c)«;
+    // $TEST$ serialization Int
+    »f1(a1, b2, c)«;
+    // $TEST$ serialization Nothing
+    »f1(a1, b3, c)«;
+    // $TEST$ serialization Int
+    »f1(a1, b1, (p1) {})«;
+}

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/multiple contravariant/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/multiple contravariant/main.sdstest
@@ -4,43 +4,41 @@ class Contravariant<in T>
 class ContravariantNumber sub Contravariant<Number>
 class SomeContravariant<in T> sub Contravariant<T>
 
-class C1<T>(p1: T, p2: Contravariant<T>, p3: (p1: T) -> ())
-@Pure fun f1<T>(p1: T, p2: Contravariant<T>, p3: (p1: T) -> ()) -> r1: T
+class C1<T>(p1: Contravariant<T>, p2: (p1: T) -> ())
+@Pure fun f1<T>(p1: Contravariant<T>, p2: (p1: T) -> ()) -> r1: T
 
 segment mySegment(
-    a1: Int,
-    a2: Number,
-    a3: Any?,
-
-    b1: Contravariant<Number>,
-    b2: ContravariantNumber,
-    b3: SomeContravariant<String?>,
+    a1: Contravariant<Int>,
+    a2: Contravariant<Number>,
+    a3: Contravariant<Any?>,
+    a4: ContravariantNumber,
+    a5: SomeContravariant<String?>,
 
     c: (p1: Number) -> ()
 ) {
     // $TEST$ serialization C1<Int>
-    »C1(a1, b1, c)«;
+    »C1(a1, c)«;
     // $TEST$ serialization C1<Number>
-    »C1(a2, b1, c)«;
+    »C1(a2, c)«;
     // $TEST$ serialization C1<Number>
-    »C1(a3, b1, c)«;
-    // $TEST$ serialization C1<Int>
-    »C1(a1, b2, c)«;
+    »C1(a3, c)«;
+    // $TEST$ serialization C1<Number>
+    »C1(a4, c)«;
     // $TEST$ serialization C1<Nothing>
-    »C1(a1, b3, c)«;
+    »C1(a5, c)«;
     // $TEST$ serialization C1<Int>
-    »C1(a1, b1, (p1) {})«;
+    »C1(a1, (p1) {})«;
 
     // $TEST$ serialization Int
-    »f1(a1, b1, c)«;
+    »f1(a1, c)«;
     // $TEST$ serialization Number
-    »f1(a2, b1, c)«;
+    »f1(a2, c)«;
     // $TEST$ serialization Number
-    »f1(a3, b1, c)«;
-    // $TEST$ serialization Int
-    »f1(a1, b2, c)«;
+    »f1(a3, c)«;
+    // $TEST$ serialization Number
+    »f1(a4, c)«;
     // $TEST$ serialization Nothing
-    »f1(a1, b3, c)«;
+    »f1(a5, c)«;
     // $TEST$ serialization Int
-    »f1(a1, b1, (p1) {})«;
+    »f1(a1, (p1) {})«;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/multiple covariant/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/multiple covariant/main.sdstest
@@ -7,6 +7,8 @@ class SomeCovariant<out T> sub Covariant<T>
 class C1<T>(p1: T, p2: Covariant<T>, p3: () -> r1: T)
 @Pure fun f1<T>(p1: T, p2: Covariant<T>, p3: () -> r1: T) -> r1: T
 
+class SomeClass()
+
 segment mySegment(
     a1: Int,
     a2: Number,
@@ -30,6 +32,8 @@ segment mySegment(
     »C1(a1, b3, c)«;
     // $TEST$ serialization C1<Any>
     »C1(a1, b1, () -> "")«;
+    // $TEST$ serialization C1<Any>
+    »C1(a1, b1, SomeClass)«;
 
     // $TEST$ serialization Number
     »f1(a1, b1, c)«;
@@ -43,4 +47,6 @@ segment mySegment(
     »f1(a1, b3, c)«;
     // $TEST$ serialization Any
     »f1(a1, b1, () -> "")«;
+    // $TEST$ serialization Any
+    »f1(a1, b1, SomeClass)«;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/multiple covariant/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/multiple covariant/main.sdstest
@@ -1,0 +1,46 @@
+package tests.typing.expressions.calls.typeParameterInference.multipleCovariant
+
+class Covariant<out T>
+class CovariantNumber sub Covariant<Number>
+class SomeCovariant<out T> sub Covariant<T>
+
+class C1<T>(p1: T, p2: Covariant<T>, p3: () -> r1: T)
+@Pure fun f1<T>(p1: T, p2: Covariant<T>, p3: () -> r1: T) -> r1: T
+
+segment mySegment(
+    a1: Int,
+    a2: Number,
+    a3: Any?,
+
+    b1: Covariant<Number>,
+    b2: CovariantNumber,
+    b3: SomeCovariant<String?>,
+
+    c: () -> r1: Number
+) {
+    // $TEST$ serialization C1<Number>
+    »C1(a1, b1, c)«;
+    // $TEST$ serialization C1<Number>
+    »C1(a2, b1, c)«;
+    // $TEST$ serialization C1<Any?>
+    »C1(a3, b1, c)«;
+    // $TEST$ serialization C1<Number>
+    »C1(a1, b2, c)«;
+    // $TEST$ serialization C1<Any?>
+    »C1(a1, b3, c)«;
+    // $TEST$ serialization C1<Any>
+    »C1(a1, b1, () -> "")«;
+
+    // $TEST$ serialization Number
+    »f1(a1, b1, c)«;
+    // $TEST$ serialization Number
+    »f1(a2, b1, c)«;
+    // $TEST$ serialization Any?
+    »f1(a3, b1, c)«;
+    // $TEST$ serialization Number
+    »f1(a1, b2, c)«;
+    // $TEST$ serialization Any?
+    »f1(a1, b3, c)«;
+    // $TEST$ serialization Any
+    »f1(a1, b1, () -> "")«;
+}

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/single contravariant/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/single contravariant/main.sdstest
@@ -1,0 +1,16 @@
+package tests.typing.expressions.calls.typeParameterInference.singleContravariant
+
+class Contravariant<in T>
+
+class C1<T>(p1: Contravariant<T>)
+@Pure fun f1<T>(p1: Contravariant<T>) -> r1: T
+
+segment mySegment(
+    p1: Contravariant<Int>,
+) {
+    // $TEST$ serialization C1<Int>
+    »C1(p1)«;
+
+    // $TEST$ serialization Int
+    »f1(p1)«;
+}

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/single covariant/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/single covariant/main.sdstest
@@ -1,0 +1,14 @@
+package tests.typing.expressions.calls.typeParameterInference.singleCovariant
+
+class C1<T>(p1: T)
+@Pure fun f1<T>(p1: T) -> r1: T
+
+segment mySegment(
+    p1: Int,
+) {
+    // $TEST$ serialization C1<Int>
+    »C1(p1)«;
+
+    // $TEST$ serialization Int
+    »f1(p1)«;
+}


### PR DESCRIPTION
Closes #861

### Summary of Changes

Compute and apply substitutions for the type parameters of a called callable.