### PR TITLE
feat: substitute type parameter when type checking calls

### DIFF
--- a/packages/safe-ds-lang/src/language/typing/model.ts
+++ b/packages/safe-ds-lang/src/language/typing/model.ts
@@ -737,9 +737,7 @@ export class UnionType extends Type {
                 const candidateType = otherType.withExplicitNullability(
                     currentType.isExplicitlyNullable || otherType.isExplicitlyNullable,
                 );
-                if (
-                    this.typeChecker.isSupertypeOf(candidateType, currentType, { strictTypeParameterTypeCheck: true })
-                ) {
+                if (this.typeChecker.isSupertypeOf(candidateType, currentType)) {
                     // Replace the other type with the candidate type (updated nullability)
                     newTypes.splice(j, 1, candidateType);
                     // Remove the current type

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -348,9 +348,7 @@ export class SafeDsTypeComputer {
             // as `Literal<"a", "b">`. But then we would be unable to pass an unknown `String` as the key in an indexed
             // access. Where possible, we already validate the existence of keys in indexed accesses using the partial
             // evaluator.
-            if (keyType instanceof LiteralType) {
-                keyType = this.computeClassTypeForLiteralType(keyType);
-            }
+            keyType = this.computeClassTypeForLiteralType(keyType);
 
             const valueType = this.lowestCommonSupertype(node.entries.map((it) => this.computeType(it.value)));
             return this.coreTypes.Map(keyType, valueType);
@@ -679,10 +677,15 @@ export class SafeDsTypeComputer {
     }
 
     /**
-     * Returns the lowest class type for the given literal type.
+     * Returns the lowest class type for the given literal type. If the given type is not a literal type, it is returned
+     * as is.
      */
-    computeClassTypeForLiteralType(literalType: LiteralType): Type {
-        return this.lowestCommonSupertype(literalType.constants.map((it) => this.computeClassTypeForConstant(it)));
+    computeClassTypeForLiteralType(type: Type): Type {
+        if (!(type instanceof LiteralType)) {
+            return type;
+        }
+
+        return this.lowestCommonSupertype(type.constants.map((it) => this.computeClassTypeForConstant(it)));
     }
 
     /**

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -528,8 +528,8 @@ export class SafeDsTypeComputer {
         const rightOperandType = this.computeType(node.rightOperand);
 
         if (
-            this.typeChecker.isSubtypeOf(leftOperandType, this.coreTypes.Int, { strictTypeParameterTypeCheck: true }) &&
-            this.typeChecker.isSubtypeOf(rightOperandType, this.coreTypes.Int, { strictTypeParameterTypeCheck: true })
+            this.typeChecker.isSubtypeOf(leftOperandType, this.coreTypes.Int) &&
+            this.typeChecker.isSubtypeOf(rightOperandType, this.coreTypes.Int)
         ) {
             return this.coreTypes.Int;
         } else {
@@ -581,7 +581,7 @@ export class SafeDsTypeComputer {
     private computeTypeOfArithmeticPrefixOperation(node: SdsPrefixOperation): Type {
         const operandType = this.computeType(node.operand);
 
-        if (this.typeChecker.isSubtypeOf(operandType, this.coreTypes.Int, { strictTypeParameterTypeCheck: true })) {
+        if (this.typeChecker.isSubtypeOf(operandType, this.coreTypes.Int)) {
             return this.coreTypes.Int;
         } else {
             return this.coreTypes.Float;
@@ -874,7 +874,7 @@ export class SafeDsTypeComputer {
                 stopAtTypeParameterType: true,
             }).substituteTypeParameters(state.substitutions);
 
-            if (!this.typeChecker.isSubtypeOf(newSubstitution, upperBound, { strictTypeParameterTypeCheck: true })) {
+            if (!this.typeChecker.isSubtypeOf(newSubstitution, upperBound)) {
                 newSubstitution = upperBound;
             }
 
@@ -1243,15 +1243,12 @@ export class SafeDsTypeComputer {
         return otherTypes.every((it) =>
             this.typeChecker.isSupertypeOf(candidate, it, {
                 ignoreTypeParameters: true,
-                strictTypeParameterTypeCheck: true,
             }),
         );
     }
 
     private isCommonSupertype(candidate: Type, otherTypes: Type[]): boolean {
-        return otherTypes.every((it) =>
-            this.typeChecker.isSupertypeOf(candidate, it, { strictTypeParameterTypeCheck: true }),
-        );
+        return otherTypes.every((it) => this.typeChecker.isSupertypeOf(candidate, it));
     }
 
     // -----------------------------------------------------------------------------------------------------------------
@@ -1486,15 +1483,12 @@ export class SafeDsTypeComputer {
         return otherTypes.every((it) =>
             this.typeChecker.isSubtypeOf(candidate, it, {
                 ignoreTypeParameters: true,
-                strictTypeParameterTypeCheck: true,
             }),
         );
     }
 
     private isCommonSubtype(candidate: Type, otherTypes: Type[]): boolean {
-        return otherTypes.every((it) =>
-            this.typeChecker.isSubtypeOf(candidate, it, { strictTypeParameterTypeCheck: true }),
-        );
+        return otherTypes.every((it) => this.typeChecker.isSubtypeOf(candidate, it));
     }
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -455,7 +455,7 @@ export class SafeDsTypeComputer {
 
             // Substitute type parameters
             if (isSdsFunction(nonNullableReceiverType.callable)) {
-                const substitutions = this.computeTypeParameterSubstitutionsForCall(node);
+                const substitutions = this.computeSubstitutionsForCall(node);
                 result = result.substituteTypeParameters(substitutions);
             }
         } else if (nonNullableReceiverType instanceof StaticType) {
@@ -466,7 +466,7 @@ export class SafeDsTypeComputer {
 
             // Substitute type parameters
             if (instanceType instanceof ClassType) {
-                const substitutions = this.computeTypeParameterSubstitutionsForCall(node);
+                const substitutions = this.computeSubstitutionsForCall(node);
 
                 result = this.factory.createClassType(
                     instanceType.declaration,
@@ -786,7 +786,7 @@ export class SafeDsTypeComputer {
      * @param call The call to compute substitutions for.
      * @returns The computed substitutions for the type parameters of the callable.
      */
-    computeTypeParameterSubstitutionsForCall(call: SdsCall): TypeParameterSubstitutions {
+    computeSubstitutionsForCall(call: SdsCall): TypeParameterSubstitutions {
         const callable = this.nodeMapper.callToCallable(call);
         const typeParameters = getTypeParameters(callable);
         if (isEmpty(typeParameters)) {

--- a/packages/safe-ds-lang/src/language/validation/inheritance.ts
+++ b/packages/safe-ds-lang/src/language/validation/inheritance.ts
@@ -31,11 +31,7 @@ export const classMemberMustMatchOverriddenMemberAndShouldBeNeeded = (services: 
             computeMemberTypes(node, overriddenMember, typeComputer);
 
         // Check whether the overriding is legal and needed
-        if (
-            !typeChecker.isSubtypeOf(substitutedOwnMemberType, overriddenMemberType, {
-                strictTypeParameterTypeCheck: true,
-            })
-        ) {
+        if (!typeChecker.isSubtypeOf(substitutedOwnMemberType, overriddenMemberType)) {
             accept(
                 'error',
                 expandToStringWithNL`
@@ -49,11 +45,7 @@ export const classMemberMustMatchOverriddenMemberAndShouldBeNeeded = (services: 
                     code: CODE_INHERITANCE_INCOMPATIBLE_TO_OVERRIDDEN_MEMBER,
                 },
             );
-        } else if (
-            typeChecker.isSubtypeOf(substitutedOverriddenMemberType, ownMemberType, {
-                strictTypeParameterTypeCheck: true,
-            })
-        ) {
+        } else if (typeChecker.isSubtypeOf(substitutedOverriddenMemberType, ownMemberType)) {
             // Prevents the info from showing when editing the builtin files
             if (isInSafedsLangAnyClass(services, node)) {
                 return;

--- a/packages/safe-ds-lang/src/language/validation/other/expressions/infixOperations.ts
+++ b/packages/safe-ds-lang/src/language/validation/other/expressions/infixOperations.ts
@@ -24,8 +24,8 @@ export const divisionDivisorMustNotBeZero = (services: SafeDsServices) => {
         const dividendType = typeComputer.computeType(node.leftOperand);
         if (
             dividendType === UnknownType ||
-            (!typeChecker.isSubtypeOf(dividendType, coreTypes.Float, { strictTypeParameterTypeCheck: true }) &&
-                !typeChecker.isSubtypeOf(dividendType, coreTypes.Int, { strictTypeParameterTypeCheck: true }))
+            (!typeChecker.isSubtypeOf(dividendType, coreTypes.Float) &&
+                !typeChecker.isSubtypeOf(dividendType, coreTypes.Int))
         ) {
             return;
         }

--- a/packages/safe-ds-lang/src/language/validation/other/expressions/infixOperations.ts
+++ b/packages/safe-ds-lang/src/language/validation/other/expressions/infixOperations.ts
@@ -24,8 +24,8 @@ export const divisionDivisorMustNotBeZero = (services: SafeDsServices) => {
         const dividendType = typeComputer.computeType(node.leftOperand);
         if (
             dividendType === UnknownType ||
-            (!typeChecker.isSubtypeOf(dividendType, coreTypes.Float) &&
-                !typeChecker.isSubtypeOf(dividendType, coreTypes.Int))
+            (!typeChecker.isSubtypeOf(dividendType, coreTypes.Float, { strictTypeParameterTypeCheck: true }) &&
+                !typeChecker.isSubtypeOf(dividendType, coreTypes.Int, { strictTypeParameterTypeCheck: true }))
         ) {
             return;
         }

--- a/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
+++ b/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
@@ -157,8 +157,8 @@ import {
     unionTypeShouldNotHaveASingularTypeArgument,
 } from './style.js';
 import {
-    argumentTypeMustMatchParameterType,
     attributeMustHaveTypeHint,
+    callArgumentTypesMustMatchParameterTypes,
     callReceiverMustBeCallable,
     indexedAccessIndexMustHaveCorrectType,
     indexedAccessReceiverMustBeListOrMap,
@@ -216,7 +216,6 @@ export const registerValidationChecks = function (services: SafeDsServices) {
         SdsArgument: [
             argumentCorrespondingParameterShouldNotBeDeprecated(services),
             argumentCorrespondingParameterShouldNotBeExperimental(services),
-            argumentTypeMustMatchParameterType(services),
         ],
         SdsArgumentList: [
             argumentListMustNotHavePositionalArgumentsAfterNamedArguments,
@@ -228,6 +227,7 @@ export const registerValidationChecks = function (services: SafeDsServices) {
             callArgumentListShouldBeNeeded(services),
             callArgumentAssignedToPureParameterMustBePure(services),
             callArgumentMustBeConstantIfParameterIsConstant(services),
+            callArgumentTypesMustMatchParameterTypes(services),
             callMustNotBeRecursive(services),
             callReceiverMustBeCallable(services),
         ],

--- a/packages/safe-ds-lang/src/language/validation/types.ts
+++ b/packages/safe-ds-lang/src/language/validation/types.ts
@@ -328,7 +328,7 @@ export const prefixOperationOperandMustHaveCorrectType = (services: SafeDsServic
         const operandType = typeComputer.computeType(node.operand);
         switch (node.operator) {
             case 'not':
-                if (!typeChecker.isSubtypeOf(operandType, coreTypes.Boolean)) {
+                if (!typeChecker.isSubtypeOf(operandType, coreTypes.Boolean, { strictTypeParameterTypeCheck: true })) {
                     accept('error', `Expected type '${coreTypes.Boolean}' but got '${operandType}'.`, {
                         node,
                         property: 'operand',
@@ -338,8 +338,8 @@ export const prefixOperationOperandMustHaveCorrectType = (services: SafeDsServic
                 return;
             case '-':
                 if (
-                    !typeChecker.isSubtypeOf(operandType, coreTypes.Float) &&
-                    !typeChecker.isSubtypeOf(operandType, coreTypes.Int)
+                    !typeChecker.isSubtypeOf(operandType, coreTypes.Float, { strictTypeParameterTypeCheck: true }) &&
+                    !typeChecker.isSubtypeOf(operandType, coreTypes.Int, { strictTypeParameterTypeCheck: true })
                 ) {
                     accept(
                         'error',

--- a/packages/safe-ds-lang/src/language/validation/types.ts
+++ b/packages/safe-ds-lang/src/language/validation/types.ts
@@ -160,13 +160,19 @@ export const infixOperationOperandsMustHaveCorrectType = (services: SafeDsServic
         switch (node.operator) {
             case 'or':
             case 'and':
-                if (node.leftOperand && !typeChecker.isSubtypeOf(leftType, coreTypes.Boolean)) {
+                if (
+                    node.leftOperand &&
+                    !typeChecker.isSubtypeOf(leftType, coreTypes.Boolean, { strictTypeParameterTypeCheck: true })
+                ) {
                     accept('error', `Expected type '${coreTypes.Boolean}' but got '${leftType}'.`, {
                         node: node.leftOperand,
                         code: CODE_TYPE_MISMATCH,
                     });
                 }
-                if (node.rightOperand && !typeChecker.isSubtypeOf(rightType, coreTypes.Boolean)) {
+                if (
+                    node.rightOperand &&
+                    !typeChecker.isSubtypeOf(rightType, coreTypes.Boolean, { strictTypeParameterTypeCheck: true })
+                ) {
                     accept('error', `Expected type '${coreTypes.Boolean}' but got '${rightType}'.`, {
                         node: node.rightOperand,
                         code: CODE_TYPE_MISMATCH,
@@ -183,8 +189,8 @@ export const infixOperationOperandsMustHaveCorrectType = (services: SafeDsServic
             case '/':
                 if (
                     node.leftOperand &&
-                    !typeChecker.isSubtypeOf(leftType, coreTypes.Float) &&
-                    !typeChecker.isSubtypeOf(leftType, coreTypes.Int)
+                    !typeChecker.isSubtypeOf(leftType, coreTypes.Float, { strictTypeParameterTypeCheck: true }) &&
+                    !typeChecker.isSubtypeOf(leftType, coreTypes.Int, { strictTypeParameterTypeCheck: true })
                 ) {
                     accept('error', `Expected type '${coreTypes.Float}' or '${coreTypes.Int}' but got '${leftType}'.`, {
                         node: node.leftOperand,
@@ -193,8 +199,8 @@ export const infixOperationOperandsMustHaveCorrectType = (services: SafeDsServic
                 }
                 if (
                     node.rightOperand &&
-                    !typeChecker.isSubtypeOf(rightType, coreTypes.Float) &&
-                    !typeChecker.isSubtypeOf(rightType, coreTypes.Int)
+                    !typeChecker.isSubtypeOf(rightType, coreTypes.Float, { strictTypeParameterTypeCheck: true }) &&
+                    !typeChecker.isSubtypeOf(rightType, coreTypes.Int, { strictTypeParameterTypeCheck: true })
                 ) {
                     accept(
                         'error',
@@ -400,7 +406,7 @@ export const yieldTypeMustMatchResultType = (services: SafeDsServices) => {
         const yieldType = typeComputer.computeType(node);
         const resultType = typeComputer.computeType(result);
 
-        if (!typeChecker.isSubtypeOf(yieldType, resultType)) {
+        if (!typeChecker.isSubtypeOf(yieldType, resultType, { strictTypeParameterTypeCheck: true })) {
             accept('error', `Expected type '${resultType}' but got '${yieldType}'.`, {
                 node,
                 property: 'result',

--- a/packages/safe-ds-lang/src/language/validation/types.ts
+++ b/packages/safe-ds-lang/src/language/validation/types.ts
@@ -10,7 +10,6 @@ import {
     isSdsPipeline,
     isSdsReference,
     isSdsSchema,
-    SdsArgument,
     SdsAttribute,
     SdsCall,
     SdsIndexedAccess,
@@ -25,7 +24,7 @@ import {
     SdsTypeParameter,
     SdsYield,
 } from '../generated/ast.js';
-import { getTypeArguments, getTypeParameters, TypeParameter } from '../helpers/nodeProperties.js';
+import { getArguments, getTypeArguments, getTypeParameters, TypeParameter } from '../helpers/nodeProperties.js';
 import { SafeDsServices } from '../safe-ds-module.js';
 import { ClassType, NamedTupleType, TypeParameterType, UnknownType } from '../typing/model.js';
 
@@ -38,26 +37,30 @@ export const CODE_TYPE_MISSING_TYPE_HINT = 'type/missing-type-hint';
 // Type checking
 // -----------------------------------------------------------------------------
 
-export const argumentTypeMustMatchParameterType = (services: SafeDsServices) => {
+export const callArgumentTypesMustMatchParameterTypes = (services: SafeDsServices) => {
     const nodeMapper = services.helpers.NodeMapper;
     const typeChecker = services.types.TypeChecker;
     const typeComputer = services.types.TypeComputer;
 
-    return (node: SdsArgument, accept: ValidationAcceptor) => {
-        const parameter = nodeMapper.argumentToParameter(node);
-        if (!parameter) {
-            return;
-        }
+    return (node: SdsCall, accept: ValidationAcceptor) => {
+        const substitutions = typeComputer.computeSubstitutionsForCall(node);
 
-        const argumentType = typeComputer.computeType(node);
-        const parameterType = typeComputer.computeType(parameter);
+        for (const argument of getArguments(node)) {
+            const parameter = nodeMapper.argumentToParameter(argument);
+            if (!parameter) {
+                return;
+            }
 
-        if (!typeChecker.isSubtypeOf(argumentType, parameterType)) {
-            accept('error', `Expected type '${parameterType}' but got '${argumentType}'.`, {
-                node,
-                property: 'value',
-                code: CODE_TYPE_MISMATCH,
-            });
+            const argumentType = typeComputer.computeType(argument).substituteTypeParameters(substitutions);
+            const parameterType = typeComputer.computeType(parameter).substituteTypeParameters(substitutions);
+
+            if (!typeChecker.isSubtypeOf(argumentType, parameterType)) {
+                accept('error', `Expected type '${parameterType}' but got '${argumentType}'.`, {
+                    node: argument,
+                    property: 'value',
+                    code: CODE_TYPE_MISMATCH,
+                });
+            }
         }
     };
 };

--- a/packages/safe-ds-lang/src/language/validation/types.ts
+++ b/packages/safe-ds-lang/src/language/validation/types.ts
@@ -301,12 +301,7 @@ export const parameterDefaultValueTypeMustMatchParameterType = (services: SafeDs
         }
 
         const defaultValueType = typeComputer.computeType(defaultValue);
-        let parameterType = typeComputer.computeType(node);
-
-        // Only the upper bound must match if the default value does not have a type parameter type
-        if (!(defaultValueType instanceof TypeParameterType) && parameterType instanceof TypeParameterType) {
-            parameterType = typeComputer.computeUpperBound(parameterType, { stopAtTypeParameterType: true });
-        }
+        const parameterType = typeComputer.computeType(node);
 
         if (!typeChecker.isSubtypeOf(defaultValueType, parameterType)) {
             accept('error', `Expected type '${parameterType}' but got '${defaultValueType}'.`, {

--- a/packages/safe-ds-lang/src/language/validation/types.ts
+++ b/packages/safe-ds-lang/src/language/validation/types.ts
@@ -307,9 +307,14 @@ export const parameterDefaultValueTypeMustMatchParameterType = (services: SafeDs
         }
 
         const defaultValueType = typeComputer.computeType(defaultValue);
-        const parameterType = typeComputer.computeType(node);
+        let parameterType = typeComputer.computeType(node);
 
-        if (!typeChecker.isSubtypeOf(defaultValueType, parameterType)) {
+        // Only the upper bound must match if the default value does not have a type parameter type
+        if (!(defaultValueType instanceof TypeParameterType) && parameterType instanceof TypeParameterType) {
+            parameterType = typeComputer.computeUpperBound(parameterType, { stopAtTypeParameterType: true });
+        }
+
+        if (!typeChecker.isSubtypeOf(defaultValueType, parameterType, { strictTypeParameterTypeCheck: true })) {
             accept('error', `Expected type '${parameterType}' but got '${defaultValueType}'.`, {
                 node,
                 property: 'defaultValue',

--- a/packages/safe-ds-lang/src/language/validation/types.ts
+++ b/packages/safe-ds-lang/src/language/validation/types.ts
@@ -125,7 +125,7 @@ export const indexedAccessIndexMustHaveCorrectType = (services: SafeDsServices) 
         const receiverType = typeComputer.computeType(node.receiver);
         if (typeChecker.isList(receiverType)) {
             const indexType = typeComputer.computeType(node.index);
-            if (!typeChecker.isSubtypeOf(indexType, coreTypes.Int)) {
+            if (!typeChecker.isSubtypeOf(indexType, coreTypes.Int, { strictTypeParameterTypeCheck: true })) {
                 accept('error', `Expected type '${coreTypes.Int}' but got '${indexType}'.`, {
                     node,
                     property: 'index',
@@ -137,7 +137,7 @@ export const indexedAccessIndexMustHaveCorrectType = (services: SafeDsServices) 
             if (mapType) {
                 const keyType = mapType.getTypeParameterTypeByIndex(0);
                 const indexType = typeComputer.computeType(node.index);
-                if (!typeChecker.isSubtypeOf(indexType, keyType)) {
+                if (!typeChecker.isSubtypeOf(indexType, keyType, { strictTypeParameterTypeCheck: true })) {
                     accept('error', `Expected type '${keyType}' but got '${indexType}'.`, {
                         node,
                         property: 'index',

--- a/packages/safe-ds-lang/src/language/validation/types.ts
+++ b/packages/safe-ds-lang/src/language/validation/types.ts
@@ -125,7 +125,7 @@ export const indexedAccessIndexMustHaveCorrectType = (services: SafeDsServices) 
         const receiverType = typeComputer.computeType(node.receiver);
         if (typeChecker.isList(receiverType)) {
             const indexType = typeComputer.computeType(node.index);
-            if (!typeChecker.isSubtypeOf(indexType, coreTypes.Int, { strictTypeParameterTypeCheck: true })) {
+            if (!typeChecker.isSubtypeOf(indexType, coreTypes.Int)) {
                 accept('error', `Expected type '${coreTypes.Int}' but got '${indexType}'.`, {
                     node,
                     property: 'index',
@@ -137,7 +137,7 @@ export const indexedAccessIndexMustHaveCorrectType = (services: SafeDsServices) 
             if (mapType) {
                 const keyType = mapType.getTypeParameterTypeByIndex(0);
                 const indexType = typeComputer.computeType(node.index);
-                if (!typeChecker.isSubtypeOf(indexType, keyType, { strictTypeParameterTypeCheck: true })) {
+                if (!typeChecker.isSubtypeOf(indexType, keyType)) {
                     accept('error', `Expected type '${keyType}' but got '${indexType}'.`, {
                         node,
                         property: 'index',
@@ -160,19 +160,13 @@ export const infixOperationOperandsMustHaveCorrectType = (services: SafeDsServic
         switch (node.operator) {
             case 'or':
             case 'and':
-                if (
-                    node.leftOperand &&
-                    !typeChecker.isSubtypeOf(leftType, coreTypes.Boolean, { strictTypeParameterTypeCheck: true })
-                ) {
+                if (node.leftOperand && !typeChecker.isSubtypeOf(leftType, coreTypes.Boolean)) {
                     accept('error', `Expected type '${coreTypes.Boolean}' but got '${leftType}'.`, {
                         node: node.leftOperand,
                         code: CODE_TYPE_MISMATCH,
                     });
                 }
-                if (
-                    node.rightOperand &&
-                    !typeChecker.isSubtypeOf(rightType, coreTypes.Boolean, { strictTypeParameterTypeCheck: true })
-                ) {
+                if (node.rightOperand && !typeChecker.isSubtypeOf(rightType, coreTypes.Boolean)) {
                     accept('error', `Expected type '${coreTypes.Boolean}' but got '${rightType}'.`, {
                         node: node.rightOperand,
                         code: CODE_TYPE_MISMATCH,
@@ -189,8 +183,8 @@ export const infixOperationOperandsMustHaveCorrectType = (services: SafeDsServic
             case '/':
                 if (
                     node.leftOperand &&
-                    !typeChecker.isSubtypeOf(leftType, coreTypes.Float, { strictTypeParameterTypeCheck: true }) &&
-                    !typeChecker.isSubtypeOf(leftType, coreTypes.Int, { strictTypeParameterTypeCheck: true })
+                    !typeChecker.isSubtypeOf(leftType, coreTypes.Float) &&
+                    !typeChecker.isSubtypeOf(leftType, coreTypes.Int)
                 ) {
                     accept('error', `Expected type '${coreTypes.Float}' or '${coreTypes.Int}' but got '${leftType}'.`, {
                         node: node.leftOperand,
@@ -199,8 +193,8 @@ export const infixOperationOperandsMustHaveCorrectType = (services: SafeDsServic
                 }
                 if (
                     node.rightOperand &&
-                    !typeChecker.isSubtypeOf(rightType, coreTypes.Float, { strictTypeParameterTypeCheck: true }) &&
-                    !typeChecker.isSubtypeOf(rightType, coreTypes.Int, { strictTypeParameterTypeCheck: true })
+                    !typeChecker.isSubtypeOf(rightType, coreTypes.Float) &&
+                    !typeChecker.isSubtypeOf(rightType, coreTypes.Int)
                 ) {
                     accept(
                         'error',
@@ -285,7 +279,7 @@ export const namedTypeTypeArgumentsMustMatchBounds = (services: SafeDsServices) 
                 .computeUpperBound(typeParameter, { stopAtTypeParameterType: true })
                 .substituteTypeParameters(type.substitutions);
 
-            if (!typeChecker.isSubtypeOf(typeArgumentType, upperBound, { strictTypeParameterTypeCheck: true })) {
+            if (!typeChecker.isSubtypeOf(typeArgumentType, upperBound)) {
                 accept('error', `Expected type '${upperBound}' but got '${typeArgumentType}'.`, {
                     node: typeArgument,
                     property: 'value',
@@ -314,7 +308,7 @@ export const parameterDefaultValueTypeMustMatchParameterType = (services: SafeDs
             parameterType = typeComputer.computeUpperBound(parameterType, { stopAtTypeParameterType: true });
         }
 
-        if (!typeChecker.isSubtypeOf(defaultValueType, parameterType, { strictTypeParameterTypeCheck: true })) {
+        if (!typeChecker.isSubtypeOf(defaultValueType, parameterType)) {
             accept('error', `Expected type '${parameterType}' but got '${defaultValueType}'.`, {
                 node,
                 property: 'defaultValue',
@@ -333,7 +327,7 @@ export const prefixOperationOperandMustHaveCorrectType = (services: SafeDsServic
         const operandType = typeComputer.computeType(node.operand);
         switch (node.operator) {
             case 'not':
-                if (!typeChecker.isSubtypeOf(operandType, coreTypes.Boolean, { strictTypeParameterTypeCheck: true })) {
+                if (!typeChecker.isSubtypeOf(operandType, coreTypes.Boolean)) {
                     accept('error', `Expected type '${coreTypes.Boolean}' but got '${operandType}'.`, {
                         node,
                         property: 'operand',
@@ -343,8 +337,8 @@ export const prefixOperationOperandMustHaveCorrectType = (services: SafeDsServic
                 return;
             case '-':
                 if (
-                    !typeChecker.isSubtypeOf(operandType, coreTypes.Float, { strictTypeParameterTypeCheck: true }) &&
-                    !typeChecker.isSubtypeOf(operandType, coreTypes.Int, { strictTypeParameterTypeCheck: true })
+                    !typeChecker.isSubtypeOf(operandType, coreTypes.Float) &&
+                    !typeChecker.isSubtypeOf(operandType, coreTypes.Int)
                 ) {
                     accept(
                         'error',
@@ -388,7 +382,7 @@ export const typeParameterDefaultValueMustMatchUpperBound = (services: SafeDsSer
         const defaultValueType = typeComputer.computeType(node.defaultValue);
         const upperBoundType = typeComputer.computeUpperBound(node, { stopAtTypeParameterType: true });
 
-        if (!typeChecker.isSubtypeOf(defaultValueType, upperBoundType, { strictTypeParameterTypeCheck: true })) {
+        if (!typeChecker.isSubtypeOf(defaultValueType, upperBoundType)) {
             accept('error', `Expected type '${upperBoundType}' but got '${defaultValueType}'.`, {
                 node,
                 property: 'defaultValue',
@@ -411,7 +405,7 @@ export const yieldTypeMustMatchResultType = (services: SafeDsServices) => {
         const yieldType = typeComputer.computeType(node);
         const resultType = typeComputer.computeType(result);
 
-        if (!typeChecker.isSubtypeOf(yieldType, resultType, { strictTypeParameterTypeCheck: true })) {
+        if (!typeChecker.isSubtypeOf(yieldType, resultType)) {
             accept('error', `Expected type '${resultType}' but got '${yieldType}'.`, {
                 node,
                 property: 'result',

--- a/packages/safe-ds-lang/tests/language/typing/type checker/isSubOrSupertypeOf.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/type checker/isSubOrSupertypeOf.test.ts
@@ -1059,7 +1059,7 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
         {
             type1: coreTypes.AnyOrNull,
             type2: unbounded,
-            expected: true,
+            expected: false,
         },
         {
             type1: coreTypes.Nothing,
@@ -1069,7 +1069,7 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
         {
             type1: coreTypes.NothingOrNull,
             type2: unbounded,
-            expected: true,
+            expected: false,
         },
 
         // Compare to UpperBound
@@ -1123,6 +1123,11 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
         {
             type1: indirectUpperBound,
             type2: indirectUpperBound,
+            expected: true,
+        },
+        {
+            type1: indirectUpperBound,
+            type2: upperBound,
             expected: true,
         },
         {

--- a/packages/safe-ds-lang/tests/language/typing/type checker/isSubOrSupertypeOf.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/type checker/isSubOrSupertypeOf.test.ts
@@ -1044,17 +1044,17 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
         {
             type1: upperBound,
             type2: unbounded,
-            expected: true,
+            expected: false,
         },
         {
             type1: indirectUpperBound,
             type2: unbounded,
-            expected: true,
+            expected: false,
         },
         {
             type1: unresolved,
             type2: unbounded,
-            expected: true,
+            expected: false,
         },
         {
             type1: coreTypes.AnyOrNull,
@@ -1076,7 +1076,7 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
         {
             type1: unbounded,
             type2: upperBound,
-            expected: true,
+            expected: false,
         },
         {
             type1: upperBound,
@@ -1091,7 +1091,7 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
         {
             type1: unresolved,
             type2: upperBound,
-            expected: true,
+            expected: false,
         },
         {
             type1: coreTypes.AnyOrNull,
@@ -1101,7 +1101,7 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
         {
             type1: coreTypes.Number,
             type2: upperBound,
-            expected: true,
+            expected: false,
         },
         {
             type1: coreTypes.Number.withExplicitNullability(true),
@@ -1111,7 +1111,7 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
         {
             type1: coreTypes.Number.withExplicitNullability(true),
             type2: upperBound.withExplicitNullability(true),
-            expected: true,
+            expected: false,
         },
         {
             type1: coreTypes.Nothing,
@@ -1162,7 +1162,7 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
         {
             type1: unbounded,
             type2: coreTypes.Any,
-            expected: true,
+            expected: false,
         },
         {
             type1: unbounded,

--- a/packages/safe-ds-lang/tests/resources/validation/types/checking/arguments/with type parameters.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/types/checking/arguments/with type parameters.sdstest
@@ -1,0 +1,75 @@
+package tests.validation.types.checking.arguments.withTypeParameters
+
+class Contravariant<in T>
+
+class C1<T>(
+    p1: T,
+    p2: T,
+)
+
+class C2<T sub Number>(
+    p1: T,
+    p2: T,
+)
+
+class C3<T>(
+    p1: T,
+    p2: Contravariant<T>,
+)
+
+@Pure fun f<T>(
+    c: (p: T) -> r: T
+)
+
+segment mySegment(
+    int: Int,
+    number: Number,
+    contravariantInt: Contravariant<Int>,
+) {
+    // $TEST$ no error r"Expected type .* but got .*\."
+    // $TEST$ no error r"Expected type .* but got .*\."
+    C1(»1«, »2«);
+
+    // $TEST$ no error r"Expected type .* but got .*\."
+    // $TEST$ no error r"Expected type .* but got .*\."
+    C1(»1«, »int«);
+
+
+    // $TEST$ no error r"Expected type .* but got .*\."
+    // $TEST$ no error r"Expected type .* but got .*\."
+    C2(»1«, »2«);
+
+    // $TEST$ no error r"Expected type .* but got .*\."
+    // $TEST$ error "Expected type 'Number' but got 'literal<"">'."
+    C2(»1«, »""«);
+
+
+    // $TEST$ no error r"Expected type .* but got .*\."
+    // $TEST$ no error r"Expected type .* but got .*\."
+    C3(»1«, »contravariantInt«);
+
+    // $TEST$ no error r"Expected type .* but got .*\."
+    // $TEST$ no error r"Expected type .* but got .*\."
+    C3(»int«, »contravariantInt«);
+
+    // $TEST$ no error r"Expected type .* but got .*\."
+    // $TEST$ error "Expected type 'Contravariant<Number>' but got 'Contravariant<Int>'."
+    C3(»number«, »contravariantInt«);
+
+    // $TEST$ no error r"Expected type .* but got .*\."
+    // $TEST$ error "Expected type 'Contravariant<literal<"">>' but got 'Contravariant<Int>'."
+    C3(»""«, »contravariantInt«);
+
+
+    // $TEST$ no error r"Expected type .* but got .*\."
+    f(»(p) -> p«);
+
+    // $TEST$ no error r"Expected type .* but got .*\."
+    f(»(p) -> 1«);
+
+    // $TEST$ no error r"Expected type .* but got .*\."
+    f(»(p: Int) -> p«);
+
+    // $TEST$ error "Expected type '(p: Int) -> (r: Int)' but got '(p: Int) -> (result: literal<"">)'."
+    f(»(p: Int) -> ""«);
+}

--- a/packages/safe-ds-lang/tests/resources/validation/types/checking/default values/with type parameters.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/types/checking/default values/with type parameters.sdstest
@@ -1,15 +1,15 @@
 package tests.validation.types.checking.defaultValues
 
 class SomeClass<T1, T2 sub Number, T3 sub T2>(
-    // $TEST$ no error r"Expected type .* but got .*\."
+    // $TEST$ error "Expected type 'T1' but got 'literal<true>'."
     a1: T1 = »true«,
-    // $TEST$ no error r"Expected type .* but got .*\."
+    // $TEST$ error "Expected type 'T1' but got 'literal<1>'."
     a2: T1 = »1«,
-    // $TEST$ error "Expected type 'Number' but got 'literal<"">'."
-    a3: T2 = »""«,
-    // $TEST$ error "Expected type 'T2' but got 'literal<1>'."
-    a4: T3 = »1«,
     // $TEST$ error "Expected type 'T2' but got 'literal<"">'."
+    a3: T2 = »""«,
+    // $TEST$ error "Expected type 'T3' but got 'literal<1>'."
+    a4: T3 = »1«,
+    // $TEST$ error "Expected type 'T3' but got 'literal<"">'."
     a5: T3 = »""«,
 
     // $TEST$ no error r"Expected type .* but got .*\."
@@ -23,15 +23,15 @@ class SomeClass<T1, T2 sub Number, T3 sub T2>(
 )
 
 @Pure fun someFunction<T1, T2 sub Number, T3 sub T2>(
-    // $TEST$ no error r"Expected type .* but got .*\."
+    // $TEST$ error "Expected type 'T1' but got 'literal<true>'."
     a1: T1 = »true«,
-    // $TEST$ no error r"Expected type .* but got .*\."
+    // $TEST$ error "Expected type 'T1' but got 'literal<1>'."
     a2: T1 = »1«,
-    // $TEST$ error "Expected type 'Number' but got 'literal<"">'."
-    a3: T2 = »""«,
-    // $TEST$ error "Expected type 'T2' but got 'literal<1>'."
-    a4: T3 = »1«,
     // $TEST$ error "Expected type 'T2' but got 'literal<"">'."
+    a3: T2 = »""«,
+    // $TEST$ error "Expected type 'T3' but got 'literal<1>'."
+    a4: T3 = »1«,
+    // $TEST$ error "Expected type 'T3' but got 'literal<"">'."
     a5: T3 = »""«,
 
     // $TEST$ no error r"Expected type .* but got .*\."

--- a/packages/safe-ds-lang/tests/resources/validation/types/checking/default values/with type parameters.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/types/checking/default values/with type parameters.sdstest
@@ -1,19 +1,45 @@
 package tests.validation.types.checking.defaultValues
 
-class SomeClass<T1, T2 sub Number>(
+class SomeClass<T1, T2 sub Number, T3 sub T2>(
     // $TEST$ no error r"Expected type .* but got .*\."
-    p1: T1 = »true«,
+    a1: T1 = »true«,
     // $TEST$ no error r"Expected type .* but got .*\."
-    p2: T1 = »1«,
+    a2: T1 = »1«,
+    // $TEST$ error "Expected type 'Number' but got 'literal<"">'."
+    a3: T2 = »""«,
+    // $TEST$ error "Expected type 'T2' but got 'literal<1>'."
+    a4: T3 = »1«,
     // $TEST$ error "Expected type 'T2' but got 'literal<"">'."
-    p3: T2 = »""«,
+    a5: T3 = »""«,
+
+    // $TEST$ no error r"Expected type .* but got .*\."
+    b1: T1 = »a1«,
+    // $TEST$ error "Expected type 'T2' but got 'T1'."
+    b2: T2 = »a1«,
+    // $TEST$ error "Expected type 'T1' but got 'T2'."
+    b3: T1 = »a3«,
+    // $TEST$ no error r"Expected type .* but got .*\."
+    b4: T2 = »a4«,
 )
 
-fun someFunction<T1, T2 sub Number>(
+@Pure fun someFunction<T1, T2 sub Number, T3 sub T2>(
     // $TEST$ no error r"Expected type .* but got .*\."
-    p1: T1 = »true«,
+    a1: T1 = »true«,
     // $TEST$ no error r"Expected type .* but got .*\."
-    p2: T1 = »1«,
+    a2: T1 = »1«,
+    // $TEST$ error "Expected type 'Number' but got 'literal<"">'."
+    a3: T2 = »""«,
+    // $TEST$ error "Expected type 'T2' but got 'literal<1>'."
+    a4: T3 = »1«,
     // $TEST$ error "Expected type 'T2' but got 'literal<"">'."
-    p3: T2 = »""«,
+    a5: T3 = »""«,
+
+    // $TEST$ no error r"Expected type .* but got .*\."
+    b1: T1 = »a1«,
+    // $TEST$ error "Expected type 'T2' but got 'T1'."
+    b2: T2 = »a1«,
+    // $TEST$ error "Expected type 'T1' but got 'T2'."
+    b3: T1 = »a3«,
+    // $TEST$ no error r"Expected type .* but got .*\."
+    b4: T2 = »a4«,
 )

--- a/packages/safe-ds-lang/tests/resources/validation/types/checking/indexed access on list/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/types/checking/indexed access on list/main.sdstest
@@ -25,3 +25,11 @@ pipeline myPipeline {
     // $TEST$ no error r"Expected type .* but got .*\."
     unresolved[»""«];
 }
+
+// Strict checking of type parameter types
+class MyClass<T sub Any>(
+    p1: T,
+
+    // $TEST$ error "Expected type 'Int' but got 'T'."
+    a: Any? = [0][»p1«],
+)

--- a/packages/safe-ds-lang/tests/resources/validation/types/checking/indexed access on map/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/types/checking/indexed access on map/main.sdstest
@@ -40,3 +40,11 @@ segment mySegment(
     // $TEST$ no error r"Expected type .* but got .*\."
     myMap[»key()«];
 }
+
+// Strict checking of type parameter types
+class MyClass<T sub Any>(
+    p1: T,
+
+    // $TEST$ error "Expected type 'String' but got 'T'."
+    a: Any? = {"": ""}[»p1«],
+)

--- a/packages/safe-ds-lang/tests/resources/validation/types/checking/infix operations/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/types/checking/infix operations/main.sdstest
@@ -128,3 +128,41 @@ pipeline myPipeline {
     // $TEST$ error "Expected type 'Float' or 'Int' but got '$unknown'."
     »unresolved« > »unresolved«;
 }
+
+// Strict checking of type parameter types
+class MyClass<T sub Any>(
+    p1: T,
+
+    // $TEST$ error "Expected type 'Boolean' but got 'T'."
+    // $TEST$ error "Expected type 'Boolean' but got 'T'."
+    a1: Any? = »p1« or »p1«,
+    // $TEST$ error "Expected type 'Boolean' but got 'T'."
+    // $TEST$ error "Expected type 'Boolean' but got 'T'."
+    a2: Any? = »p1« and »p1«,
+
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'T'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'T'."
+    b1: Any? = »p1« + »p1«,
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'T'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'T'."
+    b2: Any? = »p1« - »p1«,
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'T'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'T'."
+    b3: Any? = »p1« * »p1«,
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'T'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'T'."
+    b4: Any? = »p1« / »p1«,
+
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'T'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'T'."
+    c1: Any? = »p1« < »p1«,
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'T'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'T'."
+    c2: Any? = »p1« <= »p1«,
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'T'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'T'."
+    c3: Any? = »p1« >= »p1«,
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'T'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'T'."
+    c4: Any? = »p1« > »p1«,
+)

--- a/packages/safe-ds-lang/tests/resources/validation/types/checking/prefix operations/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/types/checking/prefix operations/main.sdstest
@@ -18,3 +18,14 @@ segment mySegment() {
     // $TEST$ error "Expected type 'Float' or 'Int' but got '$unknown'."
     -»unresolved«;
 }
+
+// Strict checking of type parameter types
+class MyClass<T sub Any>(
+    p1: T,
+
+    // $TEST$ error "Expected type 'Boolean' but got 'T'."
+    a: Any? = not »p1«,
+
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'T'."
+    b: Any? = -»p1«,
+)

--- a/packages/safe-ds-lang/tests/resources/validation/types/checking/type parameter bounds for default values/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/types/checking/type parameter bounds for default values/main.sdstest
@@ -17,6 +17,8 @@ class C2<
     T3 sub Number = »Number«,
     // $TEST$ no error r"Expected type '.*' but got '.*'\."
     T4 sub T1 = »T1«,
+    // $TEST$ error "Expected type 'T1' but got 'T2'."
+    T5 sub T1 = »T2«,
 >
 class C3<
     T1 sub Int,
@@ -45,6 +47,8 @@ class C3<
     T3 sub Number = »Number«,
     // $TEST$ no error r"Expected type '.*' but got '.*'\."
     T4 sub T1 = »T1«,
+    // $TEST$ error "Expected type 'T1' but got 'T2'."
+    T5 sub T1 = »T2«,
 >()
 @Pure fun f3<
     T1 sub Int,

--- a/packages/safe-ds-lang/tests/resources/validation/types/checking/type parameter bounds for named types/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/types/checking/type parameter bounds for named types/main.sdstest
@@ -4,18 +4,22 @@ class C1<T1>
 class C2<T1 sub Number>
 class C3<T1, T2 sub T1>
 
-@Pure fun f(
+@Pure fun f<T>(
     // $TEST$ no error r"Expected type '.*' but got '.*'\."
     a1: C1<»Any?«>,
     // $TEST$ no error r"Expected type '.*' but got '.*'\."
     a2: C1<T1 = »Any?«>,
     // $TEST$ no error r"Expected type '.*' but got '.*'\."
     a3: C1<Unknown = »Any?«>,
+    // $TEST$ no error r"Expected type '.*' but got '.*'\."
+    a4: C1<»T«>,
 
     // $TEST$ no error r"Expected type '.*' but got '.*'\."
     b1: C2<»Number«>,
     // $TEST$ error "Expected type 'Number' but got 'String'."
     b2: C2<»String«>,
+    // $TEST$ error "Expected type 'Number' but got 'T'."
+    b3: C2<»T«>,
 
     // $TEST$ no error r"Expected type '.*' but got '.*'\."
     // $TEST$ no error r"Expected type '.*' but got '.*'\."


### PR DESCRIPTION
Closes #915

### Summary of Changes

* Substitute type parameter when type checking calls.
* Remove lenient type checking mode. We now use the strict mode everywhere, which means when calling `isSubtypeOf(type, other)` that the upper bound of `type` must be a subtype of the lower bound of `other`.
