### PR TITLE
feat: `unknown` default value of stub parameters

### DIFF
--- a/docs/lexer/safe_ds_lexer/_safe_ds_lexer.py
+++ b/docs/lexer/safe_ds_lexer/_safe_ds_lexer.py
@@ -23,6 +23,7 @@ keywords_literal = (
     "false",
     "null",
     "true",
+    "unknown",
 )
 
 keywords_namespace = (

--- a/packages/safe-ds-lang/src/language/grammar/safe-ds.langium
+++ b/packages/safe-ds-lang/src/language/grammar/safe-ds.langium
@@ -756,6 +756,7 @@ SdsLiteral returns SdsLiteral:
   | SdsMap
   | SdsNull
   | SdsString
+  | SdsUnknown
 ;
 
 interface SdsBoolean extends SdsLiteral {
@@ -822,6 +823,12 @@ interface SdsString extends SdsLiteral {
 
 SdsString returns SdsString:
     value=STRING
+;
+
+interface SdsUnknown extends SdsLiteral {}
+
+SdsUnknown returns SdsUnknown:
+    {SdsUnknown} 'unknown'
 ;
 
 interface SdsParenthesizedExpression extends SdsExpression {

--- a/packages/safe-ds-lang/src/language/partialEvaluation/safe-ds-partial-evaluator.ts
+++ b/packages/safe-ds-lang/src/language/partialEvaluation/safe-ds-partial-evaluator.ts
@@ -681,7 +681,14 @@ export class SafeDsPartialEvaluator {
      * Returns whether the given expression can be the value of a constant parameter.
      */
     canBeValueOfConstantParameter = (node: SdsExpression): boolean => {
-        if (isSdsBoolean(node) || isSdsFloat(node) || isSdsInt(node) || isSdsNull(node) || isSdsString(node)) {
+        if (
+            isSdsBoolean(node) ||
+            isSdsFloat(node) ||
+            isSdsInt(node) ||
+            isSdsNull(node) ||
+            isSdsString(node) ||
+            isSdsUnknown(node)
+        ) {
             return true;
         } else if (isSdsCall(node)) {
             // If some arguments are not provided, we already show an error.

--- a/packages/safe-ds-lang/src/language/partialEvaluation/safe-ds-partial-evaluator.ts
+++ b/packages/safe-ds-lang/src/language/partialEvaluation/safe-ds-partial-evaluator.ts
@@ -34,6 +34,7 @@ import {
     isSdsTemplateStringInner,
     isSdsTemplateStringStart,
     isSdsTypeCast,
+    isSdsUnknown,
     type SdsArgument,
     type SdsAssignee,
     type SdsCall,
@@ -212,6 +213,8 @@ export class SafeDsPartialEvaluator {
             return new StringConstant(node.value);
         } else if (isSdsTemplateStringEnd(node)) {
             return new StringConstant(node.value);
+        } else if (isSdsUnknown(node)) {
+            return UnknownEvaluatedNode;
         } else if (isSdsBlockLambda(node)) {
             return new BlockLambdaClosure(node, substitutions);
         } else if (isSdsExpressionLambda(node)) {

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -41,6 +41,7 @@ import {
     isSdsTypeCast,
     isSdsTypeParameter,
     isSdsUnionType,
+    isSdsUnknown,
     isSdsYield,
     SdsAbstractResult,
     SdsAssignee,
@@ -345,6 +346,8 @@ export class SafeDsTypeComputer {
             return this.coreTypes.Map(keyType, valueType);
         } else if (isSdsTemplateString(node)) {
             return this.coreTypes.String;
+        } else if (isSdsUnknown(node)) {
+            return this.coreTypes.Nothing;
         }
 
         // Recursive cases

--- a/packages/safe-ds-lang/src/language/validation/other/expressions/literals.ts
+++ b/packages/safe-ds-lang/src/language/validation/other/expressions/literals.ts
@@ -1,0 +1,39 @@
+import {
+    isSdsCallable,
+    isSdsCallableType,
+    isSdsClass,
+    isSdsEnumVariant,
+    isSdsFunction,
+    isSdsParameter,
+    SdsUnknown,
+} from '../../../generated/ast.js';
+import { AstUtils, ValidationAcceptor } from 'langium';
+
+export const CODE_LITERALS_UNKNOWN = 'literals/unknown';
+
+export const unknownMustOnlyBeUsedAsDefaultValueOfStub = (node: SdsUnknown, accept: ValidationAcceptor): void => {
+    if (!unknownIsUsedCorrectly(node)) {
+        accept(
+            'error',
+            'unknown is only allowed as the default value of a parameter of a class, enum variant, or function.',
+            {
+                node,
+                code: CODE_LITERALS_UNKNOWN,
+            },
+        );
+    }
+};
+
+const unknownIsUsedCorrectly = (node: SdsUnknown): boolean => {
+    if (!isSdsParameter(node.$container) || node.$containerProperty !== 'defaultValue') {
+        return false;
+    }
+
+    const containingCallable = AstUtils.getContainerOfType(node.$container, isSdsCallable);
+    return (
+        isSdsCallableType(containingCallable) || // Callable types must not have default values in general
+        isSdsClass(containingCallable) ||
+        isSdsEnumVariant(containingCallable) ||
+        isSdsFunction(containingCallable)
+    );
+};

--- a/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
+++ b/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
@@ -185,6 +185,7 @@ import {
     parameterBoundRightOperandMustEvaluateToFloatConstantOrIntConstant,
     parameterDefaultValueMustRespectParameterBounds,
 } from './other/declarations/parameterBounds.js';
+import { unknownMustOnlyBeUsedAsDefaultValueOfStub } from './other/expressions/literals.js';
 
 /**
  * Register custom validation checks.
@@ -379,6 +380,7 @@ export const registerValidationChecks = function (services: SafeDsServices) {
             unionTypeShouldNotHaveDuplicateTypes(services),
             unionTypeShouldNotHaveASingularTypeArgument(services),
         ],
+        SdsUnknown: [unknownMustOnlyBeUsedAsDefaultValueOfStub],
         SdsYield: [yieldMustNotBeUsedInPipeline, yieldTypeMustMatchResultType(services)],
     };
     registry.register(checks);

--- a/packages/safe-ds-lang/tests/language/partialEvaluation/canBeValueOfConstantParameter.test.ts
+++ b/packages/safe-ds-lang/tests/language/partialEvaluation/canBeValueOfConstantParameter.test.ts
@@ -34,6 +34,10 @@ describe('SafeDsTypeChecker', async () => {
             expected: true,
         },
         {
+            code: 'unknown',
+            expected: true,
+        },
+        {
             code: 'unresolved()',
             expected: true,
         },

--- a/packages/safe-ds-lang/tests/language/typing/type computer/computeUpperBound.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/type computer/computeUpperBound.test.ts
@@ -16,7 +16,7 @@ const code = `
         LegalDirectBounds sub Number,
         LegalIndirectBounds sub LegalDirectBounds,
         UnnamedBounds sub literal<2>,
-        UnresolvedBounds sub unknown,
+        UnresolvedBounds sub Unresolved,
     >
 `;
 const module = await getNodeOfType(services, code, isSdsModule);

--- a/packages/safe-ds-lang/tests/resources/formatting/expressions/literals/unknown.sdstest
+++ b/packages/safe-ds-lang/tests/resources/formatting/expressions/literals/unknown.sdstest
@@ -1,0 +1,9 @@
+pipeline myPipeline {
+    unknown;
+}
+
+// -----------------------------------------------------------------------------
+
+pipeline myPipeline {
+    unknown;
+}

--- a/packages/safe-ds-lang/tests/resources/grammar/expressions/literals/good-unknown.sdstest
+++ b/packages/safe-ds-lang/tests/resources/grammar/expressions/literals/good-unknown.sdstest
@@ -1,0 +1,5 @@
+// $TEST$ no_syntax_error
+
+pipeline myPipeline {
+    unknown;
+}

--- a/packages/safe-ds-lang/tests/resources/grammar/keywords as names/bad-unescaped unknown.sdstest
+++ b/packages/safe-ds-lang/tests/resources/grammar/keywords as names/bad-unescaped unknown.sdstest
@@ -1,0 +1,3 @@
+// $TEST$ syntax_error
+
+class unknown

--- a/packages/safe-ds-lang/tests/resources/grammar/keywords as names/good-escapedKeywords.sdstest
+++ b/packages/safe-ds-lang/tests/resources/grammar/keywords as names/good-escapedKeywords.sdstest
@@ -26,6 +26,7 @@ class `segment`
 class `sub`
 class `true`
 class `union`
+class `unknown`
 class `val`
 class `where`
 class `yield`

--- a/packages/safe-ds-lang/tests/resources/partial evaluation/base cases/unknown literals/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/partial evaluation/base cases/unknown literals/main.sdstest
@@ -1,0 +1,6 @@
+package tests.partialValidation.baseCases.unknownLiterals
+
+pipeline test {
+    // $TEST$ serialization ?
+    »unknown«;
+}

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/literals/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/literals/main.sdstest
@@ -16,4 +16,7 @@ pipeline myPipeline {
 
     // $TEST$ serialization literal<"myString">
     val stringLiteral = »"myString"«;
+
+    // $TEST$ serialization Nothing
+    val unknownLiteral = »unknown«;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/highest common subtype/unknown type/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/highest common subtype/unknown type/main.sdstest
@@ -5,11 +5,11 @@ class Contravariant<in T>
 segment mySegment(
     one: Contravariant<literal<1>>,
     nullable: Contravariant<literal<null>>,
-    unknown: Contravariant<Unresolved>,
+    unresolved: Contravariant<Unresolved>,
 ) {
     // $TEST$ serialization List<Contravariant<Nothing>>
-    »[one, unknown]«;
+    »[one, unresolved]«;
 
     // $TEST$ serialization List<Contravariant<Nothing>>
-    »[nullable, unknown]«;
+    »[nullable, unresolved]«;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/singular type after simplification/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/singular type after simplification/main.sdstest
@@ -32,7 +32,7 @@ segment mySegment(
     »[C]«;
 
     // $TEST$ serialization List<$unknown>
-    »[unknown]«;
+    »[unresolved]«;
 }
 
 // $TEST$ serialization List<T>

--- a/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/unknown type/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/unknown type/main.sdstest
@@ -2,8 +2,8 @@ package tests.typing.lowestCommonSupertype.unknownType
 
 segment mySegment() {
     // $TEST$ serialization List<Any?>
-    »[1, unknown]«;
+    »[1, unresolved]«;
 
     // $TEST$ serialization List<Any?>
-    »[null, unknown]«;
+    »[null, unresolved]«;
 }

--- a/packages/safe-ds-lang/tests/resources/validation/other/expressions/literals/unknown must only be used as default value of stub/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/other/expressions/literals/unknown must only be used as default value of stub/main.sdstest
@@ -1,0 +1,30 @@
+package tests.validation.other.expressions.literals.unknownMustOnlyBeUsedAsDefaultValueOfStub
+
+// $TEST$ error "unknown is only allowed as the default value of a parameter of a class, enum variant, or function."
+annotation MyAnnotation(p: Int = »unknown«)
+
+// $TEST$ no error "unknown is only allowed as the default value of a parameter of a class, enum variant, or function."
+class MyClass(p: Int = »unknown«)
+
+enum MyEnum {
+    // $TEST$ no error "unknown is only allowed as the default value of a parameter of a class, enum variant, or function."
+    MyVariant(p: Int = »unknown«)
+}
+
+// $TEST$ no error "unknown is only allowed as the default value of a parameter of a class, enum variant, or function."
+fun myFunction(p: Int = »unknown«)
+
+segment mySegment(
+    // $TEST$ no error "unknown is only allowed as the default value of a parameter of a class, enum variant, or function."
+    f: (p: Int = »unknown«) -> (),
+    // $TEST$ error "unknown is only allowed as the default value of a parameter of a class, enum variant, or function."
+    p: Int = »unknown«,
+) {
+    // $TEST$ error "unknown is only allowed as the default value of a parameter of a class, enum variant, or function."
+    (p: Int = »unknown«) {};
+    // $TEST$ error "unknown is only allowed as the default value of a parameter of a class, enum variant, or function."
+    (p: Int = »unknown«) -> 1;
+
+    // $TEST$ error "unknown is only allowed as the default value of a parameter of a class, enum variant, or function."
+    »unknown«;
+}

--- a/packages/safe-ds-vscode/syntaxes/safe-ds.tmLanguage.json
+++ b/packages/safe-ds-vscode/syntaxes/safe-ds.tmLanguage.json
@@ -12,7 +12,7 @@
         },
         {
             "name": "constant.language.safe-ds",
-            "match": "\\b(false|null|true)\\b"
+            "match": "\\b(false|null|true|unknown)\\b"
         },
         {
             "name": "storage.type.safe-ds",


### PR DESCRIPTION
Closes #951

### Summary of Changes

Add a new literal `unknown` that can be used to mark parameters as optional if the exact default value of a class/enum variant/function parameter is unknown. This literal can be used nowhere else.