### PR TITLE
feat: mark entire type cast as wrong if cast is impossible

### DIFF
--- a/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
+++ b/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
@@ -171,7 +171,7 @@ import {
     parameterMustHaveTypeHint,
     prefixOperationOperandMustHaveCorrectType,
     resultMustHaveTypeHint,
-    typeCastExpressionMustHaveUnknownType,
+    typeCastMustNotAlwaysFail,
     typeParameterDefaultValueMustMatchUpperBound,
     yieldTypeMustMatchResultType,
 } from './types.js';
@@ -361,7 +361,7 @@ export const registerValidationChecks = function (services: SafeDsServices) {
         ],
         SdsStatement: [statementMustDoSomething(services)],
         SdsTemplateString: [templateStringMustHaveExpressionBetweenTwoStringParts],
-        SdsTypeCast: [typeCastExpressionMustHaveUnknownType(services)],
+        SdsTypeCast: [typeCastMustNotAlwaysFail(services)],
         SdsTypeParameter: [
             typeParameterDefaultValueMustMatchUpperBound(services),
             typeParameterMustBeUsedInCorrectPosition(services),

--- a/packages/safe-ds-lang/src/language/validation/types.ts
+++ b/packages/safe-ds-lang/src/language/validation/types.ts
@@ -353,7 +353,7 @@ export const prefixOperationOperandMustHaveCorrectType = (services: SafeDsServic
     };
 };
 
-export const typeCastExpressionMustHaveUnknownType = (services: SafeDsServices) => {
+export const typeCastMustNotAlwaysFail = (services: SafeDsServices) => {
     const typeChecker = services.typing.TypeChecker;
     const typeComputer = services.typing.TypeComputer;
 
@@ -369,7 +369,7 @@ export const typeCastExpressionMustHaveUnknownType = (services: SafeDsServices) 
         ) {
             accept('error', 'This type cast can never succeed.', {
                 // Using property: "expression" does not work here, probably due to eclipse-langium/langium#1218
-                node: node.expression,
+                node,
                 code: CODE_TYPE_MISMATCH,
             });
         }

--- a/packages/safe-ds-lang/tests/resources/validation/types/checking/type casts/main.sdstest
+++ b/packages/safe-ds-lang/tests/resources/validation/types/checking/type casts/main.sdstest
@@ -6,17 +6,17 @@ class E() sub C
 
 pipeline test {
     // $TEST$ error "This type cast can never succeed."
-    »D()« as E;
+    »D() as E«;
 
     // $TEST$ no error "This type cast can never succeed."
-    »C()« as C;
+    »C() as C«;
 
     // $TEST$ no error "This type cast can never succeed."
-    »C()« as D;
+    »C() as D«;
 
     // $TEST$ no error "This type cast can never succeed."
-    »D()« as C;
+    »D() as C«;
 
     // $TEST$ no error "This type cast can never succeed."
-    »unresolved« as Int;
+    »unresolved as Int«;
 }


### PR DESCRIPTION
### Summary of Changes

If a type cast can never succeed, it is now marked completely as erroneous. Previously, only its left operand was marked, which makes little sense since both operands determine whether the cast is legal. 