### PR TITLE
feat: clamp default values of parameter types to upper bound

### DIFF
--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -832,15 +832,17 @@ export class SafeDsTypeComputer {
 
         // Normalize substitutions
         for (const [typeParameter, substitution] of state.substitutions) {
+            let newSubstitution = substitution;
+
             // Replace unknown types by default values or lower bound (Nothing)
-            if (substitution === UnknownType) {
+            if (newSubstitution === UnknownType) {
                 const defaultValueType = this.computeType(typeParameter.defaultValue);
                 if (defaultValueType === UnknownType) {
                     state.substitutions.set(typeParameter, this.coreTypes.Nothing);
+                    continue;
                 } else {
-                    state.substitutions.set(typeParameter, defaultValueType);
+                    newSubstitution = defaultValueType;
                 }
-                continue;
             }
 
             // Clamp to upper bound
@@ -848,9 +850,11 @@ export class SafeDsTypeComputer {
                 stopAtTypeParameterType: true,
             }).substituteTypeParameters(state.substitutions);
 
-            if (!this.typeChecker.isSubtypeOf(substitution, upperBound)) {
-                state.substitutions.set(typeParameter, upperBound);
+            if (!this.typeChecker.isSubtypeOf(newSubstitution, upperBound)) {
+                newSubstitution = upperBound;
             }
+
+            state.substitutions.set(typeParameter, newSubstitution);
         }
 
         return state.substitutions;

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/clamp to upper bound/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/calls/type parameter inference/clamp to upper bound/main.sdstest
@@ -1,13 +1,19 @@
 package tests.typing.expressions.calls.typeParameterInference.clampToUpperBound
 
-class C1<T sub Int>(p1: T)
+class C1<T sub Int = String>(p1: T)
 
-@Pure fun f1<T sub Int>(p1: T) -> r1: T
+@Pure fun f1<T sub Int = String>(p1: T) -> r1: T
 
 pipeline myPipeline {
     // $TEST$ serialization C1<Int>
     »C1("")«;
 
+    // $TEST$ serialization C1<Int>
+    »C1()«;
+
     // $TEST$ serialization Int
     »f1("")«;
+
+    // $TEST$ serialization Int
+    »f1()«;
 }


### PR DESCRIPTION
### Summary of Changes

The default value of a type parameter is now clamped to its upper bound during inference of type parameters for calls. 