### PR TITLE
feat: `unknown` type

### DIFF
--- a/docs/language/common/types.md
+++ b/docs/language/common/types.md
@@ -309,6 +309,10 @@ If exactly one result is expected, the surrounding parentheses may be also remov
 (a: Int, b: Int) -> r: Int
 ```
 
+### Unknown
+
+If the actual type of a declaration is not known, you can denote that with the special type `#!sds unknown`. However, to later use the declaration in any meaningful way, you will have to cast it to another type.
+
 ## Corresponding Python Code
 
 **Note:** This section is only relevant if you are interested in the [stub language][stub-language].

--- a/packages/safe-ds-lang/src/language/grammar/safe-ds.langium
+++ b/packages/safe-ds-lang/src/language/grammar/safe-ds.langium
@@ -906,6 +906,7 @@ SdsPrimaryType returns SdsType:
   | SdsLiteralType
   | SdsNamedType
   | SdsUnionType
+  | SdsUnknownType
 ;
 
 interface SdsCallableType extends SdsCallable, SdsType {
@@ -973,6 +974,12 @@ SdsUnionTypeArgumentList returns SdsTypeArgumentList:
 
 SdsUnionTypeArgument returns SdsTypeArgument:
     value=SdsType
+;
+
+interface SdsUnknownType extends SdsType {}
+
+SdsUnknownType returns SdsType:
+    {SdsUnknownType} 'unknown'
 ;
 
 SdsParentType returns SdsType:

--- a/packages/safe-ds-lang/src/language/typing/model.ts
+++ b/packages/safe-ds-lang/src/language/typing/model.ts
@@ -786,7 +786,7 @@ class UnknownTypeClass extends Type {
     }
 
     override toString(): string {
-        return '$unknown';
+        return 'unknown';
     }
 
     override simplify(): Type {

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -42,6 +42,7 @@ import {
     isSdsTypeParameter,
     isSdsUnionType,
     isSdsUnknown,
+    isSdsUnknownType,
     isSdsYield,
     SdsAbstractResult,
     SdsAssignee,
@@ -605,6 +606,8 @@ export class SafeDsTypeComputer {
             return this.factory.createUnionType(
                 ...typeArguments.map((typeArgument) => this.computeType(typeArgument.value)),
             );
+        } else if (isSdsUnknownType(node)) {
+            return UnknownType;
         } /* c8 ignore start */ else {
             return UnknownType;
         } /* c8 ignore stop */

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -743,7 +743,7 @@ export class SafeDsTypeComputer {
     /**
      * Returns the upper bound for the given input. If no upper bound is specified explicitly, the result is `Any?`. If
      * invalid upper bounds are specified, but are invalid (e.g. because of an unresolved reference or a cycle),
-     * `$unknown` is returned. The result is simplified as much as possible.
+     * `unknown` is returned. The result is simplified as much as possible.
      */
     computeUpperBound(nodeOrType: SdsTypeParameter | TypeParameterType, options: ComputeUpperBoundOptions = {}): Type {
         let type: TypeParameterType;

--- a/packages/safe-ds-lang/tests/language/typing/model.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/model.test.ts
@@ -159,7 +159,7 @@ describe('type model', async () => {
                 factory.createNamedTupleType(new NamedTupleEntry(parameter1, 'p1', UnknownType)),
                 factory.createNamedTupleType(),
             ),
-            expectedString: '(p1: $unknown) -> ()',
+            expectedString: '(p1: unknown) -> ()',
         },
         {
             value: factory.createCallableType(
@@ -168,7 +168,7 @@ describe('type model', async () => {
                 factory.createNamedTupleType(new NamedTupleEntry(parameter2, 'p2', UnknownType)),
                 factory.createNamedTupleType(),
             ),
-            expectedString: '(p2?: $unknown) -> ()',
+            expectedString: '(p2?: unknown) -> ()',
         },
         {
             value: factory.createLiteralType(new BooleanConstant(true)),
@@ -176,7 +176,7 @@ describe('type model', async () => {
         },
         {
             value: factory.createNamedTupleType(new NamedTupleEntry(parameter1, 'p1', UnknownType)),
-            expectedString: '(p1: $unknown)',
+            expectedString: '(p1: unknown)',
         },
         {
             value: new ClassType(class1, new Map(), false),
@@ -220,11 +220,11 @@ describe('type model', async () => {
         },
         {
             value: factory.createUnionType(UnknownType),
-            expectedString: 'union<$unknown>',
+            expectedString: 'union<unknown>',
         },
         {
             value: UnknownType,
-            expectedString: '$unknown',
+            expectedString: 'unknown',
         },
     ];
     describe.each(toStringTests)('toString', ({ value, expectedString }) => {

--- a/packages/safe-ds-lang/tests/resources/formatting/types/unknown types/unknown.sdstest
+++ b/packages/safe-ds-lang/tests/resources/formatting/types/unknown types/unknown.sdstest
@@ -1,0 +1,5 @@
+segment mySegment(x: unknown) {}
+
+// -----------------------------------------------------------------------------
+
+segment mySegment(x: unknown) {}

--- a/packages/safe-ds-lang/tests/resources/grammar/types/unknown types/good-unknown.sdstest
+++ b/packages/safe-ds-lang/tests/resources/grammar/types/unknown types/good-unknown.sdstest
@@ -1,0 +1,5 @@
+// $TEST$ no_syntax_error
+
+segment mySegment(
+    x: unknown
+) {}

--- a/packages/safe-ds-lang/tests/resources/typing/assignees/block lambda results/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/assignees/block lambda results/main.sdstest
@@ -11,7 +11,7 @@ segment mySegment() -> (r: Int) {
 
     () {
         // $TEST$ serialization literal<1>
-        // $TEST$ serialization $unknown
+        // $TEST$ serialization unknown
         yield »r«, yield »s« = 1;
     };
 

--- a/packages/safe-ds-lang/tests/resources/typing/assignees/placeholders/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/assignees/placeholders/main.sdstest
@@ -10,7 +10,7 @@ segment mySegment1() -> (r: Int) {
 
 segment mySegment2() -> (r: Int, s: String) {
     // $TEST$ serialization literal<1>
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     val »r«, val »s« = 1;
 }
 

--- a/packages/safe-ds-lang/tests/resources/typing/assignees/yields/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/assignees/yields/main.sdstest
@@ -10,7 +10,7 @@ segment mySegment1() -> (r: Int) {
 
 segment mySegment2() -> (r: Int, s: String) {
     // $TEST$ serialization literal<1>
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »yield r«, »yield s« = 1;
 }
 

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/annotations/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/annotations/main.sdstest
@@ -6,5 +6,5 @@ annotation »myAnnotation1«
 // $TEST$ serialization (p1: Int, p2: String) -> ()
 annotation »myAnnotation3«(p1: Int, p2: String)
 
-// $TEST$ serialization (p1: $unknown) -> ()
+// $TEST$ serialization (p1: unknown) -> ()
 annotation »myAnnotation5«(p1)

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/attributes/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/attributes/main.sdstest
@@ -1,14 +1,14 @@
 package tests.typing.declarations.attributes
 
 class C {
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     attr »a«
 
     // $TEST$ equivalence_class instanceAttribute
     // $TEST$ equivalence_class instanceAttribute
     attr »b«: »Int«
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     static attr »c«
 
     // $TEST$ equivalence_class staticAttribute

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/functions/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/functions/main.sdstest
@@ -12,5 +12,5 @@ fun »myFunction3«(p1: Int, p2: String)
 // $TEST$ serialization (p1: Int, p2: String) -> (r1: Int, r2: String)
 fun »myFunction4«(p1: Int, p2: String) -> (r1: Int, r2: String)
 
-// $TEST$ serialization (p1: $unknown) -> (r1: $unknown)
+// $TEST$ serialization (p1: unknown) -> (r1: unknown)
 fun »myFunction5«(p1) -> (r1)

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of annotations/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of annotations/main.sdstest
@@ -4,5 +4,5 @@ package tests.typing.declarations.parameters.ofAnnotations
 // $TEST$ equivalence_class parameterType
 annotation MyAnnotation1(»p«: »Int«)
 
-// $TEST$ serialization $unknown
+// $TEST$ serialization unknown
 annotation MyAnnotation2(»p«)

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of block lambdas/that are isolated/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of block lambdas/that are isolated/main.sdstest
@@ -1,6 +1,6 @@
 package tests.typing.declarations.parameters.ofBlockLambdas.thatAreIsolated
 
 segment mySegment() {
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     (»p«) {};
 }

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of block lambdas/that are passed as arguments/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of block lambdas/that are passed as arguments/main.sdstest
@@ -12,15 +12,15 @@ segment mySegment() {
     // $TEST$ equivalence_class parameterType1
     higherOrderFunction1(param = (»p«) {});
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     higherOrderFunction2((»p«) {});
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     higherOrderFunction2(param = (»p«) {});
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     normalFunction((»p«) {});
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     normalFunction(param = (»p«) {});
 }

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of block lambdas/that are passed as default values/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of block lambdas/that are passed as default values/main.sdstest
@@ -7,11 +7,11 @@ fun higherOrderFunction1(
 )
 
 fun higherOrderFunction2(
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     param: () -> () = (»p«) {}
 )
 
 fun normalFunction(
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     param: Int = (»p«) {}
 )

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of block lambdas/that are yielded/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of block lambdas/that are yielded/main.sdstest
@@ -9,9 +9,9 @@ segment mySegment() -> (
     // $TEST$ equivalence_class parameterType2
     yield r = (»p«) {};
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     yield s = (»p«) {};
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     yield t = (»p«) {};
 }

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of callable types/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of callable types/main.sdstest
@@ -4,5 +4,5 @@ package tests.typing.declarations.parameters.ofCallableTypes
 // $TEST$ equivalence_class parameterType
 annotation MyAnnotation1(f: (»p«: »Int«) -> ())
 
-// $TEST$ serialization $unknown
+// $TEST$ serialization unknown
 annotation MyAnnotation2(f: (»p«) -> ())

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of classes/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of classes/main.sdstest
@@ -4,5 +4,5 @@ package tests.typing.declarations.parameters.ofClasses
 // $TEST$ equivalence_class parameterType
 class MyClass1(»p«: »Int«)
 
-// $TEST$ serialization $unknown
+// $TEST$ serialization unknown
 class MyClass2(»p«)

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of enum variants/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of enum variants/main.sdstest
@@ -5,6 +5,6 @@ enum MyEnum {
     // $TEST$ equivalence_class parameterType
     MyEnumVariant1(»p«: »Int«)
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     MyEnumVariant2(»p«)
 }

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of expression lambdas/that are isolated/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of expression lambdas/that are isolated/main.sdstest
@@ -1,6 +1,6 @@
 package tests.typing.declarations.parameters.ofExpressionLambdas.thatAreIsolated
 
 segment mySegment() {
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     (»p«) -> 1;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of expression lambdas/that are passed as arguments/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of expression lambdas/that are passed as arguments/main.sdstest
@@ -12,15 +12,15 @@ segment mySegment() {
     // $TEST$ equivalence_class parameterType1
     higherOrderFunction1(param = (»p«) -> "");
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     higherOrderFunction2((»p«) -> "");
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     higherOrderFunction2(param = (»p«) -> "");
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     normalFunction((»p«) -> "");
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     normalFunction(param = (»p«) -> "");
 }

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of expression lambdas/that are passed as default values/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of expression lambdas/that are passed as default values/main.sdstest
@@ -7,11 +7,11 @@ fun higherOrderFunction1(
 )
 
 fun higherOrderFunction2(
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     param: () -> r: String = (»p«) -> ""
 )
 
 fun normalFunction(
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     param: Int = (»p«) -> ""
 )

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of expression lambdas/that are yielded/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of expression lambdas/that are yielded/main.sdstest
@@ -9,9 +9,9 @@ segment mySegment() -> (
     // $TEST$ equivalence_class parameterType2
     yield r = (»p«) -> true;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     yield s = (»p«) -> true;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     yield t = (»p«) -> true;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of functions/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of functions/main.sdstest
@@ -4,5 +4,5 @@ package tests.typing.declarations.parameters.ofFunctions
 // $TEST$ equivalence_class parameterType
 fun myFunction1(»p«: »Int«)
 
-// $TEST$ serialization $unknown
+// $TEST$ serialization unknown
 fun myFunction2(»p«)

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of segments/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of segments/main.sdstest
@@ -4,5 +4,5 @@ package tests.typing.declarations.parameters.ofSegments
 // $TEST$ equivalence_class parameterType
 segment mySegment1(»p«: »Int«) {}
 
-// $TEST$ serialization $unknown
+// $TEST$ serialization unknown
 segment mySegment2(»p«) {}

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/pipelines/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/pipelines/main.sdstest
@@ -1,4 +1,4 @@
 package tests.typing.declarations.pipelines
 
-// $TEST$ serialization $unknown
+// $TEST$ serialization unknown
 pipeline »myPipeline« {}

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/segments/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/segments/main.sdstest
@@ -12,5 +12,5 @@ segment »mySegment3«(p1: Int, p2: String) {}
 // $TEST$ serialization (p1: Int, p2: String) -> (r1: Int, r2: String)
 segment »mySegment4«(p1: Int, p2: String) -> (r1: Int, r2: String) {}
 
-// $TEST$ serialization (p1: $unknown) -> (r1: $unknown)
+// $TEST$ serialization (p1: unknown) -> (r1: unknown)
 segment »mySegment5«(p1) -> (r1) {}

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/block lambdas/that are isolated/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/block lambdas/that are isolated/main.sdstest
@@ -3,12 +3,12 @@ package tests.typing.expressions.blockLambdas.thatAreIsolated
 fun g() -> r: Int
 
 segment mySegment() {
-    // $TEST$ serialization (p: $unknown) -> (r: literal<1>, s: $unknown)
+    // $TEST$ serialization (p: unknown) -> (r: literal<1>, s: unknown)
     »(p) {
         yield r, yield s = 1;
     }«;
 
-    // $TEST$ serialization (p: $unknown) -> (r: Int, s: $unknown)
+    // $TEST$ serialization (p: unknown) -> (r: Int, s: unknown)
     val f = »(p) {
         yield r, yield s = g();
     }«;

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/block lambdas/that are passed as arguments/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/block lambdas/that are passed as arguments/main.sdstest
@@ -12,34 +12,34 @@ segment mySegment() {
         yield s = "";
     }«);
 
-    // $TEST$ serialization (p: String) -> (r: literal<1>, s: $unknown)
+    // $TEST$ serialization (p: String) -> (r: literal<1>, s: unknown)
     higherOrderFunction1(param = »(p) {
         yield r, yield s = 1;
     }«);
 
-    // $TEST$ serialization (p: $unknown) -> (r: literal<1>, s: literal<"">)
+    // $TEST$ serialization (p: unknown) -> (r: literal<1>, s: literal<"">)
     higherOrderFunction2(»(p) {
         yield r = 1;
         yield s = "";
     }«);
 
-    // $TEST$ serialization (p: $unknown) -> (r: literal<1>, s: $unknown)
+    // $TEST$ serialization (p: unknown) -> (r: literal<1>, s: unknown)
     higherOrderFunction2(param = »(p) {
         yield r, yield s = 1;
     }«);
 
-    // $TEST$ serialization (p: $unknown) -> (r: literal<1>, s: literal<"">)
+    // $TEST$ serialization (p: unknown) -> (r: literal<1>, s: literal<"">)
     normalFunction(»(p) {
         yield r = 1;
         yield s = "";
     }«);
 
-    // $TEST$ serialization (p: $unknown) -> (r: literal<1>, s: $unknown)
+    // $TEST$ serialization (p: unknown) -> (r: literal<1>, s: unknown)
     normalFunction(param = »(p) {
         yield r, yield s = 1;
     }«);
 
-    // $TEST$ serialization (p: $unknown) -> (r: literal<1>, s: $unknown)
+    // $TEST$ serialization (p: unknown) -> (r: literal<1>, s: unknown)
     parameterlessFunction(»(p) {
         yield r, yield s = 1;
     }«);

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/block lambdas/that are passed as default values/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/block lambdas/that are passed as default values/main.sdstest
@@ -6,31 +6,31 @@ fun higherOrderFunction1(
         yield r = 1;
         yield s = "";
     }«,
-    // $TEST$ serialization (p: String) -> (r: literal<1>, s: $unknown)
+    // $TEST$ serialization (p: String) -> (r: literal<1>, s: unknown)
     param2: (p: String) -> (r: Int, s: String) = »(p) {
         yield r, yield s = 1;
     }«,
 )
 
 fun higherOrderFunction2(
-    // $TEST$ serialization (p: $unknown) -> (r: literal<1>, s: literal<"">)
+    // $TEST$ serialization (p: unknown) -> (r: literal<1>, s: literal<"">)
     param1: () -> () = »(p) {
         yield r = 1;
         yield s = "";
     }«,
-    // $TEST$ serialization (p: $unknown) -> (r: literal<1>, s: $unknown)
+    // $TEST$ serialization (p: unknown) -> (r: literal<1>, s: unknown)
     param2: () -> () = »(p) {
         yield r, yield s = 1;
     }«,
 )
 
 fun normalFunction(
-    // $TEST$ serialization (p: $unknown) -> (r: literal<1>, s: literal<"">)
+    // $TEST$ serialization (p: unknown) -> (r: literal<1>, s: literal<"">)
     param1: Int = »(p) {
         yield r = 1;
         yield s = "";
     }«,
-    // $TEST$ serialization (p: $unknown) -> (r: literal<1>, s: $unknown)
+    // $TEST$ serialization (p: unknown) -> (r: literal<1>, s: unknown)
     param2: Int = »(p) {
         yield r, yield s = 1;
     }«,

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/block lambdas/that are yielded/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/block lambdas/that are yielded/main.sdstest
@@ -11,13 +11,13 @@ segment mySegment() -> (
         yield s = "";
     }«;
 
-    // $TEST$ serialization (p: $unknown) -> (r: literal<1>, s: literal<"">)
+    // $TEST$ serialization (p: unknown) -> (r: literal<1>, s: literal<"">)
     yield s = »(p) {
         yield r = 1;
         yield s = "";
     }«;
 
-    // $TEST$ serialization (p: $unknown) -> (r: literal<1>, s: $unknown)
+    // $TEST$ serialization (p: unknown) -> (r: literal<1>, s: unknown)
     yield t = »(p) {
         yield r, yield s = 1;
     }«;

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/block lambdas/with manifest types/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/block lambdas/with manifest types/main.sdstest
@@ -7,7 +7,7 @@ segment mySegment() {
         yield s = "";
     }«;
 
-    // $TEST$ serialization (p: String) -> (r: literal<1>, s: $unknown)
+    // $TEST$ serialization (p: String) -> (r: literal<1>, s: unknown)
     »(p: String) {
         yield r, yield s = 1;
     }«;

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/calls/of annotations/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/calls/of annotations/main.sdstest
@@ -3,9 +3,9 @@ package tests.typing.expressions.calls.ofAnnotations
 annotation MyAnnotation
 
 pipeline myPipeline {
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »MyAnnotation()«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »MyAnnotation?()«;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/calls/of classes/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/calls/of classes/main.sdstest
@@ -6,12 +6,12 @@ pipeline myPipeline {
     // $TEST$ serialization C
     »C()«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »C()()«;
 
     // $TEST$ serialization C
     »C?()«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »C?()?()«;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/calls/of enum variants/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/calls/of enum variants/main.sdstest
@@ -10,21 +10,21 @@ pipeline myPipeline {
     // $TEST$ serialization MyEnum.MyEnumVariantWithoutParameterList
     »MyEnum.MyEnumVariantWithoutParameterList()«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     val alias1 = MyEnum.MyEnumVariantWithoutParameterList;
     »alias1()«;
 
     // $TEST$ serialization MyEnum.MyEnumVariantWithoutParameters
     »MyEnum.MyEnumVariantWithoutParameters()«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     val alias2 = MyEnum.MyEnumVariantWithoutParameters;
     »alias2()«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »MyEnum.MyEnumVariantWithoutParameters()()«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     val alias3 = MyEnum.MyEnumVariantWithoutParameters();
     »alias3()«;
 
@@ -35,10 +35,10 @@ pipeline myPipeline {
     val alias4 = MyEnum.MyEnumVariantWithParameters;
     »alias4(1)«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »MyEnum.MyEnumVariantWithParameters(1)()«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     val alias5 = MyEnum.MyEnumVariantWithParameters(1);
     »alias5()«;
 
@@ -48,21 +48,21 @@ pipeline myPipeline {
     // $TEST$ serialization MyEnum.MyEnumVariantWithoutParameterList
     »MyEnum.MyEnumVariantWithoutParameterList?()«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     val alias1 = MyEnum.MyEnumVariantWithoutParameterList;
     »alias1?()«;
 
     // $TEST$ serialization MyEnum.MyEnumVariantWithoutParameters
     »MyEnum.MyEnumVariantWithoutParameters?()«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     val alias2 = MyEnum.MyEnumVariantWithoutParameters;
     »alias2?()«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »MyEnum.MyEnumVariantWithoutParameters?()?()«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     val alias3 = MyEnum.MyEnumVariantWithoutParameters?();
     »alias3?()«;
 
@@ -73,10 +73,10 @@ pipeline myPipeline {
     val alias4 = MyEnum.MyEnumVariantWithParameters;
     »alias4?(1)«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »MyEnum.MyEnumVariantWithParameters(1)?()«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     val alias5 = MyEnum.MyEnumVariantWithParameters(1);
     »alias5?()«;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/calls/of non-callable/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/calls/of non-callable/main.sdstest
@@ -3,9 +3,9 @@ package tests.typing.expressions.calls.ofNonCallables
 enum MyEnum
 
 pipeline myPipeline {
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »MyEnum()«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »MyEnum?()«;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/calls/unresolved/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/calls/unresolved/main.sdstest
@@ -1,9 +1,9 @@
 package tests.typing.expressions.calls.ofUnresolved
 
 pipeline myPipeline {
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »unresolved()«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »unresolved?()«;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/expression lambdas/that are isolated/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/expression lambdas/that are isolated/main.sdstest
@@ -3,9 +3,9 @@ package tests.typing.expressions.expressionLambdas.thatAreIsolated
 fun g() -> r: Int
 
 segment mySegment() {
-    // $TEST$ serialization (p: $unknown) -> (result: Int)
+    // $TEST$ serialization (p: unknown) -> (result: Int)
     »(p) -> g()«;
 
-    // $TEST$ serialization (p: $unknown) -> (result: literal<1>)
+    // $TEST$ serialization (p: unknown) -> (result: literal<1>)
     val f = »(p) -> 1«;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/expression lambdas/that are passed as arguments/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/expression lambdas/that are passed as arguments/main.sdstest
@@ -12,18 +12,18 @@ segment mySegment() {
     // $TEST$ serialization (p: String) -> (result: literal<1>)
     higherOrderFunction1(param = »(p) -> 1«);
 
-    // $TEST$ serialization (p: $unknown) -> (result: literal<1>)
+    // $TEST$ serialization (p: unknown) -> (result: literal<1>)
     higherOrderFunction2(»(p) -> 1«);
 
-    // $TEST$ serialization (p: $unknown) -> (result: literal<1>)
+    // $TEST$ serialization (p: unknown) -> (result: literal<1>)
     higherOrderFunction2(param = »(p) -> 1«);
 
-    // $TEST$ serialization (p: $unknown) -> (result: literal<1>)
+    // $TEST$ serialization (p: unknown) -> (result: literal<1>)
     normalFunction(»(p) -> 1«);
 
-    // $TEST$ serialization (p: $unknown) -> (result: literal<1>)
+    // $TEST$ serialization (p: unknown) -> (result: literal<1>)
     normalFunction(param = »(p) -> 1«);
 
-    // $TEST$ serialization (p: $unknown) -> (result: literal<1>)
+    // $TEST$ serialization (p: unknown) -> (result: literal<1>)
     parameterlessFunction(»(p) -> 1«);
 }

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/expression lambdas/that are passed as default values/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/expression lambdas/that are passed as default values/main.sdstest
@@ -6,11 +6,11 @@ fun higherOrderFunction1(
 )
 
 fun higherOrderFunction2(
-    // $TEST$ serialization (p: $unknown) -> (result: literal<1>)
+    // $TEST$ serialization (p: unknown) -> (result: literal<1>)
     param: () -> () = »(p) -> 1«
 )
 
 fun normalFunction(
-    // $TEST$ serialization (p: $unknown) -> (result: literal<1>)
+    // $TEST$ serialization (p: unknown) -> (result: literal<1>)
     param: Int = »(p) -> 1«
 )

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/expression lambdas/that are yielded/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/expression lambdas/that are yielded/main.sdstest
@@ -8,9 +8,9 @@ segment mySegment() -> (
     // $TEST$ serialization (p: String) -> (result: literal<1>)
     yield r = »(p) -> 1«;
 
-    // $TEST$ serialization (p: $unknown) -> (result: literal<1>)
+    // $TEST$ serialization (p: unknown) -> (result: literal<1>)
     yield s = »(p) -> 1«;
 
-    // $TEST$ serialization (p: $unknown) -> (result: literal<1>)
+    // $TEST$ serialization (p: unknown) -> (result: literal<1>)
     yield t = »(p) -> 1«;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/indexed accesses/on other/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/indexed accesses/on other/main.sdstest
@@ -1,16 +1,16 @@
 package tests.typing.expressions.indexedAccesses.onOther
 
 segment mySegment3(param1: String, param2: String?) {
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »param1[0]«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »param2[0]«;
 
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »param1?[0]«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »param2?[0]«;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/indexed accesses/on unresolved/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/indexed accesses/on unresolved/main.sdstest
@@ -1,9 +1,9 @@
 package tests.typing.expressions.indexedAccesses.onUnresolved
 
 segment mySegment() {
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »unresolved[0]«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »unresolved?[0]«;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/member accesses/unresolved/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/member accesses/unresolved/main.sdstest
@@ -3,9 +3,9 @@ package tests.typing.expressions.memberAccesses.unresolved
 class C
 
 pipeline myPipeline {
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »C.unresolved«;
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »C?.unresolved«;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/references/unresolved/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/references/unresolved/main.sdstest
@@ -1,6 +1,6 @@
 package tests.typing.expressions.references.unresolved
 
 pipeline myPipeline {
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     »unresolved«;
 }

--- a/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/singular type after simplification/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/singular type after simplification/main.sdstest
@@ -31,7 +31,7 @@ segment mySegment(
     // $TEST$ serialization List<$type<C>>
     »[C]«;
 
-    // $TEST$ serialization List<$unknown>
+    // $TEST$ serialization List<unknown>
     »[unresolved]«;
 }
 

--- a/packages/safe-ds-lang/tests/resources/typing/types/callable types/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/types/callable types/main.sdstest
@@ -12,5 +12,5 @@ fun myFunction3(f: »(p1: Int, p2: String) -> ()«)
 // $TEST$ serialization (p1: Int, p2: String) -> (r1: Int, r2: String)
 fun myFunction4(f: »(p1: Int, p2: String) -> (r1: Int, r2: String)«)
 
-// $TEST$ serialization (p1: $unknown) -> (r1: $unknown)
+// $TEST$ serialization (p1: unknown) -> (r1: unknown)
 fun myFunction5(f: »(p1) -> (r1)«)

--- a/packages/safe-ds-lang/tests/resources/typing/types/member types/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/types/member types/main.sdstest
@@ -20,7 +20,7 @@ fun nonNullableMemberTypes(
     b: »MyClass.MyNestedEnum«,
     // $TEST$ equivalence_class myEnumVariant
     d: »MyEnum.MyEnumVariant«,
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     e: »MyEnum.unresolved«,
 )
 
@@ -31,6 +31,6 @@ fun nullableMemberTypes(
     b: »MyClass.MyNestedEnum?«,
     // $TEST$ serialization MyEnum.MyEnumVariant?
     d: »MyEnum.MyEnumVariant?«,
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     e: »MyEnum.unresolved?«,
 )

--- a/packages/safe-ds-lang/tests/resources/typing/types/named types/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/types/named types/main.sdstest
@@ -9,7 +9,7 @@ fun nonNullableNamedTypes(
     a: »MyClass«,
     // $TEST$ serialization MyEnum
     b: »MyEnum«,
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     c: »unresolved«,
 )
 
@@ -18,6 +18,6 @@ fun nullableNamedTypes(
     a: »MyClass?«,
     // $TEST$ serialization MyEnum?
     b: »MyEnum?«,
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     c: »unresolved?«,
 )

--- a/packages/safe-ds-lang/tests/resources/typing/types/named types/with type parameters.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/types/named types/with type parameters.sdstest
@@ -6,31 +6,31 @@ class MyClass3<T = Int>
 fun nonNullableNamedTypes(
     // $TEST$ serialization MyClass2<Int>
     a: »MyClass2<Int>«,
-    // $TEST$ serialization MyClass2<$unknown>
+    // $TEST$ serialization MyClass2<unknown>
     b: »MyClass2<unresolved>«,
-    // $TEST$ serialization MyClass2<$unknown>
+    // $TEST$ serialization MyClass2<unknown>
     c: »MyClass2«,
     // $TEST$ serialization MyClass2<Int>
     d: »MyClass2<T = Int, T = String>«,
 
     // $TEST$ serialization MyClass3<Int>
     y: »MyClass3«,
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     z: »unresolved<Int>«,
 )
 
 fun nullableNamedTypes(
     // $TEST$ serialization MyClass2<Int>?
     a: »MyClass2<Int>?«,
-    // $TEST$ serialization MyClass2<$unknown>?
+    // $TEST$ serialization MyClass2<unknown>?
     b: »MyClass2<unresolved>?«,
-    // $TEST$ serialization MyClass2<$unknown>?
+    // $TEST$ serialization MyClass2<unknown>?
     c: »MyClass2?«,
     // $TEST$ serialization MyClass2<Int>?
     d: »MyClass2<T = Int, T = String>?«,
 
     // $TEST$ serialization MyClass3<Int>?
     y: »MyClass3?«,
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     z: »unresolved<Int>?«,
 )

--- a/packages/safe-ds-lang/tests/resources/typing/types/type arguments/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/types/type arguments/main.sdstest
@@ -13,8 +13,8 @@ fun myFunction(
     // $TEST$ serialization Boolean
     f: unresolved<»T = Boolean«>,
 
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     g: MyClass<»unresolved«>,
-    // $TEST$ serialization $unknown
+    // $TEST$ serialization unknown
     h: MyClass<»T = unresolved«>,
 )

--- a/packages/safe-ds-lang/tests/resources/typing/types/unknown types/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/types/unknown types/main.sdstest
@@ -1,0 +1,4 @@
+package tests.typing.types.unknownTypes
+
+// $TEST$ serialization $unknown
+fun myFunction(a: »unknown«)

--- a/packages/safe-ds-lang/tests/resources/typing/types/unknown types/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/typing/types/unknown types/main.sdstest
@@ -1,4 +1,4 @@
 package tests.typing.types.unknownTypes
 
-// $TEST$ serialization $unknown
+// $TEST$ serialization unknown
 fun myFunction(a: »unknown«)

--- a/packages/safe-ds-lang/tests/resources/validation/types/checking/indexed access receiver/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/types/checking/indexed access receiver/main.sdstest
@@ -29,7 +29,7 @@ segment mySegment(
     »myList«[0];
     // $TEST$ no error r"Expected type 'List<T>' or 'Map<K, V>' but got .*\."
     »myMap«[""];
-    // $TEST$ error "Expected type 'List<T>' or 'Map<K, V>' but got '$unknown'."
+    // $TEST$ error "Expected type 'List<T>' or 'Map<K, V>' but got 'unknown'."
     »unresolved«[0];
 }
 

--- a/packages/safe-ds-lang/tests/resources/validation/types/checking/infix operations/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/types/checking/infix operations/main.sdstest
@@ -8,8 +8,8 @@ pipeline myPipeline {
     // $TEST$ error "Expected type 'Boolean' but got 'literal<0>'."
     // $TEST$ error "Expected type 'Boolean' but got 'literal<0>'."
     »0« or »0«;
-    // $TEST$ error "Expected type 'Boolean' but got '$unknown'."
-    // $TEST$ error "Expected type 'Boolean' but got '$unknown'."
+    // $TEST$ error "Expected type 'Boolean' but got 'unknown'."
+    // $TEST$ error "Expected type 'Boolean' but got 'unknown'."
     »unresolved« or »unresolved«;
 
     // $TEST$ no error r"Expected type 'Boolean' but got .*\."
@@ -18,8 +18,8 @@ pipeline myPipeline {
     // $TEST$ error "Expected type 'Boolean' but got 'literal<0>'."
     // $TEST$ error "Expected type 'Boolean' but got 'literal<0>'."
     »0« and »0«;
-    // $TEST$ error "Expected type 'Boolean' but got '$unknown'."
-    // $TEST$ error "Expected type 'Boolean' but got '$unknown'."
+    // $TEST$ error "Expected type 'Boolean' but got 'unknown'."
+    // $TEST$ error "Expected type 'Boolean' but got 'unknown'."
     »unresolved« and »unresolved«;
 
 
@@ -32,8 +32,8 @@ pipeline myPipeline {
     // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<"">'."
     // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<"">'."
     »""« + »""«;
-    // $TEST$ error "Expected type 'Float' or 'Int' but got '$unknown'."
-    // $TEST$ error "Expected type 'Float' or 'Int' but got '$unknown'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'unknown'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'unknown'."
     »unresolved« + »unresolved«;
 
     // $TEST$ no error r"Expected type 'Float' or 'Int' but got .*\."
@@ -45,8 +45,8 @@ pipeline myPipeline {
     // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<"">'."
     // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<"">'."
     »""« - »""«;
-    // $TEST$ error "Expected type 'Float' or 'Int' but got '$unknown'."
-    // $TEST$ error "Expected type 'Float' or 'Int' but got '$unknown'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'unknown'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'unknown'."
     »unresolved« - »unresolved«;
 
     // $TEST$ no error r"Expected type 'Float' or 'Int' but got .*\."
@@ -58,8 +58,8 @@ pipeline myPipeline {
     // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<"">'."
     // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<"">'."
     »""« * »""«;
-    // $TEST$ error "Expected type 'Float' or 'Int' but got '$unknown'."
-    // $TEST$ error "Expected type 'Float' or 'Int' but got '$unknown'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'unknown'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'unknown'."
     »unresolved« * »unresolved«;
 
     // $TEST$ no error r"Expected type 'Float' or 'Int' but got .*\."
@@ -71,8 +71,8 @@ pipeline myPipeline {
     // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<"">'."
     // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<"">'."
     »""« / »""«;
-    // $TEST$ error "Expected type 'Float' or 'Int' but got '$unknown'."
-    // $TEST$ error "Expected type 'Float' or 'Int' but got '$unknown'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'unknown'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'unknown'."
     »unresolved« / »unresolved«;
 
 
@@ -85,8 +85,8 @@ pipeline myPipeline {
     // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<"">'."
     // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<"">'."
     »""« < »""«;
-    // $TEST$ error "Expected type 'Float' or 'Int' but got '$unknown'."
-    // $TEST$ error "Expected type 'Float' or 'Int' but got '$unknown'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'unknown'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'unknown'."
     »unresolved« < »unresolved«;
 
     // $TEST$ no error r"Expected type 'Float' or 'Int' but got .*\."
@@ -98,8 +98,8 @@ pipeline myPipeline {
     // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<"">'."
     // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<"">'."
     »""« <= »""«;
-    // $TEST$ error "Expected type 'Float' or 'Int' but got '$unknown'."
-    // $TEST$ error "Expected type 'Float' or 'Int' but got '$unknown'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'unknown'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'unknown'."
     »unresolved« <= »unresolved«;
 
     // $TEST$ no error r"Expected type 'Float' or 'Int' but got .*\."
@@ -111,8 +111,8 @@ pipeline myPipeline {
     // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<"">'."
     // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<"">'."
     »""« >= »""«;
-    // $TEST$ error "Expected type 'Float' or 'Int' but got '$unknown'."
-    // $TEST$ error "Expected type 'Float' or 'Int' but got '$unknown'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'unknown'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'unknown'."
     »unresolved« >= »unresolved«;
 
     // $TEST$ no error r"Expected type 'Float' or 'Int' but got .*\."
@@ -124,8 +124,8 @@ pipeline myPipeline {
     // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<"">'."
     // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<"">'."
     »""« > »""«;
-    // $TEST$ error "Expected type 'Float' or 'Int' but got '$unknown'."
-    // $TEST$ error "Expected type 'Float' or 'Int' but got '$unknown'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'unknown'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'unknown'."
     »unresolved« > »unresolved«;
 }
 

--- a/packages/safe-ds-lang/tests/resources/validation/types/checking/prefix operations/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/types/checking/prefix operations/main.sdstest
@@ -6,7 +6,7 @@ segment mySegment() {
     not »true«;
     // $TEST$ error "Expected type 'Boolean' but got 'literal<0>'."
     not »0«;
-    // $TEST$ error "Expected type 'Boolean' but got '$unknown'."
+    // $TEST$ error "Expected type 'Boolean' but got 'unknown'."
     not »unresolved«;
 
     // $TEST$ no error r"Expected type 'Float' or 'Int' but got .*\."
@@ -15,7 +15,7 @@ segment mySegment() {
     -»0«;
     // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<"">'."
     -»""«;
-    // $TEST$ error "Expected type 'Float' or 'Int' but got '$unknown'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'unknown'."
     -»unresolved«;
 }
 


### PR DESCRIPTION
Closes #967

### Summary of Changes

The keyword `unknown` can now be used as a type as well. It denotes that the actual type is not known. To do anything with it, values with that type must be cast to another type.
