### PR TITLE
feat: resolve name paths in `{@link }` tags in documentation

### DIFF
--- a/docs/language/common/comments.md
+++ b/docs/language/common/comments.md
@@ -93,6 +93,27 @@ an argument:
 fun sum(a: Int, b: Int): sum: Int
 ```
 
+To point to _static_ members of a [class][class] or an [enum variant][enum-variant] of an [enum][enum], write the name of
+the containing declaration followed by a dot and the name of the member or enum variant:
+
+```sds
+/**
+ * To create a Table, use {@link Table.fromCsv}.
+ */
+class Table
+```
+
+To point to an _instance_ member of a [class][class], write the name of the containing declaration followed by a hash and
+the name of the member:
+
+```sds
+/**
+ * An alias for {@link List#size}.
+ */
+fun size(list: List<Any?>): size: Int
+```
+
+
 #### `@param`
 
 Use `@param` to document a [parameter][parameter] of a callable declaration. This tag takes the name of the parameter
@@ -155,6 +176,9 @@ fun sum(a: Int, b: Int): sum: Int
 the [`@param`](#param), [`@result`](#result), and [`@typeParam`](#typeparam) tags on the containing declaration,
 respectively.
 
+[class]: ../stub-language/classes.md
+[enum]: ../stub-language/enumerations.md
+[enum-variant]: ../stub-language/enumerations.md#enum-variants
 [parameter]: parameters.md
 [result]: results.md
 [type-parameter]: ../stub-language/type-parameters.md

--- a/docs/stdlib/safeds/data/tabular/containers/Column.md
+++ b/docs/stdlib/safeds/data/tabular/containers/Column.md
@@ -128,7 +128,7 @@ A column is a named collection of values.
         @Pure
         fun transform<R>(
             transformer: (param1: T) -> param2: R
-        ) -> result1: Column
+        ) -> result1: Column<R>
     
         /**
          * Calculate Pearson correlation between this and another column. Both columns have to be numerical.
@@ -738,7 +738,7 @@ The original column is not modified.
 
 | Name | Type | Description |
 |------|------|-------------|
-| `result1` | [`Column<Any?>`][safeds.data.tabular.containers.Column] | The transformed column. |
+| `result1` | [`Column<R>`][safeds.data.tabular.containers.Column] | The transformed column. |
 
 **Type parameters:**
 
@@ -752,7 +752,7 @@ The original column is not modified.
     @Pure
     fun transform<R>(
         transformer: (param1: T) -> param2: R
-    ) -> result1: Column
+    ) -> result1: Column<R>
     ```
 
 ## `#!sds fun` variance {#safeds.data.tabular.containers.Column.variance data-toc-label='variance'}

--- a/docs/stdlib/safeds/data/tabular/containers/Table.md
+++ b/docs/stdlib/safeds/data/tabular/containers/Table.md
@@ -4,13 +4,13 @@ A table is a two-dimensional collection of data. It can either be seen as a list
 
 To create a `Table` call the constructor or use one of the following static methods:
 
-| Method                                                            | Description                            |
-| ------------------------------------------------------------------| -------------------------------------- |
-| [fromCsvFile][safeds.data.tabular.containers.Table.fromCsvFile]   | Create a table from a CSV file.        |
-| [fromJsonFile][safeds.data.tabular.containers.Table.fromJsonFile] | Create a table from a JSON file.       |
-| [fromDict][safeds.data.tabular.containers.Table.fromDict]         | Create a table from a dictionary.      |
-| [fromColumns][safeds.data.tabular.containers.Table.fromColumns]   | Create a table from a list of columns. |
-| [fromRows][safeds.data.tabular.containers.Table.fromRows]         | Create a table from a list of rows.    |
+| Method                     | Description                            |
+| ---------------------------| -------------------------------------- |
+| [Table.fromCsvFile][safeds.data.tabular.containers.Table.fromCsvFile]  | Create a table from a CSV file.        |
+| [Table.fromJsonFile][safeds.data.tabular.containers.Table.fromJsonFile] | Create a table from a JSON file.       |
+| [Table.fromDict][safeds.data.tabular.containers.Table.fromDict]     | Create a table from a dictionary.      |
+| [Table.fromColumns][safeds.data.tabular.containers.Table.fromColumns]  | Create a table from a list of columns. |
+| [Table.fromRows][safeds.data.tabular.containers.Table.fromRows]     | Create a table from a list of rows.    |
 
 Note: When removing the last column of the table, the `number_of_columns` property will be set to 0.
 

--- a/docs/stdlib/safeds/data/tabular/containers/Table.md
+++ b/docs/stdlib/safeds/data/tabular/containers/Table.md
@@ -61,7 +61,7 @@ Note: When removing the last column of the table, the `number_of_columns` proper
         /**
          * Read data from an Excel file into a table.
          *
-         * Valid file extensions are `.xls`, '.xlsx', `.xlsm`, `.xlsb`, `.odf`, `.ods` and `.odt`.
+         * Valid file extensions are `.xls`, `.xlsx`, `.xlsm`, `.xlsb`, `.odf`, `.ods` and `.odt`.
          *
          * @param path The path to the Excel file.
          *
@@ -1940,7 +1940,7 @@ Create a table from a dictionary that maps column names to column values.
 
 Read data from an Excel file into a table.
 
-Valid file extensions are `.xls`, '.xlsx', `.xlsm`, `.xlsb`, `.odf`, `.ods` and `.odt`.
+Valid file extensions are `.xls`, `.xlsx`, `.xlsm`, `.xlsb`, `.odf`, `.ods` and `.odt`.
 
 **Parameters:**
 

--- a/packages/safe-ds-lang/src/language/documentation/safe-ds-documentation-provider.ts
+++ b/packages/safe-ds-lang/src/language/documentation/safe-ds-documentation-provider.ts
@@ -170,6 +170,7 @@ export class SafeDsDocumentationProvider extends JSDocDocumentationProvider {
                 if (!linkRenderer) {
                     const nameSegment = this.nameProvider.getNameNode(target);
                     if (!nameSegment) {
+                        /* c8 ignore next 2 */
                         return display;
                     }
 
@@ -177,17 +178,18 @@ export class SafeDsDocumentationProvider extends JSDocDocumentationProvider {
                     const character = nameSegment.range.start.character + 1;
                     const uri = AstUtils.getDocument(target).uri.with({ fragment: `L${line},${character}` });
                     return `[${display}](${uri.toString()})`;
-                } else {
-                    return linkRenderer(target, display);
                 }
+
+                return linkRenderer(target, display);
             },
         };
     }
 
     private findTarget(node: AstNode, namePath: string): SdsDeclaration | undefined {
         let [globalName, ...rest] = this.tokenizeNamepath(namePath);
+        // `rest` contains pairs of separators and names
         if (!globalName || rest.length % 2 !== 0) {
-            // `rest` contains pairs of separators and names
+            /* c8 ignore next 2 */
             return undefined;
         }
 
@@ -202,6 +204,7 @@ export class SafeDsDocumentationProvider extends JSDocDocumentationProvider {
             } else if (separator === '#') {
                 current = this.findInstanceMember(current, name);
             } else {
+                /* c8 ignore next 2 */
                 return undefined;
             }
         }
@@ -274,4 +277,4 @@ const isTag = (element: JSDocElement): element is JSDocTag => {
     return 'name' in element;
 };
 
-type LinkRenderer = (target: SdsDeclaration | undefined, display: string) => string | undefined;
+type LinkRenderer = (target: SdsDeclaration, display: string) => string | undefined;

--- a/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
+++ b/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
@@ -426,11 +426,7 @@ export class SafeDsMarkdownGenerator {
 
     private renderDescription(node: SdsDeclaration) {
         return this.documentationProvider.getDescription(node, (target, display) => {
-            if (target) {
-                return `[${display}][${getQualifiedName(target)}]`;
-            } else {
-                return display;
-            }
+            return `[${display}][${getQualifiedName(target)}]`;
         });
     }
 

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/data/tabular/containers/column.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/data/tabular/containers/column.sdsstub
@@ -119,7 +119,7 @@ class Column<T = Any?>(
     @Pure
     fun transform<R>(
         transformer: (param1: T) -> param2: R
-    ) -> result1: Column
+    ) -> result1: Column<R>
 
     /**
      * Calculate Pearson correlation between this and another column. Both columns have to be numerical.

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/data/tabular/containers/table.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/data/tabular/containers/table.sdsstub
@@ -60,7 +60,7 @@ class Table(
     /**
      * Read data from an Excel file into a table.
      *
-     * Valid file extensions are `.xls`, '.xlsx', `.xlsm`, `.xlsb`, `.odf`, `.ods` and `.odt`.
+     * Valid file extensions are `.xls`, `.xlsx`, `.xlsm`, `.xlsb`, `.odf`, `.ods` and `.odt`.
      *
      * @param path The path to the Excel file.
      *

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/data/tabular/containers/table.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/data/tabular/containers/table.sdsstub
@@ -10,13 +10,13 @@ from safeds.data.tabular.typing import ColumnType, Schema
  *
  * To create a `Table` call the constructor or use one of the following static methods:
  *
- * | Method                                                            | Description                            |
- * | ------------------------------------------------------------------| -------------------------------------- |
- * | [fromCsvFile][safeds.data.tabular.containers.Table.fromCsvFile]   | Create a table from a CSV file.        |
- * | [fromJsonFile][safeds.data.tabular.containers.Table.fromJsonFile] | Create a table from a JSON file.       |
- * | [fromDict][safeds.data.tabular.containers.Table.fromDict]         | Create a table from a dictionary.      |
- * | [fromColumns][safeds.data.tabular.containers.Table.fromColumns]   | Create a table from a list of columns. |
- * | [fromRows][safeds.data.tabular.containers.Table.fromRows]         | Create a table from a list of rows.    |
+ * | Method                     | Description                            |
+ * | ---------------------------| -------------------------------------- |
+ * | {@link Table.fromCsvFile}  | Create a table from a CSV file.        |
+ * | {@link Table.fromJsonFile} | Create a table from a JSON file.       |
+ * | {@link Table.fromDict}     | Create a table from a dictionary.      |
+ * | {@link Table.fromColumns}  | Create a table from a list of columns. |
+ * | {@link Table.fromRows}     | Create a table from a list of rows.    |
  *
  * Note: When removing the last column of the table, the `number_of_columns` property will be set to 0.
  *

--- a/packages/safe-ds-lang/tests/language/documentation/safe-ds-documentation-provider.test.ts
+++ b/packages/safe-ds-lang/tests/language/documentation/safe-ds-documentation-provider.test.ts
@@ -344,17 +344,6 @@ describe('SafeDsDocumentationProvider', () => {
     describe('findTarget', () => {
         const testCases: DocumentationProviderTest[] = [
             {
-                testName: 'link (unresolved)',
-                code: `
-                    /**
-                     * {@link myFunction2}
-                     */
-                    fun myFunction1()
-                `,
-                predicate: isSdsFunction,
-                expectedDocumentation: `myFunction2`,
-            },
-            {
                 testName: 'link (global)',
                 code: `
                     /**
@@ -473,6 +462,39 @@ describe('SafeDsDocumentationProvider', () => {
                 `,
                 predicate: isSdsFunction,
                 expectedDocumentation: `[MyClass.NestedClass#myMethod](`,
+            },
+            {
+                testName: 'link (unresolved global)',
+                code: `
+                    /**
+                     * {@link myFunction2}
+                     */
+                    fun myFunction1()
+                `,
+                predicate: isSdsFunction,
+                expectedDocumentation: `myFunction2`,
+            },
+            {
+                testName: 'link (wrong container for instance)',
+                code: `
+                    /**
+                     * {@link myFunction1#test}
+                     */
+                    fun myFunction1()
+                `,
+                predicate: isSdsFunction,
+                expectedDocumentation: `myFunction1#test`,
+            },
+            {
+                testName: 'link (wrong container for static)',
+                code: `
+                    /**
+                     * {@link myFunction1.test}
+                     */
+                    fun myFunction1()
+                `,
+                predicate: isSdsFunction,
+                expectedDocumentation: `myFunction1.test`,
             },
         ];
 

--- a/packages/safe-ds-lang/tests/language/documentation/safe-ds-documentation-provider.test.ts
+++ b/packages/safe-ds-lang/tests/language/documentation/safe-ds-documentation-provider.test.ts
@@ -204,19 +204,6 @@ describe('SafeDsDocumentationProvider', () => {
             const normalizedExpected = normalizeLineBreaks(expectedDocumentation);
             expect(normalizedActual).toStrictEqual(normalizedExpected);
         });
-
-        it('should resolve links', async () => {
-            const code = `
-                /**
-                 * {@link myFunction2}
-                 */
-                fun myFunction1()
-
-                fun myFunction2()
-            `;
-            const node = await getNodeOfType(services, code, isSdsFunction);
-            expect(documentationProvider.getDocumentation(node)).toMatch(/\[myFunction2\]\(.*\)/u);
-        });
     });
 
     describe('getDescription', () => {
@@ -351,6 +338,153 @@ describe('SafeDsDocumentationProvider', () => {
             const normalizedActual = normalizeLineBreaks(documentationProvider.getSince(node));
             const normalizedExpected = normalizeLineBreaks(expectedDocumentation);
             expect(normalizedActual).toStrictEqual(normalizedExpected);
+        });
+    });
+
+    describe('findTarget', () => {
+        const testCases: DocumentationProviderTest[] = [
+            {
+                testName: 'link (unresolved)',
+                code: `
+                    /**
+                     * {@link myFunction2}
+                     */
+                    fun myFunction1()
+                `,
+                predicate: isSdsFunction,
+                expectedDocumentation: `myFunction2`,
+            },
+            {
+                testName: 'link (global)',
+                code: `
+                    /**
+                     * {@link myFunction2}
+                     */
+                    fun myFunction1()
+
+                    fun myFunction2()
+                `,
+                predicate: isSdsFunction,
+                expectedDocumentation: `[myFunction2](`,
+            },
+            {
+                testName: 'link (instance attribute)',
+                code: `
+                    /**
+                     * {@link MyClass#myAttribute}
+                     */
+                    fun myFunction1()
+
+                    class MyClass {
+                        attr myAttribute: String
+                    }
+                `,
+                predicate: isSdsFunction,
+                expectedDocumentation: `[MyClass#myAttribute](`,
+            },
+            {
+                testName: 'link (static attribute)',
+                code: `
+                    /**
+                     * {@link MyClass.myAttribute}
+                     */
+                    fun myFunction1()
+
+                    class MyClass {
+                        static attr myAttribute: String
+                    }
+                `,
+                predicate: isSdsFunction,
+                expectedDocumentation: `[MyClass.myAttribute`,
+            },
+            {
+                testName: 'link (instance method)',
+                code: `
+                    /**
+                     * {@link MyClass#myMethod}
+                     */
+                    fun myFunction1()
+
+                    class MyClass {
+                        fun myMethod()
+                    }
+                `,
+                predicate: isSdsFunction,
+                expectedDocumentation: `[MyClass#myMethod](`,
+            },
+            {
+                testName: 'link (nested class)',
+                code: `
+                    /**
+                     * {@link MyClass.NestedClass}
+                     */
+                    fun myFunction1()
+
+                    class MyClass {
+                        class NestedClass
+                    }
+                `,
+                predicate: isSdsFunction,
+                expectedDocumentation: `[MyClass.NestedClass](`,
+            },
+            {
+                testName: 'link (nested enum)',
+                code: `
+                    /**
+                     * {@link MyClass.NestedEnum}
+                     */
+                    fun myFunction1()
+
+                    class MyClass {
+                        enum NestedEnum
+                    }
+                `,
+                predicate: isSdsFunction,
+                expectedDocumentation: `[MyClass.NestedEnum](`,
+            },
+            {
+                testName: 'link (enum variant)',
+                code: `
+                    /**
+                     * {@link MyEnum.Variant}
+                     */
+                    fun myFunction1()
+
+                    enum MyEnum {
+                        Variant
+                    }
+                `,
+                predicate: isSdsFunction,
+                expectedDocumentation: `[MyEnum.Variant](`,
+            },
+            {
+                testName: 'link (long chain)',
+                code: `
+                    /**
+                     * {@link MyClass.NestedClass#myMethod}
+                     */
+                    fun myFunction1()
+
+                    class MyClass {
+                        class NestedClass {
+                            fun myMethod()
+                        }
+                    }
+                `,
+                predicate: isSdsFunction,
+                expectedDocumentation: `[MyClass.NestedClass#myMethod](`,
+            },
+        ];
+
+        it.each(testCases)('$testName', async ({ code, predicate, expectedDocumentation }) => {
+            const node = await getNodeOfType(services, code, predicate);
+            const actualDocumentation = documentationProvider.getDocumentation(node);
+
+            if (expectedDocumentation === undefined) {
+                expect(actualDocumentation).toBeUndefined();
+            } else {
+                expect(actualDocumentation).toMatch(expectedDocumentation);
+            }
         });
     });
 });


### PR DESCRIPTION
### Summary of Changes

`{@link }` tags can now also contain name paths to access instance & static members of classes and variants of enums. Refer to the documentation for usage instructions.
