### PR TITLE
ci: fix Codecov upload from forks

### DIFF
--- a/.github/workflows/pr-codecov.yml
+++ b/.github/workflows/pr-codecov.yml
@@ -22,6 +22,8 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/pr-codecov.yml
+++ b/.github/workflows/pr-codecov.yml
@@ -19,12 +19,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: coverage
-          path: coverage.zip
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Unzip coverage
-        run: unzip coverage.zip
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/pr-codecov.yml
+++ b/.github/workflows/pr-codecov.yml
@@ -1,0 +1,45 @@
+name: Pull Request Codecov
+
+on:
+  workflow_run:
+    workflows:
+      - "Pull Request"
+    types:
+      - completed
+
+jobs:
+  upload-coverage-to-codecov:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+
+    steps:
+      - name: Download artifact
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            const matchArtifact = allArtifacts.data.artifacts.find((artifact) => artifact.name == "coverage");
+            const download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            const fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/coverage.zip`, Buffer.from(download.data));
+
+      - name: Unzip artifact
+        run: unzip coverage.zip
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: coverage
+          files: coverage-final.json

--- a/.github/workflows/pr-codecov.yml
+++ b/.github/workflows/pr-codecov.yml
@@ -15,26 +15,15 @@ jobs:
         working-directory: .
 
     steps:
-      - name: Download artifact
-        uses: actions/github-script@v6
+      - name: Download coverage
+        uses: actions/download-artifact@v4
         with:
-          script: |
-            const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
-            });
-            const matchArtifact = allArtifacts.data.artifacts.find((artifact) => artifact.name == "coverage");
-            const download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            const fs = require('fs');
-            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/coverage.zip`, Buffer.from(download.data));
+          name: coverage
+          path: coverage.zip
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Unzip artifact
+      - name: Unzip coverage
         run: unzip coverage.zip
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/pr-codecov.yml
+++ b/.github/workflows/pr-codecov.yml
@@ -26,5 +26,4 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: coverage
           files: coverage-final.json

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,9 +45,8 @@ jobs:
       - name: Test with Vitest
         run: npm run test-with-coverage
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+      - name: Upload coverage as artifact
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: coverage
-          files: coverage-final.json
+          name: coverage
+          path: coverage/coverage-final.json


### PR DESCRIPTION
### Summary of Changes

Coverage computed for forks (including Dependabot) should now get uploaded to Codecov.
