### PR TITLE
fix: catch internal errors caused by wrong synthetic nodes created by completion provider

### DIFF
--- a/packages/safe-ds-lang/src/language/scoping/safe-ds-scope-provider.ts
+++ b/packages/safe-ds-lang/src/language/scoping/safe-ds-scope-provider.ts
@@ -124,7 +124,12 @@ export class SafeDsScopeProvider extends DefaultScopeProvider {
         } else if (isSdsYield(node) && context.property === 'result') {
             return this.getScopeForYieldResult(node);
         } else {
-            return super.getScope(context);
+            try {
+                // May throw errors when triggered from the completion provider due to wrong synthetic nodes
+                return super.getScope(context);
+            } catch {
+                return EMPTY_SCOPE;
+            }
         }
     }
 

--- a/packages/safe-ds-lang/tests/language/lsp/safe-ds.completion-provider.test.ts
+++ b/packages/safe-ds-lang/tests/language/lsp/safe-ds.completion-provider.test.ts
@@ -361,6 +361,18 @@ describe('SafeDsCompletionProvider', async () => {
                     shouldContain: ['Annotation', 'MyAnnotation', 'OtherAnnotation'],
                 },
             },
+            {
+                testName: 'no error when completing block lambda result',
+                code: `
+                    pipeline myPipeline {
+                        (param1) {
+                            yield <|>
+                    }
+                `,
+                expectedLabels: {
+                    shouldEqual: [],
+                },
+            },
         ];
 
         it.each(testCases)('$testName', async ({ code, uri, expectedLabels }) => {


### PR DESCRIPTION
### Summary of Changes

Triggering completion could lead to errors like `Error: SdsMap:result is not a valid reference id.`. These are now caught, since the completion provider inevitably sometimes creates the wrong synthetic nodes before invoking the scope provider.