### PR TITLE
feat: forbid instance and static class members with same name

### DIFF
--- a/docs/language/common/comments.md
+++ b/docs/language/common/comments.md
@@ -70,7 +70,7 @@ with no special meaning.
 
 Documentation comments support [Markdown](https://www.markdownguide.org/) to format the text. Here is an example:
 
-```sds
+```sds hl_lines="2"
 /**
  * This is a documentation comment with **bold** and *italic* text.
  */
@@ -86,40 +86,35 @@ Documentation comments can contain tags to provide structured information.
 `{@link}` is an **inline** tag that can be used to link to another declaration. It takes the name of the declaration as
 an argument:
 
-```sds
+```sds hl_lines="2"
 /**
  * Computes the sum of two {@link Int}s.
  */
 fun sum(a: Int, b: Int): sum: Int
 ```
 
-To point to _static_ members of a [class][class] or an [enum variant][enum-variant] of an [enum][enum], write the name of
-the containing declaration followed by a dot and the name of the member or enum variant:
+To point to a member of a [class][class] or an [enum variant][enum-variant] of an [enum][enum], write the name of the
+containing declaration followed by a dot and the name of the member or enum variant:
 
-```sds
+```sds hl_lines="2"
 /**
- * To create a Table, use {@link Table.fromCsv}.
+ * To create a Configuration, use {@link Configuration.fromFile}.
  */
-class Table
+class Configuration {
+
+    /**
+     * Creates a Configuration from a file.
+     */
+    fun fromFile(file: String) -> result: Configuration
+}
 ```
-
-To point to an _instance_ member of a [class][class], write the name of the containing declaration followed by a hash and
-the name of the member:
-
-```sds
-/**
- * An alias for {@link List#size}.
- */
-fun size(list: List<Any?>): size: Int
-```
-
 
 #### `@param`
 
 Use `@param` to document a [parameter][parameter] of a callable declaration. This tag takes the name of the parameter
 and its description as arguments. Since a callable can have multiple parameters, this tag can be used multiple times.
 
-```sds
+```sds  hl_lines="4 5"
 /**
  * ...
  *
@@ -134,7 +129,7 @@ fun sum(a: Int, b: Int): sum: Int
 Use `@result` to document a [result][result] of a callable declaration. This tag takes the name of the result and its
 description as arguments. Since a callable can have multiple results, this tag can be used multiple times.
 
-```sds
+```sds hl_lines="4"
 /**
  * ...
  *
@@ -149,7 +144,7 @@ Use `@typeParam` to document a [type parameter][type-parameter] of a generic dec
 type parameter and its description as arguments. Since a generic declaration can have multiple type parameters, this
 tag can be used multiple times.
 
-```sds
+```sds hl_lines="4"
 /**
  * ...
  *
@@ -163,7 +158,7 @@ class List<T>
 The `@since` tag can be used to specify when a declaration was added. It takes the version as argument and should be
 used only once.
 
-```sds
+```sds hl_lines="4"
 /**
  * ...
  *

--- a/packages/safe-ds-lang/src/language/validation/names.ts
+++ b/packages/safe-ds-lang/src/language/validation/names.ts
@@ -38,7 +38,6 @@ import {
     getParameters,
     getResults,
     getTypeParameters,
-    isStatic,
     streamBlockLambdaResults,
     streamPlaceholders,
 } from '../helpers/nodeProperties.js';
@@ -224,11 +223,7 @@ export const classMustContainUniqueNames = (node: SdsClass, accept: ValidationAc
         accept,
     );
 
-    const instanceMembers = getClassMembers(node).filter((it) => !isStatic(it));
-    namesMustBeUnique(instanceMembers, (name) => `An instance member with name '${name}' exists already.`, accept);
-
-    const staticMembers = getClassMembers(node).filter(isStatic);
-    namesMustBeUnique(staticMembers, (name) => `A static member with name '${name}' exists already.`, accept);
+    namesMustBeUnique(getClassMembers(node), (name) => `A class member with name '${name}' exists already.`, accept);
 };
 
 export const enumMustContainUniqueNames = (node: SdsEnum, accept: ValidationAcceptor): void => {

--- a/packages/safe-ds-lang/tests/language/documentation/safe-ds-documentation-provider.test.ts
+++ b/packages/safe-ds-lang/tests/language/documentation/safe-ds-documentation-provider.test.ts
@@ -360,7 +360,7 @@ describe('SafeDsDocumentationProvider', () => {
                 testName: 'link (instance attribute)',
                 code: `
                     /**
-                     * {@link MyClass#myAttribute}
+                     * {@link MyClass.myAttribute}
                      */
                     fun myFunction1()
 
@@ -369,7 +369,7 @@ describe('SafeDsDocumentationProvider', () => {
                     }
                 `,
                 predicate: isSdsFunction,
-                expectedDocumentation: `[MyClass#myAttribute](`,
+                expectedDocumentation: `[MyClass.myAttribute](`,
             },
             {
                 testName: 'link (static attribute)',
@@ -390,7 +390,7 @@ describe('SafeDsDocumentationProvider', () => {
                 testName: 'link (instance method)',
                 code: `
                     /**
-                     * {@link MyClass#myMethod}
+                     * {@link MyClass.myMethod}
                      */
                     fun myFunction1()
 
@@ -399,7 +399,7 @@ describe('SafeDsDocumentationProvider', () => {
                     }
                 `,
                 predicate: isSdsFunction,
-                expectedDocumentation: `[MyClass#myMethod](`,
+                expectedDocumentation: `[MyClass.myMethod](`,
             },
             {
                 testName: 'link (nested class)',
@@ -450,7 +450,7 @@ describe('SafeDsDocumentationProvider', () => {
                 testName: 'link (long chain)',
                 code: `
                     /**
-                     * {@link MyClass.NestedClass#myMethod}
+                     * {@link MyClass.NestedClass.myMethod}
                      */
                     fun myFunction1()
 
@@ -461,7 +461,7 @@ describe('SafeDsDocumentationProvider', () => {
                     }
                 `,
                 predicate: isSdsFunction,
-                expectedDocumentation: `[MyClass.NestedClass#myMethod](`,
+                expectedDocumentation: `[MyClass.NestedClass.myMethod](`,
             },
             {
                 testName: 'link (unresolved global)',
@@ -473,17 +473,6 @@ describe('SafeDsDocumentationProvider', () => {
                 `,
                 predicate: isSdsFunction,
                 expectedDocumentation: `myFunction2`,
-            },
-            {
-                testName: 'link (wrong container for instance)',
-                code: `
-                    /**
-                     * {@link myFunction1#test}
-                     */
-                    fun myFunction1()
-                `,
-                predicate: isSdsFunction,
-                expectedDocumentation: `myFunction1#test`,
             },
             {
                 testName: 'link (wrong container for static)',

--- a/packages/safe-ds-lang/tests/resources/validation/names/duplicates/in class/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/names/duplicates/in class/main.sdstest
@@ -9,8 +9,6 @@ class MyClass1<
     »UniqueTypeParameter«,
     // $TEST$ no error r"A type parameter or parameter with name '\w*' exists already\."
     »TypeParameterAndParameter«,
-    // $TEST$ no error r"A type parameter or parameter with name '\w*' exists already\."
-    »TypeParameterAndMember«,
 >(
     // $TEST$ no error r"A type parameter or parameter with name '\w*' exists already\."
     »duplicateParameter«: Int,
@@ -20,222 +18,228 @@ class MyClass1<
     »uniqueParameter«: Int,
     // $TEST$ error "A type parameter or parameter with name 'TypeParameterAndParameter' exists already."
     »TypeParameterAndParameter«: Int,
-    // $TEST$ no error r"A type parameter or parameter with name '\w*' exists already\."
-    »parameterAndMember«: Int,
 ) {
-	// $TEST$ no error r"An instance member with name '\w*' exists already\."
+	// $TEST$ no error r"A class member with name '\w*' exists already\."
     attr »duplicateInstanceAttribute«: Int
-    // $TEST$ error "An instance member with name 'duplicateInstanceAttribute' exists already."
+    // $TEST$ error "A class member with name 'duplicateInstanceAttribute' exists already."
     attr »duplicateInstanceAttribute«: Int
-	// $TEST$ no error r"An instance member with name '\w*' exists already\."
+	// $TEST$ no error r"A class member with name '\w*' exists already\."
     attr »uniqueInstanceAttribute«: Int
 
-	// $TEST$ no error r"A static member with name '\w*' exists already\."
+	// $TEST$ no error r"A class member with name '\w*' exists already\."
     static attr »duplicateStaticAttribute«: Int
-    // $TEST$ error "A static member with name 'duplicateStaticAttribute' exists already."
+    // $TEST$ error "A class member with name 'duplicateStaticAttribute' exists already."
     static attr »duplicateStaticAttribute«: Int
-	// $TEST$ no error r"A static member with name '\w*' exists already\."
+	// $TEST$ no error r"A class member with name '\w*' exists already\."
     static attr »uniqueStaticAttribute«: Int
 
-    // $TEST$ no error r"A static member with name '\w*' exists already\."
+    // $TEST$ no error r"A class member with name '\w*' exists already\."
     class »DuplicateClass«
-    // $TEST$ error "A static member with name 'DuplicateClass' exists already."
+    // $TEST$ error "A class member with name 'DuplicateClass' exists already."
     class »DuplicateClass«
-    // $TEST$ no error r"A static member with name '\w*' exists already\."
+    // $TEST$ no error r"A class member with name '\w*' exists already\."
     class »UniqueClass«
 
-    // $TEST$ no error r"A static member with name '\w*' exists already\."
+    // $TEST$ no error r"A class member with name '\w*' exists already\."
     enum »DuplicateEnum«
-    // $TEST$ error "A static member with name 'DuplicateEnum' exists already."
+    // $TEST$ error "A class member with name 'DuplicateEnum' exists already."
     enum »DuplicateEnum«
-    // $TEST$ no error r"A static member with name '\w*' exists already\."
+    // $TEST$ no error r"A class member with name '\w*' exists already\."
     enum »UniqueEnum«
 
-    // $TEST$ no error r"An instance member with name '\w*' exists already\."
+    // $TEST$ no error r"A class member with name '\w*' exists already\."
     fun »duplicateInstanceMethod«()
-    // $TEST$ error "An instance member with name 'duplicateInstanceMethod' exists already."
+    // $TEST$ error "A class member with name 'duplicateInstanceMethod' exists already."
     fun »duplicateInstanceMethod«()
-    // $TEST$ no error r"An instance member with name '\w*' exists already\."
+    // $TEST$ no error r"A class member with name '\w*' exists already\."
     fun »uniqueInstanceMethod«()
 
-    // $TEST$ no error r"A static member with name '\w*' exists already\."
+    // $TEST$ no error r"A class member with name '\w*' exists already\."
     static fun »duplicateStaticMethod«()
-    // $TEST$ error "A static member with name 'duplicateStaticMethod' exists already."
+    // $TEST$ error "A class member with name 'duplicateStaticMethod' exists already."
     static fun »duplicateStaticMethod«()
-    // $TEST$ no error r"A static member with name '\w*' exists already\."
+    // $TEST$ no error r"A class member with name '\w*' exists already\."
     static fun »uniqueStaticMethod«()
 
-    // $TEST$ no error r"An instance member with name '\w*' exists already\."
-    attr »duplicateInstanceMember«: Int
-    // $TEST$ error "An instance member with name 'duplicateInstanceMember' exists already."
-    fun »duplicateInstanceMember«()
+    // $TEST$ no error r"A class member with name '\w*' exists already\."
+    attr »duplicateMember«: Int
 
-    // $TEST$ no error r"A static member with name '\w*' exists already\."
-    static attr »duplicateStaticMember«: Int
-    // $TEST$ error "A static member with name 'duplicateStaticMember' exists already."
-    class »duplicateStaticMember«
-    // $TEST$ error "A static member with name 'duplicateStaticMember' exists already."
-    enum »duplicateStaticMember«
-    // $TEST$ error "A static member with name 'duplicateStaticMember' exists already."
-    static fun »duplicateStaticMember«()
+    // $TEST$ error "A class member with name 'duplicateMember' exists already."
+    attr »duplicateMember«: Int
+    // $TEST$ error "A class member with name 'duplicateMember' exists already."
+    fun »duplicateMember«()
+
+    // $TEST$ error "A class member with name 'duplicateMember' exists already."
+    static attr »duplicateMember«: Int
+    // $TEST$ error "A class member with name 'duplicateMember' exists already."
+    class »duplicateMember«
+    // $TEST$ error "A class member with name 'duplicateMember' exists already."
+    enum »duplicateMember«
+    // $TEST$ error "A class member with name 'duplicateMember' exists already."
+    static fun »duplicateMember«()
 }
 
 class MyClass2<
     // $TEST$ no error r"A type parameter or parameter with name '\w*' exists already\."
     »TypeParameterAndMember«,
-> {
+>(
+    // $TEST$ no error r"A type parameter or parameter with name '\w*' exists already\."
+    »parameterAndMember«: Int,
+) {
 	// $TEST$ no error r"A.*member with name '\w*' exists already\."
     attr »TypeParameterAndMember«: Int
 
     // $TEST$ no error r"A.*member with name '\w*' exists already\."
-    attr »instanceAndStaticMember«: Int
-    // $TEST$ no error "r"A.*member with name '\w*' exists already\."
-    static attr »instanceAndStaticMember«: Int
-
-    // $TEST$ no error "r"A.*member with name '\w*' exists already\."
-    static attr »staticAndInstanceMember«: Int
-    // $TEST$ no error r"A.*member with name '\w*' exists already\."
-    attr »staticAndInstanceMember«: Int
-}
-
-class MyClass3<
-    // $TEST$ no error r"A type parameter or parameter with name '\w*' exists already\."
-    »TypeParameterAndMember«,
-> {
-	// $TEST$ no error r"A.*member with name '\w*' exists already\."
-    static attr »TypeParameterAndMember«: Int
-
-    // $TEST$ no error r"A.*member with name '\w*' exists already\."
-    attr »instanceAndStaticMember«: Int
-    // $TEST$ no error "r"A.*member with name '\w*' exists already\."
-    class »instanceAndStaticMember«
-
-    // $TEST$ no error "r"A.*member with name '\w*' exists already\."
-    class »staticAndInstanceMember«
-    // $TEST$ no error r"A.*member with name '\w*' exists already\."
-    attr »staticAndInstanceMember«: Int
+    attr »parameterAndMember«: Int
 }
 
 class MyClass4<
     // $TEST$ no error r"A type parameter or parameter with name '\w*' exists already\."
     »TypeParameterAndMember«,
-> {
+>(
+    // $TEST$ no error r"A type parameter or parameter with name '\w*' exists already\."
+    »parameterAndMember«: Int,
+) {
 	// $TEST$ no error r"A.*member with name '\w*' exists already\."
     class »TypeParameterAndMember«
 
     // $TEST$ no error r"A.*member with name '\w*' exists already\."
-    attr »instanceAndStaticMember«: Int
-    // $TEST$ no error "r"A.*member with name '\w*' exists already\."
-    enum »instanceAndStaticMember«
-
-    // $TEST$ no error "r"A.*member with name '\w*' exists already\."
-    enum »staticAndInstanceMember«
-    // $TEST$ no error r"A.*member with name '\w*' exists already\."
-    attr »staticAndInstanceMember«: Int
+    class »parameterAndMember«
 }
+
 
 class MyClass5<
     // $TEST$ no error r"A type parameter or parameter with name '\w*' exists already\."
     »TypeParameterAndMember«,
-> {
+>(
+    // $TEST$ no error r"A type parameter or parameter with name '\w*' exists already\."
+    »parameterAndMember«: Int,
+) {
 	// $TEST$ no error r"A.*member with name '\w*' exists already\."
     enum »TypeParameterAndMember«
 
     // $TEST$ no error r"A.*member with name '\w*' exists already\."
-    attr »instanceAndStaticMember«: Int
-    // $TEST$ no error "r"A.*member with name '\w*' exists already\."
-    static fun »instanceAndStaticMember«()
-
-    // $TEST$ no error "r"A.*member with name '\w*' exists already\."
-    static fun »staticAndInstanceMember«()
-    // $TEST$ no error r"A.*member with name '\w*' exists already\."
-    attr »staticAndInstanceMember«: Int
+    enum »parameterAndMember«
 }
 
 class MyClass6<
     // $TEST$ no error r"A type parameter or parameter with name '\w*' exists already\."
     »TypeParameterAndMember«,
-> {
+>(
+    // $TEST$ no error r"A type parameter or parameter with name '\w*' exists already\."
+    »parameterAndMember«: Int,
+) {
 	// $TEST$ no error r"A.*member with name '\w*' exists already\."
-    fun »TypeParameterAndMember«()
+    @Pure fun »TypeParameterAndMember«()
 
     // $TEST$ no error r"A.*member with name '\w*' exists already\."
-    fun »instanceAndStaticMember«()
-    // $TEST$ no error "r"A.*member with name '\w*' exists already\."
-    static attr »instanceAndStaticMember«: Int
-
-    // $TEST$ no error "r"A.*member with name '\w*' exists already\."
-    static attr »staticAndInstanceMember«: Int
-    // $TEST$ no error r"A.*member with name '\w*' exists already\."
-    fun »staticAndInstanceMember«()
+    @Pure fun »parameterAndMember«()
 }
 
 class MyClass7<
     // $TEST$ no error r"A type parameter or parameter with name '\w*' exists already\."
     »TypeParameterAndMember«,
-> {
+>(
+    // $TEST$ no error r"A type parameter or parameter with name '\w*' exists already\."
+    »parameterAndMember«: Int,
+) {
 	// $TEST$ no error r"A.*member with name '\w*' exists already\."
-    fun »TypeParameterAndMember«()
+    @Pure static fun »TypeParameterAndMember«()
 
     // $TEST$ no error r"A.*member with name '\w*' exists already\."
-    fun »instanceAndStaticMember«()
+    @Pure static fun »parameterAndMember«()
+}
+
+class MyClass8 {
+    // $TEST$ no error r"A.*member with name '\w*' exists already\."
+    attr »instanceAndStaticMember«: Int
+    // $TEST$ error "A class member with name 'instanceAndStaticMember' exists already."
+    static attr »instanceAndStaticMember«: Int
+
     // $TEST$ no error "r"A.*member with name '\w*' exists already\."
+    static attr »staticAndInstanceMember«: Int
+    // $TEST$ error "A class member with name 'staticAndInstanceMember' exists already."
+    attr »staticAndInstanceMember«: Int
+}
+
+class MyClass9 {
+    // $TEST$ no error r"A.*member with name '\w*' exists already\."
+    attr »instanceAndStaticMember«: Int
+    // $TEST$ error "A class member with name 'instanceAndStaticMember' exists already."
     class »instanceAndStaticMember«
 
     // $TEST$ no error "r"A.*member with name '\w*' exists already\."
     class »staticAndInstanceMember«
-    // $TEST$ no error r"A.*member with name '\w*' exists already\."
-    fun »staticAndInstanceMember«()
+    // $TEST$ error "A class member with name 'staticAndInstanceMember' exists already."
+    attr »staticAndInstanceMember«: Int
 }
-
-class MyClass8(
-    // $TEST$ no error r"A type parameter or parameter with name '\w*' exists already\."
-    »parameterAndMember«: Int,
-) {
-	// $TEST$ no error r"A.*member with name '\w*' exists already\."
-    attr »parameterAndMember«: Int
-
+class MyClass10 {
     // $TEST$ no error r"A.*member with name '\w*' exists already\."
-    fun »instanceAndStaticMember«()
-    // $TEST$ no error "r"A.*member with name '\w*' exists already\."
+    attr »instanceAndStaticMember«: Int
+    // $TEST$ error "A class member with name 'instanceAndStaticMember' exists already."
     enum »instanceAndStaticMember«
 
     // $TEST$ no error "r"A.*member with name '\w*' exists already\."
     enum »staticAndInstanceMember«
-    // $TEST$ no error r"A.*member with name '\w*' exists already\."
-    fun »staticAndInstanceMember«()
+    // $TEST$ error "A class member with name 'staticAndInstanceMember' exists already."
+    attr »staticAndInstanceMember«: Int
 }
 
-class MyClass9(
-    // $TEST$ no error r"A type parameter or parameter with name '\w*' exists already\."
-    »parameterAndMember«: Int,
-) {
-	// $TEST$ no error r"A.*member with name '\w*' exists already\."
-    class »parameterAndMember«
-
+class MyClass11 {
     // $TEST$ no error r"A.*member with name '\w*' exists already\."
-    fun »instanceAndStaticMember«()
-    // $TEST$ no error "r"A.*member with name '\w*' exists already\."
-    static fun »instanceAndStaticMember«()
+    attr »instanceAndStaticMember«: Int
+    // $TEST$ error "A class member with name 'instanceAndStaticMember' exists already."
+    @Pure static fun »instanceAndStaticMember«()
 
     // $TEST$ no error "r"A.*member with name '\w*' exists already\."
-    static fun »staticAndInstanceMember«()
+    @Pure static fun »staticAndInstanceMember«()
+    // $TEST$ error "A class member with name 'staticAndInstanceMember' exists already."
+    attr »staticAndInstanceMember«: Int
+}
+
+class MyClass12 {
     // $TEST$ no error r"A.*member with name '\w*' exists already\."
-    fun »staticAndInstanceMember«()
+    @Pure fun»instanceAndStaticMember«()
+    // $TEST$ error "A class member with name 'instanceAndStaticMember' exists already."
+    static attr »instanceAndStaticMember«: Int
+
+    // $TEST$ no error "r"A.*member with name '\w*' exists already\."
+    static attr »staticAndInstanceMember«: Int
+    // $TEST$ error "A class member with name 'staticAndInstanceMember' exists already."
+    @Pure fun»staticAndInstanceMember«()
 }
 
-class MyClass10(
-    // $TEST$ no error r"A type parameter or parameter with name '\w*' exists already\."
-    »parameterAndMember«: Int,
-) {
-	// $TEST$ no error r"A.*member with name '\w*' exists already\."
-    enum »parameterAndMember«
+class MyClass13 {
+    // $TEST$ no error r"A.*member with name '\w*' exists already\."
+    @Pure fun»instanceAndStaticMember«()
+    // $TEST$ error "A class member with name 'instanceAndStaticMember' exists already."
+    class »instanceAndStaticMember«
+
+    // $TEST$ no error "r"A.*member with name '\w*' exists already\."
+    class »staticAndInstanceMember«
+    // $TEST$ error "A class member with name 'staticAndInstanceMember' exists already."
+    @Pure fun»staticAndInstanceMember«()
+}
+class MyClass14 {
+    // $TEST$ no error r"A.*member with name '\w*' exists already\."
+    @Pure fun»instanceAndStaticMember«()
+    // $TEST$ error "A class member with name 'instanceAndStaticMember' exists already."
+    enum »instanceAndStaticMember«
+
+    // $TEST$ no error "r"A.*member with name '\w*' exists already\."
+    enum »staticAndInstanceMember«
+    // $TEST$ error "A class member with name 'staticAndInstanceMember' exists already."
+    @Pure fun»staticAndInstanceMember«()
 }
 
-class MyClass11(
-    // $TEST$ no error r"A type parameter or parameter with name '\w*' exists already\."
-    »parameterAndMember«: Int,
-) {
-	// $TEST$ no error r"A.*member with name '\w*' exists already\."
-    fun »parameterAndMember«()
+class MyClass15 {
+    // $TEST$ no error r"A.*member with name '\w*' exists already\."
+    @Pure fun»instanceAndStaticMember«()
+    // $TEST$ error "A class member with name 'instanceAndStaticMember' exists already."
+    @Pure static fun »instanceAndStaticMember«()
+
+    // $TEST$ no error "r"A.*member with name '\w*' exists already\."
+    @Pure static fun »staticAndInstanceMember«()
+    // $TEST$ error "A class member with name 'staticAndInstanceMember' exists already."
+    @Pure fun»staticAndInstanceMember«()
 }


### PR DESCRIPTION
### Summary of Changes

* Classes can no longer have instance and static members with the same name. This was very confusing and frequently required special handling (e.g. `.` vs. `#` separators for name paths in `{@link}` tags.

* `.` is now the only separator in name paths of `{@link}` tags, regardless of whether it's an instance or static member.

