### PR TITLE
feat: VS Code command to dump diagnostics into a JSON file

### DIFF
--- a/packages/safe-ds-vscode/package.json
+++ b/packages/safe-ds-vscode/package.json
@@ -133,20 +133,20 @@
         },
         "commands": [
             {
-                "command": "safe-ds.runPipelineFile",
-                "title": "Run Pipeline",
-                "category": "Safe-DS",
-                "icon": "$(play)"
-            },
-            {
                 "command": "safe-ds.refreshWebview",
                 "title": "Refresh Webview",
-                "category": "EDA"
+                "category": "Safe-DS"
             },
             {
                 "command": "safe-ds.runEdaFromContext",
                 "title": "Explore Table",
-                "category": "EDA"
+                "category": "Safe-DS"
+            },
+            {
+                "command": "safe-ds.runPipelineFile",
+                "title": "Run Pipeline",
+                "category": "Safe-DS",
+                "icon": "$(play)"
             }
         ],
         "snippets": [

--- a/packages/safe-ds-vscode/package.json
+++ b/packages/safe-ds-vscode/package.json
@@ -133,6 +133,11 @@
         },
         "commands": [
             {
+                "command": "safe-ds.dumpDiagnostics",
+                "title": "Dump Diagnostics to JSON",
+                "category": "Safe-DS"
+            },
+            {
                 "command": "safe-ds.refreshWebview",
                 "title": "Refresh Webview",
                 "category": "Safe-DS"

--- a/packages/safe-ds-vscode/package.json
+++ b/packages/safe-ds-vscode/package.json
@@ -138,6 +138,11 @@
                 "category": "Safe-DS"
             },
             {
+                "command": "safe-ds.openDiagnosticsDumps",
+                "title": "Open Diagnostics Dumps in New VS Code Window",
+                "category": "Safe-DS"
+            },
+            {
                 "command": "safe-ds.refreshWebview",
                 "title": "Refresh Webview",
                 "category": "Safe-DS"

--- a/packages/safe-ds-vscode/src/extension/commands/dumpDiagnostics.ts
+++ b/packages/safe-ds-vscode/src/extension/commands/dumpDiagnostics.ts
@@ -1,0 +1,48 @@
+import vscode, { ExtensionContext, Uri } from 'vscode';
+
+export const dumpDiagnostics = (context: ExtensionContext) => async () => {
+    // Get the current document
+    const currentDocument = vscode.window.activeTextEditor?.document;
+    if (!currentDocument) {
+        vscode.window.showErrorMessage('No active document.');
+        return;
+    } else if (currentDocument.languageId !== 'safe-ds') {
+        vscode.window.showErrorMessage('The active document is not a Safe-DS document.');
+        return;
+    }
+
+    // Get diagnostics for the current document
+    const diagnostics = vscode.languages.getDiagnostics(currentDocument.uri);
+    if (diagnostics.length === 0) {
+        vscode.window.showErrorMessage('The active document has no diagnostics.');
+        return;
+    }
+
+    // Dump diagnostics to a file
+    const uri = vscode.Uri.joinPath(diagnosticsDumpsUri(context), `${basicISOTimestamp()}.json`);
+    const content = JSON.stringify(
+        {
+            text: currentDocument.getText(),
+            diagnostics,
+        },
+        null,
+        2,
+    );
+
+    await vscode.workspace.fs.writeFile(uri, Buffer.from(content));
+
+    // Inform the user and ask for further action
+    const item = await vscode.window.showInformationMessage(`Diagnostics successfully dumped.`, 'Open file', 'Close');
+
+    if (item === 'Open file') {
+        vscode.window.showTextDocument(uri);
+    }
+};
+
+export const diagnosticsDumpsUri = (context: ExtensionContext): Uri => {
+    return vscode.Uri.joinPath(context.globalStorageUri, 'diagnosticsDumps');
+};
+
+const basicISOTimestamp = (): string => {
+    return new Date().toISOString().replaceAll(/[-:]/gu, '');
+};

--- a/packages/safe-ds-vscode/src/extension/commands/dumpDiagnostics.ts
+++ b/packages/safe-ds-vscode/src/extension/commands/dumpDiagnostics.ts
@@ -19,9 +19,14 @@ export const dumpDiagnostics = (context: ExtensionContext) => async () => {
     }
 
     // Dump diagnostics to a file
-    const uri = vscode.Uri.joinPath(diagnosticsDumpsUri(context), `${basicISOTimestamp()}.json`);
+    const machineId = vscode.env.machineId;
+    const timestamp = new Date();
+    const fileName = `${machineId}-${toBasicISOString(timestamp)}.json`;
+    const uri = vscode.Uri.joinPath(diagnosticsDumpsUri(context), fileName);
     const content = JSON.stringify(
         {
+            machineId,
+            timestamp: timestamp.toISOString(),
             text: currentDocument.getText(),
             diagnostics,
         },
@@ -43,6 +48,6 @@ export const diagnosticsDumpsUri = (context: ExtensionContext): Uri => {
     return vscode.Uri.joinPath(context.globalStorageUri, 'diagnosticsDumps');
 };
 
-const basicISOTimestamp = (): string => {
-    return new Date().toISOString().replaceAll(/[-:]/gu, '');
+const toBasicISOString = (date: Date): string => {
+    return date.toISOString().replaceAll(/[-:]/gu, '');
 };

--- a/packages/safe-ds-vscode/src/extension/commands/openDiagnosticsDumps.ts
+++ b/packages/safe-ds-vscode/src/extension/commands/openDiagnosticsDumps.ts
@@ -1,0 +1,7 @@
+import vscode, { ExtensionContext } from 'vscode';
+import { diagnosticsDumpsUri } from './dumpDiagnostics.js';
+
+export const openDiagnosticsDumps = (context: ExtensionContext) => async () => {
+    const uri = diagnosticsDumpsUri(context);
+    vscode.commands.executeCommand('vscode.openFolder', uri, { forceNewWindow: true });
+};

--- a/packages/safe-ds-vscode/src/extension/mainClient.ts
+++ b/packages/safe-ds-vscode/src/extension/mainClient.ts
@@ -8,6 +8,7 @@ import { getSafeDSOutputChannel, initializeLog, logError, logOutput, printOutput
 import crypto from 'crypto';
 import { LangiumDocument, URI } from 'langium';
 import { EDAPanel, undefinedPanelIdentifier } from './eda/edaPanel.ts';
+import { dumpDiagnostics } from './commands/dumpDiagnostics.js';
 
 let client: LanguageClient;
 let services: SafeDsServices;
@@ -152,6 +153,8 @@ const registerVSCodeCommands = function (context: vscode.ExtensionContext) {
             return callback(...args);
         });
     };
+
+    context.subscriptions.push(vscode.commands.registerCommand('safe-ds.dumpDiagnostics', dumpDiagnostics(context)));
 
     context.subscriptions.push(vscode.commands.registerCommand('safe-ds.runPipelineFile', commandRunPipelineFile));
 

--- a/packages/safe-ds-vscode/src/extension/mainClient.ts
+++ b/packages/safe-ds-vscode/src/extension/mainClient.ts
@@ -9,6 +9,7 @@ import crypto from 'crypto';
 import { LangiumDocument, URI } from 'langium';
 import { EDAPanel, undefinedPanelIdentifier } from './eda/edaPanel.ts';
 import { dumpDiagnostics } from './commands/dumpDiagnostics.js';
+import { openDiagnosticsDumps } from './commands/openDiagnosticsDumps.js';
 
 let client: LanguageClient;
 let services: SafeDsServices;
@@ -155,6 +156,9 @@ const registerVSCodeCommands = function (context: vscode.ExtensionContext) {
     };
 
     context.subscriptions.push(vscode.commands.registerCommand('safe-ds.dumpDiagnostics', dumpDiagnostics(context)));
+    context.subscriptions.push(
+        vscode.commands.registerCommand('safe-ds.openDiagnosticsDumps', openDiagnosticsDumps(context)),
+    );
 
     context.subscriptions.push(vscode.commands.registerCommand('safe-ds.runPipelineFile', commandRunPipelineFile));
 


### PR DESCRIPTION
Closes #927

### Summary of Changes

Add two new commands:
* Dump Diagnostics to JSON
* Open Diagnostics Dumps in New VS Code Window (to quickly discover them)
