### PR TITLE
feat: require `safe-ds-runner>=0.8.0,<0.9.0`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ Safely develop Data Science programs with a statically checked domain specific l
 2. To _execute_ Safe-DS programs, the [Safe-DS Runner](https://github.com/Safe-DS/Runner) has to be installed and
    configured additionally:
     1. Install [Python](https://www.python.org/) (3.11 or 3.12).
-    2. Run `pip install "safe-ds-runner>=0.7.0,<0.8.0"` in a command line to download the latest matching Runner version
+    2. Run `pip install "safe-ds-runner>=0.8.0,<0.9.0"` in a command line to download the latest matching Runner version
        from [PyPI](https://pypi.org/project/safe-ds-runner/).
     3. If the Visual Studio Code extension cannot start the runner, adjust the setting `safe-ds.runner.command`.
        Enter the absolute path to the Runner executable, as seen in the image below.

--- a/docs/stdlib/safeds/data/tabular/typing/Schema.md
+++ b/docs/stdlib/safeds/data/tabular/typing/Schema.md
@@ -45,28 +45,6 @@ Store column names and corresponding data types for a `Table` or `Row`.
         @Pure
         @PythonName("to_dict")
         fun toDict() -> result1: Map<String, ColumnType>
-    
-        /**
-         * Merge multiple schemas into one.
-         *
-         * For each type missmatch the new schema will have the least common supertype.
-         *
-         * The type hierarchy is as follows:
-         * * Anything
-         *     * RealNumber
-         *         * Integer
-         *     * Boolean
-         *     * String
-         *
-         * @param schemas the list of schemas you want to merge
-         *
-         * @result result1 the new merged schema
-         */
-        @Pure
-        @PythonName("merge_multiple_schemas")
-        static fun mergeMultipleSchemas(
-            schemas: List<Schema>
-        ) -> result1: Schema
     }
     ```
 
@@ -144,39 +122,4 @@ Return a dictionary that maps column names to column types.
     @Pure
     @PythonName("to_dict")
     fun toDict() -> result1: Map<String, ColumnType>
-    ```
-
-## `#!sds static fun` mergeMultipleSchemas {#safeds.data.tabular.typing.Schema.mergeMultipleSchemas data-toc-label='mergeMultipleSchemas'}
-
-Merge multiple schemas into one.
-
-For each type missmatch the new schema will have the least common supertype.
-
-The type hierarchy is as follows:
-* Anything
-    * RealNumber
-        * Integer
-    * Boolean
-    * String
-
-**Parameters:**
-
-| Name | Type | Description | Default |
-|------|------|-------------|---------|
-| `schemas` | [`List<Schema>`][safeds.lang.List] | the list of schemas you want to merge | - |
-
-**Results:**
-
-| Name | Type | Description |
-|------|------|-------------|
-| `result1` | [`Schema`][safeds.data.tabular.typing.Schema] | the new merged schema |
-
-??? quote "Source code in `schema.sdsstub`"
-
-    ```sds linenums="67"
-    @Pure
-    @PythonName("merge_multiple_schemas")
-    static fun mergeMultipleSchemas(
-        schemas: List<Schema>
-    ) -> result1: Schema
     ```

--- a/docs/stdlib/safeds/ml/classical/classification/AdaBoostClassifier.md
+++ b/docs/stdlib/safeds/ml/classical/classification/AdaBoostClassifier.md
@@ -14,7 +14,7 @@ Ada Boost classification.
 
 ??? quote "Source code in `ada_boost.sdsstub`"
 
-    ```sds linenums="16"
+    ```sds linenums="15"
     class AdaBoostClassifier(
         learner: Classifier = DecisionTreeClassifier(),
         @PythonName("maximum_number_of_learners") const maximumNumberOfLearners: Int = 50,
@@ -90,7 +90,7 @@ This classifier is not modified.
 
 ??? quote "Source code in `ada_boost.sdsstub`"
 
-    ```sds linenums="46"
+    ```sds linenums="45"
     @Pure
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable

--- a/docs/stdlib/safeds/ml/classical/classification/DecisionTreeClassifier.md
+++ b/docs/stdlib/safeds/ml/classical/classification/DecisionTreeClassifier.md
@@ -6,7 +6,7 @@ Decision tree classification.
 
 ??? quote "Source code in `decision_tree.sdsstub`"
 
-    ```sds linenums="10"
+    ```sds linenums="9"
     class DecisionTreeClassifier() sub Classifier {
         /**
          * Create a copy of this classifier and fit it with the given training data.
@@ -44,7 +44,7 @@ This classifier is not modified.
 
 ??? quote "Source code in `decision_tree.sdsstub`"
 
-    ```sds linenums="20"
+    ```sds linenums="19"
     @Pure
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable

--- a/docs/stdlib/safeds/ml/classical/classification/GradientBoostingClassifier.md
+++ b/docs/stdlib/safeds/ml/classical/classification/GradientBoostingClassifier.md
@@ -13,7 +13,7 @@ Gradient boosting classification.
 
 ??? quote "Source code in `gradient_boosting.sdsstub`"
 
-    ```sds linenums="15"
+    ```sds linenums="14"
     class GradientBoostingClassifier(
         @PythonName("number_of_trees") const numberOfTrees: Int = 100,
         @PythonName("learning_rate") const learningRate: Float = 0.1
@@ -78,7 +78,7 @@ This classifier is not modified.
 
 ??? quote "Source code in `gradient_boosting.sdsstub`"
 
-    ```sds linenums="40"
+    ```sds linenums="39"
     @Pure
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable

--- a/docs/stdlib/safeds/ml/classical/classification/KNearestNeighborsClassifier.md
+++ b/docs/stdlib/safeds/ml/classical/classification/KNearestNeighborsClassifier.md
@@ -12,7 +12,7 @@ K-nearest-neighbors classification.
 
 ??? quote "Source code in `k_nearest_neighbors.sdsstub`"
 
-    ```sds linenums="13"
+    ```sds linenums="12"
     class KNearestNeighborsClassifier(
         @PythonName("number_of_neighbors") const numberOfNeighbors: Int
     ) sub Classifier where {
@@ -65,7 +65,7 @@ This classifier is not modified.
 
 ??? quote "Source code in `k_nearest_neighbors.sdsstub`"
 
-    ```sds linenums="32"
+    ```sds linenums="31"
     @Pure
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable

--- a/docs/stdlib/safeds/ml/classical/classification/LogisticRegressionClassifier.md
+++ b/docs/stdlib/safeds/ml/classical/classification/LogisticRegressionClassifier.md
@@ -6,7 +6,7 @@ Regularized logistic regression.
 
 ??? quote "Source code in `logistic_regression.sdsstub`"
 
-    ```sds linenums="10"
+    ```sds linenums="9"
     class LogisticRegressionClassifier() sub Classifier {
         /**
          * Create a copy of this classifier and fit it with the given training data.
@@ -44,7 +44,7 @@ This classifier is not modified.
 
 ??? quote "Source code in `logistic_regression.sdsstub`"
 
-    ```sds linenums="20"
+    ```sds linenums="19"
     @Pure
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable

--- a/docs/stdlib/safeds/ml/classical/classification/RandomForestClassifier.md
+++ b/docs/stdlib/safeds/ml/classical/classification/RandomForestClassifier.md
@@ -12,7 +12,7 @@ Random forest classification.
 
 ??? quote "Source code in `random_forest.sdsstub`"
 
-    ```sds linenums="12"
+    ```sds linenums="11"
     class RandomForestClassifier(
         @PythonName("number_of_trees") const numberOfTrees: Int = 100
     ) sub Classifier where {
@@ -65,7 +65,7 @@ This classifier is not modified.
 
 ??? quote "Source code in `random_forest.sdsstub`"
 
-    ```sds linenums="31"
+    ```sds linenums="30"
     @Pure
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable

--- a/docs/stdlib/safeds/ml/classical/classification/SupportVectorMachineClassifier.md
+++ b/docs/stdlib/safeds/ml/classical/classification/SupportVectorMachineClassifier.md
@@ -13,7 +13,7 @@ Support vector machine.
 
 ??? quote "Source code in `support_vector_machine.sdsstub`"
 
-    ```sds linenums="13"
+    ```sds linenums="12"
     class SupportVectorMachineClassifier(
         const c: Float = 1.0,
         kernel: SupportVectorMachineClassifier.Kernel = SupportVectorMachineClassifier.Kernel.RadialBasisFunction
@@ -104,7 +104,7 @@ This classifier is not modified.
 
 ??? quote "Source code in `support_vector_machine.sdsstub`"
 
-    ```sds linenums="64"
+    ```sds linenums="63"
     @Pure
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable
@@ -117,7 +117,7 @@ The kernel functions that can be used in the support vector machine.
 
 ??? quote "Source code in `support_vector_machine.sdsstub`"
 
-    ```sds linenums="22"
+    ```sds linenums="21"
     enum Kernel {
         /**
          * A linear kernel.

--- a/docs/stdlib/safeds/ml/classical/regression/AdaBoostRegressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/AdaBoostRegressor.md
@@ -14,7 +14,7 @@ Ada Boost regression.
 
 ??? quote "Source code in `ada_boost.sdsstub`"
 
-    ```sds linenums="16"
+    ```sds linenums="15"
     class AdaBoostRegressor(
         learner: Regressor = DecisionTreeRegressor(),
         @PythonName("maximum_number_of_learners") const maximumNumberOfLearners: Int = 50,
@@ -90,7 +90,7 @@ This regressor is not modified.
 
 ??? quote "Source code in `ada_boost.sdsstub`"
 
-    ```sds linenums="46"
+    ```sds linenums="45"
     @Pure
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable

--- a/docs/stdlib/safeds/ml/classical/regression/DecisionTreeRegressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/DecisionTreeRegressor.md
@@ -6,7 +6,7 @@ Decision tree regression.
 
 ??? quote "Source code in `decision_tree.sdsstub`"
 
-    ```sds linenums="10"
+    ```sds linenums="9"
     class DecisionTreeRegressor() sub Regressor {
         /**
          * Create a copy of this regressor and fit it with the given training data.
@@ -44,7 +44,7 @@ This regressor is not modified.
 
 ??? quote "Source code in `decision_tree.sdsstub`"
 
-    ```sds linenums="20"
+    ```sds linenums="19"
     @Pure
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable

--- a/docs/stdlib/safeds/ml/classical/regression/ElasticNetRegressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/ElasticNetRegressor.md
@@ -13,7 +13,7 @@ Elastic net regression.
 
 ??? quote "Source code in `elastic_net_regression.sdsstub`"
 
-    ```sds linenums="14"
+    ```sds linenums="13"
     class ElasticNetRegressor(
         const alpha: Float = 1.0,
         @PythonName("lasso_ratio") const lassoRatio: Float = 0.5
@@ -79,7 +79,7 @@ This regressor is not modified.
 
 ??? quote "Source code in `elastic_net_regression.sdsstub`"
 
-    ```sds linenums="40"
+    ```sds linenums="39"
     @Pure
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable

--- a/docs/stdlib/safeds/ml/classical/regression/GradientBoostingRegressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/GradientBoostingRegressor.md
@@ -13,7 +13,7 @@ Gradient boosting regression.
 
 ??? quote "Source code in `gradient_boosting.sdsstub`"
 
-    ```sds linenums="15"
+    ```sds linenums="14"
     class GradientBoostingRegressor(
         @PythonName("number_of_trees") const numberOfTrees: Int = 100,
         @PythonName("learning_rate") const learningRate: Float = 0.1
@@ -78,7 +78,7 @@ This regressor is not modified.
 
 ??? quote "Source code in `gradient_boosting.sdsstub`"
 
-    ```sds linenums="40"
+    ```sds linenums="39"
     @Pure
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable

--- a/docs/stdlib/safeds/ml/classical/regression/KNearestNeighborsRegressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/KNearestNeighborsRegressor.md
@@ -12,7 +12,7 @@ K-nearest-neighbors regression.
 
 ??? quote "Source code in `k_nearest_neighbors.sdsstub`"
 
-    ```sds linenums="13"
+    ```sds linenums="12"
     class KNearestNeighborsRegressor(
         @PythonName("number_of_neighbors") const numberOfNeighbors: Int
     ) sub Regressor where {
@@ -65,7 +65,7 @@ This regressor is not modified.
 
 ??? quote "Source code in `k_nearest_neighbors.sdsstub`"
 
-    ```sds linenums="32"
+    ```sds linenums="31"
     @Pure
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable

--- a/docs/stdlib/safeds/ml/classical/regression/LassoRegressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/LassoRegressor.md
@@ -12,7 +12,7 @@ Lasso regression.
 
 ??? quote "Source code in `lasso_regression.sdsstub`"
 
-    ```sds linenums="12"
+    ```sds linenums="11"
     class LassoRegressor(
         const alpha: Float = 1.0
     ) sub Regressor where {
@@ -65,7 +65,7 @@ This regressor is not modified.
 
 ??? quote "Source code in `lasso_regression.sdsstub`"
 
-    ```sds linenums="31"
+    ```sds linenums="30"
     @Pure
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable

--- a/docs/stdlib/safeds/ml/classical/regression/LinearRegressionRegressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/LinearRegressionRegressor.md
@@ -6,7 +6,7 @@ Linear regression.
 
 ??? quote "Source code in `linear_regression.sdsstub`"
 
-    ```sds linenums="10"
+    ```sds linenums="9"
     class LinearRegressionRegressor() sub Regressor {
         /**
          * Create a copy of this regressor and fit it with the given training data.
@@ -44,7 +44,7 @@ This regressor is not modified.
 
 ??? quote "Source code in `linear_regression.sdsstub`"
 
-    ```sds linenums="20"
+    ```sds linenums="19"
     @Pure
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable

--- a/docs/stdlib/safeds/ml/classical/regression/RandomForestRegressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/RandomForestRegressor.md
@@ -12,7 +12,7 @@ Random forest regression.
 
 ??? quote "Source code in `random_forest.sdsstub`"
 
-    ```sds linenums="12"
+    ```sds linenums="11"
     class RandomForestRegressor(
         @PythonName("number_of_trees") const numberOfTrees: Int = 100
     ) sub Regressor where {
@@ -65,7 +65,7 @@ This regressor is not modified.
 
 ??? quote "Source code in `random_forest.sdsstub`"
 
-    ```sds linenums="31"
+    ```sds linenums="30"
     @Pure
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable

--- a/docs/stdlib/safeds/ml/classical/regression/RidgeRegressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/RidgeRegressor.md
@@ -12,7 +12,7 @@ Ridge regression.
 
 ??? quote "Source code in `ridge_regression.sdsstub`"
 
-    ```sds linenums="12"
+    ```sds linenums="11"
     class RidgeRegressor(
         const alpha: Float = 1.0
     ) sub Regressor where {
@@ -65,7 +65,7 @@ This regressor is not modified.
 
 ??? quote "Source code in `ridge_regression.sdsstub`"
 
-    ```sds linenums="31"
+    ```sds linenums="30"
     @Pure
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable

--- a/docs/stdlib/safeds/ml/classical/regression/SupportVectorMachineRegressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/SupportVectorMachineRegressor.md
@@ -13,7 +13,7 @@ Support vector machine.
 
 ??? quote "Source code in `support_vector_machine.sdsstub`"
 
-    ```sds linenums="13"
+    ```sds linenums="12"
     class SupportVectorMachineRegressor(
         const c: Float = 1.0,
         kernel: SupportVectorMachineRegressor.Kernel = SupportVectorMachineRegressor.Kernel.RadialBasisFunction
@@ -104,7 +104,7 @@ This regressor is not modified.
 
 ??? quote "Source code in `support_vector_machine.sdsstub`"
 
-    ```sds linenums="64"
+    ```sds linenums="63"
     @Pure
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable
@@ -117,7 +117,7 @@ The kernel functions that can be used in the support vector machine.
 
 ??? quote "Source code in `support_vector_machine.sdsstub`"
 
-    ```sds linenums="22"
+    ```sds linenums="21"
     enum Kernel {
         /**
          * A linear kernel.

--- a/docs/stdlib/safeds/ml/nn/NeuralNetworkClassifier.md
+++ b/docs/stdlib/safeds/ml/nn/NeuralNetworkClassifier.md
@@ -8,7 +8,7 @@
 
 ??? quote "Source code in `classifier.sdsstub`"
 
-    ```sds linenums="7"
+    ```sds linenums="6"
     class NeuralNetworkClassifier(
         layers: List<FNNLayer>
     ) {
@@ -88,7 +88,7 @@ The original model is not modified.
 
 ??? quote "Source code in `classifier.sdsstub`"
 
-    ```sds linenums="28"
+    ```sds linenums="27"
     @Pure
     fun fit(
         @PythonName("train_data") trainData: TaggedTable,
@@ -122,7 +122,7 @@ The original Model is not modified.
 
 ??? quote "Source code in `classifier.sdsstub`"
 
-    ```sds linenums="49"
+    ```sds linenums="48"
     @Pure
     fun predict(
         @PythonName("test_data") testData: Table

--- a/docs/stdlib/safeds/ml/nn/NeuralNetworkRegressor.md
+++ b/docs/stdlib/safeds/ml/nn/NeuralNetworkRegressor.md
@@ -4,13 +4,13 @@
 
 | Name | Type | Description | Default |
 |------|------|-------------|---------|
-| `layers` | [`List<Any>`][safeds.lang.List] | - | - |
+| `layers` | [`List<FNNLayer>`][safeds.lang.List] | - | - |
 
 ??? quote "Source code in `regressor.sdsstub`"
 
-    ```sds linenums="7"
+    ```sds linenums="6"
     class NeuralNetworkRegressor(
-        layers: List<Any>
+        layers: List<FNNLayer>
     ) {
         /**
          * Check if the model is fitted.
@@ -88,7 +88,7 @@ The original model is not modified.
 
 ??? quote "Source code in `regressor.sdsstub`"
 
-    ```sds linenums="28"
+    ```sds linenums="27"
     @Pure
     fun fit(
         @PythonName("train_data") trainData: TaggedTable,
@@ -122,7 +122,7 @@ The original Model is not modified.
 
 ??? quote "Source code in `regressor.sdsstub`"
 
-    ```sds linenums="49"
+    ```sds linenums="48"
     @Pure
     fun predict(
         @PythonName("test_data") testData: Table

--- a/packages/safe-ds-lang/src/language/runner/safe-ds-runner.ts
+++ b/packages/safe-ds-lang/src/language/runner/safe-ds-runner.ts
@@ -20,8 +20,8 @@ import semver from 'semver';
 
 // Most of the functionality cannot be tested automatically as a functioning runner setup would always be required
 
-const LOWEST_SUPPORTED_VERSION = '0.7.0';
-const LOWEST_UNSUPPORTED_VERSION = '0.8.0';
+const LOWEST_SUPPORTED_VERSION = '0.8.0';
+const LOWEST_UNSUPPORTED_VERSION = '0.9.0';
 const npmVersionRange = `>=${LOWEST_SUPPORTED_VERSION} <${LOWEST_UNSUPPORTED_VERSION}`;
 const pipVersionRange = `>=${LOWEST_SUPPORTED_VERSION},<${LOWEST_UNSUPPORTED_VERSION}`;
 

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/data/tabular/typing/schema.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/data/tabular/typing/schema.sdsstub
@@ -47,26 +47,4 @@ class Schema {
     @Pure
     @PythonName("to_dict")
     fun toDict() -> result1: Map<String, ColumnType>
-
-    /**
-     * Merge multiple schemas into one.
-     *
-     * For each type missmatch the new schema will have the least common supertype.
-     *
-     * The type hierarchy is as follows:
-     * * Anything
-     *     * RealNumber
-     *         * Integer
-     *     * Boolean
-     *     * String
-     *
-     * @param schemas the list of schemas you want to merge
-     *
-     * @result result1 the new merged schema
-     */
-    @Pure
-    @PythonName("merge_multiple_schemas")
-    static fun mergeMultipleSchemas(
-        schemas: List<Schema>
-    ) -> result1: Schema
 }

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/classification/ada_boost.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/classification/ada_boost.sdsstub
@@ -12,7 +12,6 @@ from safeds.ml.classical.classification import Classifier
  * @param learningRate Weight applied to each classifier at each boosting iteration. A higher learning rate increases the contribution
  * of each classifier. Has to be greater than 0.
  */
-@PythonName("AdaBoost")
 class AdaBoostClassifier(
     learner: Classifier = DecisionTreeClassifier(),
     @PythonName("maximum_number_of_learners") const maximumNumberOfLearners: Int = 50,

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/classification/decision_tree.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/classification/decision_tree.sdsstub
@@ -6,7 +6,6 @@ from safeds.ml.classical.classification import Classifier
 /**
  * Decision tree classification.
  */
-@PythonName("DecisionTree")
 class DecisionTreeClassifier() sub Classifier {
     /**
      * Create a copy of this classifier and fit it with the given training data.

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/classification/gradient_boosting.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/classification/gradient_boosting.sdsstub
@@ -11,7 +11,6 @@ from safeds.ml.classical.classification import Classifier
  * @param learningRate The larger the value, the more the model is influenced by each additional tree. If the learning rate is too
  * low, the model might underfit. If the learning rate is too high, the model might overfit.
  */
-@PythonName("GradientBoosting")
 class GradientBoostingClassifier(
     @PythonName("number_of_trees") const numberOfTrees: Int = 100,
     @PythonName("learning_rate") const learningRate: Float = 0.1

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/classification/k_nearest_neighbors.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/classification/k_nearest_neighbors.sdsstub
@@ -9,7 +9,6 @@ from safeds.ml.classical.classification import Classifier
  * @param numberOfNeighbors The number of neighbors to use for interpolation. Has to be greater than 0 (validated in the constructor) and
  * less than or equal to the sample size (validated when calling `fit`).
  */
-@PythonName("KNearestNeighbors")
 class KNearestNeighborsClassifier(
     @PythonName("number_of_neighbors") const numberOfNeighbors: Int
 ) sub Classifier where {

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/classification/logistic_regression.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/classification/logistic_regression.sdsstub
@@ -6,7 +6,6 @@ from safeds.ml.classical.classification import Classifier
 /**
  * Regularized logistic regression.
  */
-@PythonName("LogisticRegression")
 class LogisticRegressionClassifier() sub Classifier {
     /**
      * Create a copy of this classifier and fit it with the given training data.

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/classification/random_forest.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/classification/random_forest.sdsstub
@@ -8,7 +8,6 @@ from safeds.ml.classical.classification import Classifier
  *
  * @param numberOfTrees The number of trees to be used in the random forest. Has to be greater than 0.
  */
-@PythonName("RandomForest")
 class RandomForestClassifier(
     @PythonName("number_of_trees") const numberOfTrees: Int = 100
 ) sub Classifier where {

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/classification/support_vector_machine.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/classification/support_vector_machine.sdsstub
@@ -9,7 +9,6 @@ from safeds.ml.classical.classification import Classifier
  * @param c The strength of regularization. Must be strictly positive.
  * @param kernel The type of kernel to be used. Defaults to None.
  */
-@PythonName("SupportVectorMachine")
 class SupportVectorMachineClassifier(
     const c: Float = 1.0,
     kernel: SupportVectorMachineClassifier.Kernel = SupportVectorMachineClassifier.Kernel.RadialBasisFunction

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/ada_boost.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/ada_boost.sdsstub
@@ -12,7 +12,6 @@ from safeds.ml.classical.regression import Regressor
  * @param learningRate Weight applied to each regressor at each boosting iteration. A higher learning rate increases the contribution
  * of each regressor. Has to be greater than 0.
  */
-@PythonName("AdaBoost")
 class AdaBoostRegressor(
     learner: Regressor = DecisionTreeRegressor(),
     @PythonName("maximum_number_of_learners") const maximumNumberOfLearners: Int = 50,

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/decision_tree.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/decision_tree.sdsstub
@@ -6,7 +6,6 @@ from safeds.ml.classical.regression import Regressor
 /**
  * Decision tree regression.
  */
-@PythonName("DecisionTree")
 class DecisionTreeRegressor() sub Regressor {
     /**
      * Create a copy of this regressor and fit it with the given training data.

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/elastic_net_regression.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/elastic_net_regression.sdsstub
@@ -10,7 +10,6 @@ from safeds.ml.classical.regression import Regressor
  * @param lassoRatio Number between 0 and 1 that controls the ratio between Lasso and Ridge regularization. If 0, only Ridge
  * regularization is used. If 1, only Lasso regularization is used.
  */
-@PythonName("ElasticNetRegression")
 class ElasticNetRegressor(
     const alpha: Float = 1.0,
     @PythonName("lasso_ratio") const lassoRatio: Float = 0.5

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/gradient_boosting.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/gradient_boosting.sdsstub
@@ -11,7 +11,6 @@ from safeds.ml.classical.regression import Regressor
  * @param learningRate The larger the value, the more the model is influenced by each additional tree. If the learning rate is too
  * low, the model might underfit. If the learning rate is too high, the model might overfit.
  */
-@PythonName("GradientBoosting")
 class GradientBoostingRegressor(
     @PythonName("number_of_trees") const numberOfTrees: Int = 100,
     @PythonName("learning_rate") const learningRate: Float = 0.1

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/k_nearest_neighbors.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/k_nearest_neighbors.sdsstub
@@ -9,7 +9,6 @@ from safeds.ml.classical.regression import Regressor
  * @param numberOfNeighbors The number of neighbors to use for interpolation. Has to be greater than 0 (validated in the constructor) and
  * less than or equal to the sample size (validated when calling `fit`).
  */
-@PythonName("KNearestNeighbors")
 class KNearestNeighborsRegressor(
     @PythonName("number_of_neighbors") const numberOfNeighbors: Int
 ) sub Regressor where {

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/lasso_regression.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/lasso_regression.sdsstub
@@ -8,7 +8,6 @@ from safeds.ml.classical.regression import Regressor
  *
  * @param alpha Controls the regularization of the model. The higher the value, the more regularized it becomes.
  */
-@PythonName("LassoRegression")
 class LassoRegressor(
     const alpha: Float = 1.0
 ) sub Regressor where {

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/linear_regression.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/linear_regression.sdsstub
@@ -6,7 +6,6 @@ from safeds.ml.classical.regression import Regressor
 /**
  * Linear regression.
  */
-@PythonName("LinearRegression")
 class LinearRegressionRegressor() sub Regressor {
     /**
      * Create a copy of this regressor and fit it with the given training data.

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/random_forest.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/random_forest.sdsstub
@@ -8,7 +8,6 @@ from safeds.ml.classical.regression import Regressor
  *
  * @param numberOfTrees The number of trees to be used in the random forest. Has to be greater than 0.
  */
-@PythonName("RandomForest")
 class RandomForestRegressor(
     @PythonName("number_of_trees") const numberOfTrees: Int = 100
 ) sub Regressor where {

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/ridge_regression.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/ridge_regression.sdsstub
@@ -8,7 +8,6 @@ from safeds.ml.classical.regression import Regressor
  *
  * @param alpha Controls the regularization of the model. The higher the value, the more regularized it becomes.
  */
-@PythonName("RidgeRegression")
 class RidgeRegressor(
     const alpha: Float = 1.0
 ) sub Regressor where {

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/support_vector_machine.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/support_vector_machine.sdsstub
@@ -9,7 +9,6 @@ from safeds.ml.classical.regression import Regressor
  * @param c The strength of regularization. Must be strictly positive.
  * @param kernel The type of kernel to be used. Defaults to None.
  */
-@PythonName("SupportVectorMachine")
 class SupportVectorMachineRegressor(
     const c: Float = 1.0,
     kernel: SupportVectorMachineRegressor.Kernel = SupportVectorMachineRegressor.Kernel.RadialBasisFunction

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/nn/classifier.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/nn/classifier.sdsstub
@@ -3,7 +3,6 @@ package safeds.ml.nn
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.ml.nn import FNNLayer
 
-@PythonName("ClassificationNeuralNetwork")
 class NeuralNetworkClassifier(
     layers: List<FNNLayer>
 ) {

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/nn/regressor.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/nn/regressor.sdsstub
@@ -3,9 +3,8 @@ package safeds.ml.nn
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.ml.nn import FNNLayer
 
-@PythonName("RegressionNeuralNetwork")
 class NeuralNetworkRegressor(
-    layers: List<Any>
+    layers: List<FNNLayer>
 ) {
     /**
      * Check if the model is fitted.


### PR DESCRIPTION
### Summary of Changes

We now require a version of `safe-ds-runner` between `0.8.0` (included) and `0.9.0` (excluded).
