### PR TITLE
feat: substitute type parameters when checking overridden members

### DIFF
--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
@@ -395,6 +395,7 @@ export class SafeDsTypeChecker {
             !type.equals(this.coreTypes.NothingOrNull) &&
             this.isSubtypeOf(type, listOrNull, {
                 ignoreTypeParameters: true,
+                strictTypeParameterTypeCheck: true,
             })
         );
     }
@@ -410,6 +411,7 @@ export class SafeDsTypeChecker {
             !type.equals(this.coreTypes.NothingOrNull) &&
             this.isSubtypeOf(type, mapOrNull, {
                 ignoreTypeParameters: true,
+                strictTypeParameterTypeCheck: true,
             })
         );
     }

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
@@ -21,20 +21,17 @@ import { SafeDsClassHierarchy } from './safe-ds-class-hierarchy.js';
 import { SafeDsCoreTypes } from './safe-ds-core-types.js';
 import type { SafeDsTypeComputer } from './safe-ds-type-computer.js';
 import { isEmpty } from '../../helpers/collections.js';
-import { SafeDsTypeFactory } from './safe-ds-type-factory.js';
 
 export class SafeDsTypeChecker {
     private readonly builtinClasses: SafeDsClasses;
     private readonly classHierarchy: SafeDsClassHierarchy;
     private readonly coreTypes: SafeDsCoreTypes;
-    private readonly factory: SafeDsTypeFactory;
     private readonly typeComputer: () => SafeDsTypeComputer;
 
     constructor(services: SafeDsServices) {
         this.builtinClasses = services.builtins.Classes;
         this.classHierarchy = services.types.ClassHierarchy;
         this.coreTypes = services.types.CoreTypes;
-        this.factory = services.types.TypeFactory;
         this.typeComputer = () => services.types.TypeComputer;
     }
 

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -1215,7 +1215,9 @@ export class SafeDsTypeComputer {
     }
 
     private isCommonSupertype(candidate: Type, otherTypes: Type[]): boolean {
-        return otherTypes.every((it) => this.typeChecker.isSupertypeOf(candidate, it));
+        return otherTypes.every((it) =>
+            this.typeChecker.isSupertypeOf(candidate, it, { strictTypeParameterTypeCheck: true }),
+        );
     }
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/operations/arithmetic/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/operations/arithmetic/main.sdstest
@@ -140,3 +140,15 @@ pipeline mixedOperands {
     // $TEST$ serialization Float
     val divisionFloatFloat = »1.5 / anyFloat()«;
 }
+
+// Strict checking of type parameter types
+class MyClass<T sub Any>(
+    p1: T,
+
+    // $TEST$ serialization Float
+    p2: Any? = »p1 + 1«,
+    // $TEST$ serialization Float
+    p3: Any? = »1 + p1«,
+    // $TEST$ serialization Float
+    p4: Any? = »-p1«,
+)

--- a/packages/safe-ds-lang/tests/resources/validation/inheritance/overriding method must match overridden method/type parameters.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/inheritance/overriding method must match overridden method/type parameters.sdstest
@@ -1,20 +1,46 @@
-package tests.validation.inheritance.overridingMethodMustMatchOverriddenMethod
+package tests.validation.inheritance.overridingMethodMustMatchOverriddenMethod.typeParameters
 
-class MySuperClass2<T> {
+class MySuperClass<T> {
     attr myInstanceAttribute: T
-    @Pure fun myInstanceMethod(a: T = 0) -> r: T
+    @Pure fun myInstanceMethod1(a: T = 0) -> r: T
+    @Pure fun myInstanceMethod2(a: Int) -> r: Int
+    @Pure fun myInstanceMethod3<T>(a: T) -> r: T
 }
 
-class MyClass3 sub MySuperClass2<Number> {
+class MyClass1 sub MySuperClass<Number> {
     // $TEST$ no error r"Overriding member does not match the overridden member:.*"
     attr »myInstanceAttribute«: Int
     // $TEST$ no error r"Overriding member does not match the overridden member:.*"
-    @Pure fun »myInstanceMethod«(a: Any = 0) -> r: Int
+    @Pure fun »myInstanceMethod1«(a: Any = 0) -> r: Int
 }
 
-class MyClass4 sub MySuperClass2<Number> {
+class MyClass2<T> sub MySuperClass<T> {
+    // $TEST$ no error r"Overriding member does not match the overridden member:.*"
+    attr »myInstanceAttribute«: T
+    // $TEST$ no error r"Overriding member does not match the overridden member:.*"
+    @Pure fun »myInstanceMethod1«(a: T = 0) -> r: T
+}
+
+class MyClass3 sub MySuperClass<Number> {
     // $TEST$ error r"Overriding member does not match the overridden member:.*"
     attr »myInstanceAttribute«: Any
     // $TEST$ error r"Overriding member does not match the overridden member:.*"
-    @Pure fun »myInstanceMethod«(a: Number = 0) -> r: Any
+    @Pure fun »myInstanceMethod1«(a: Number = 0) -> r: Any
+}
+
+class MyClass4 sub MySuperClass<Number> {
+    // $TEST$ no error r"Overriding member does not match the overridden member:.*"
+    @Pure fun »myInstanceMethod2«<T>(a: T) -> r: T
+    // $TEST$ no error r"Overriding member does not match the overridden member:.*"
+    @Pure fun »myInstanceMethod3«<T>(a: T) -> r: T
+}
+
+class MyClass5 sub MySuperClass<Number> {
+    // $TEST$ error r"Overriding member does not match the overridden member:.*"
+    @Pure fun »myInstanceMethod3«(a: Int) -> r: Int
+}
+
+class MyClass6<T> sub MySuperClass<Number> {
+    // $TEST$ error r"Overriding member does not match the overridden member:.*"
+    attr »myInstanceAttribute«: T
 }

--- a/packages/safe-ds-lang/tests/resources/validation/inheritance/overriding method should differ from overridden method/type parameters.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/inheritance/overriding method should differ from overridden method/type parameters.sdstest
@@ -1,20 +1,41 @@
-package tests.validation.inheritance.overridingMethodShouldDifferFromOverriddenMethod
+package tests.validation.inheritance.overridingMethodShouldDifferFromOverriddenMethod.typeParameters
 
-class MySuperClass3<T> {
+class MySuperClass<T> {
     attr myInstanceAttribute: T
-    @Pure fun myInstanceMethod(a: T = 0) -> r: T
+    @Pure fun myInstanceMethod1(a: T = 0) -> r: T
+    @Pure fun myInstanceMethod2(a: Int) -> r: Int
+    @Pure fun myInstanceMethod3<T>(a: T) -> r: T
 }
 
-class MyClass5 sub MySuperClass3<Number> {
+class MyClass2<T> sub MySuperClass<T> {
+    // $TEST$ info "Overriding member is identical to overridden member and can be removed."
+    attr »myInstanceAttribute«: T
+    // $TEST$ info "Overriding member is identical to overridden member and can be removed."
+    @Pure fun »myInstanceMethod1«(a: T = 0) -> r: T
+}
+
+class MyClass1 sub MySuperClass<Number> {
     // $TEST$ info "Overriding member is identical to overridden member and can be removed."
     attr »myInstanceAttribute«: Number
     // $TEST$ info "Overriding member is identical to overridden member and can be removed."
-    @Pure fun »myInstanceMethod«(a: Number = 0) -> r: Number
+    @Pure fun »myInstanceMethod1«(a: Number = 0) -> r: Number
 }
 
-class MyClass6 sub MySuperClass3<Number> {
+class MyClass3 sub MySuperClass<Number> {
     // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
     attr »myInstanceAttribute«: Int
     // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
-    @Pure fun »myInstanceMethod«(a: Number = 0) -> r: Int
+    @Pure fun »myInstanceMethod1«(a: Number = 0) -> r: Int
+}
+
+class MyClass4 sub MySuperClass<Number> {
+    // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
+    @Pure fun »myInstanceMethod2«<T>(a: T) -> r: T
+    // $TEST$ info "Overriding member is identical to overridden member and can be removed."
+    @Pure fun »myInstanceMethod3«<T>(a: T) -> r: T
+}
+
+class MyClass5 sub MySuperClass<Number> {
+    // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
+    @Pure fun »myInstanceMethod3«(a: Int) -> r: Int
 }

--- a/packages/safe-ds-lang/tests/resources/validation/types/checking/indexed access receiver/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/types/checking/indexed access receiver/main.sdstest
@@ -13,31 +13,30 @@ segment mySegment(
 ) {
     // $TEST$ no error r"Expected type 'List<T>' or 'Map<K, V>' but got .*\."
     »[1]«[0];
-
     // $TEST$ no error r"Expected type 'List<T>' or 'Map<K, V>' but got .*\."
     »{0: 1}«[0];
-
     // $TEST$ error "Expected type 'List<T>' or 'Map<K, V>' but got 'literal<1>'."
     »1«[0];
 
-
     // $TEST$ no error r"Expected type 'List<T>' or 'Map<K, V>' but got .*\."
     »listOrNull«[0];
-
     // $TEST$ no error r"Expected type 'List<T>' or 'Map<K, V>' but got .*\."
     »mapOrNull«[""];
-
     // $TEST$ error "Expected type 'List<T>' or 'Map<K, V>' but got 'Int?'."
     »intOrNull«[0];
 
-
     // $TEST$ no error r"Expected type 'List<T>' or 'Map<K, V>' but got .*\."
     »myList«[0];
-
     // $TEST$ no error r"Expected type 'List<T>' or 'Map<K, V>' but got .*\."
     »myMap«[""];
-
-
     // $TEST$ error "Expected type 'List<T>' or 'Map<K, V>' but got '$unknown'."
     »unresolved«[0];
 }
+
+// Strict checking of type parameter types
+class MyClass<T sub Any>(
+    p1: T,
+
+    // $TEST$ error "Expected type 'List<T>' or 'Map<K, V>' but got 'T'."
+    p2: Any? = »p1«[0],
+)


### PR DESCRIPTION
Closes #917

### Summary of Changes

When checking whether overriding is legal and needed, we now use strict type checking and correctly substitute type parameters.
