### PR TITLE
feat: inlay hints for inferred types of lambda parameters

### DIFF
--- a/packages/safe-ds-lang/src/language/workspace/safe-ds-settings-provider.ts
+++ b/packages/safe-ds-lang/src/language/workspace/safe-ds-settings-provider.ts
@@ -13,6 +13,10 @@ export class SafeDsSettingsProvider {
         return (await this.getInlayHintsSettings()).assigneeTypes?.enabled ?? true;
     }
 
+    async shouldShowLambdaParameterTypeInlayHints(): Promise<boolean> {
+        return (await this.getInlayHintsSettings()).lambdaParameterTypes?.enabled ?? true;
+    }
+
     async shouldShowParameterNameInlayHints(): Promise<boolean> {
         return (await this.getInlayHintsSettings()).parameterNames?.enabled ?? true;
     }
@@ -48,6 +52,9 @@ export class SafeDsSettingsProvider {
 
 interface InlayHintsSettings {
     assigneeTypes: {
+        enabled: boolean;
+    };
+    lambdaParameterTypes: {
         enabled: boolean;
     };
     parameterNames: {

--- a/packages/safe-ds-vscode/package.json
+++ b/packages/safe-ds-vscode/package.json
@@ -88,6 +88,11 @@
                     "default": true,
                     "description": "Show inferred types for named assignees."
                 },
+                "safe-ds.inlayHints.lambdaParameterTypes.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Show inferred types for lambda parameters without manifest types."
+                },
                 "safe-ds.inlayHints.parameterNames.enabled": {
                     "type": "boolean",
                     "default": true,


### PR DESCRIPTION
### Summary of Changes

Add optional inlay hints for the inferred types of lambda parameters without manifest types.
