### PR TITLE
fix: type checking of two union types

### DIFF
--- a/packages/safe-ds-lang/tests/language/typing/type checker/isSubOrSupertypeOf.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/type checker/isSubOrSupertypeOf.test.ts
@@ -59,8 +59,6 @@ const basic = async (): Promise<IsSubOrSupertypeOfTest[]> => {
         class Class2() sub Class1
         class Class3
 
-        class Class4
-
         enum Enum1 {
             Variant1(p: Int)
             Variant2
@@ -654,7 +652,23 @@ const basic = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             type2: enumType1,
             expected: false,
         },
-        // Union type to X
+        // Union type to union type
+        {
+            type1: factory.createUnionType(classType1, classType2),
+            type2: factory.createUnionType(classType1, classType2),
+            expected: true,
+        },
+        {
+            type1: factory.createUnionType(classType1, classType2),
+            type2: factory.createUnionType(classType1, classType3),
+            expected: true,
+        },
+        {
+            type1: factory.createUnionType(classType1, classType3),
+            type2: factory.createUnionType(classType1, classType2),
+            expected: false,
+        },
+        // Union type to other
         {
             type1: factory.createUnionType(),
             type2: classType1,


### PR DESCRIPTION
### Summary of Changes

The quantifiers were in the wrong order when checking whether two union types were subtypes of each other: 

Previously, `isSubtypeOf` only returned `true`, if **there was** one entry of `other` that was a supertype **of all** entries of `type`.

Now, it returns `true` if **for all** entries of `type` **there is** one entry of `other` that is a supertype.
