### PR TITLE
refactor: move logging callbacks into language server

### DIFF
--- a/packages/safe-ds-lang/src/language/runner/safe-ds-runner.ts
+++ b/packages/safe-ds-lang/src/language/runner/safe-ds-runner.ts
@@ -60,6 +60,7 @@ export class SafeDsRunner {
         this.registerMessageLoggingCallbacks();
     }
 
+    /* c8 ignore start */
     private registerMessageLoggingCallbacks() {
         this.addMessageCallback((message) => {
             this.logging.outputInfo(
@@ -108,6 +109,7 @@ export class SafeDsRunner {
             );
         }, 'runtime_error');
     }
+    /* c8 ignore stop */
 
     /**
      * Change the command to start the runner process. This will not cause the runner process to restart, if it is already running.
@@ -295,7 +297,7 @@ export class SafeDsRunner {
      * @param executionId Id that uniquely identifies the execution that produced this stack frame
      * @param frame Stack frame from the python execution
      */
-    public async tryMapToSafeDSSource(
+    private async tryMapToSafeDSSource(
         executionId: string,
         frame: RuntimeErrorBacktraceFrame | undefined,
     ): Promise<RuntimeErrorBacktraceFrame | undefined> {

--- a/packages/safe-ds-lang/src/language/safe-ds-module.ts
+++ b/packages/safe-ds-lang/src/language/safe-ds-module.ts
@@ -78,6 +78,9 @@ export type SafeDsAddedServices = {
     purity: {
         PurityComputer: SafeDsPurityComputer;
     };
+    runtime: {
+        Runner: SafeDsRunner;
+    };
     typing: {
         ClassHierarchy: SafeDsClassHierarchy;
         CoreTypes: SafeDsCoreTypes;
@@ -88,9 +91,6 @@ export type SafeDsAddedServices = {
     workspace: {
         PackageManager: SafeDsPackageManager;
         SettingsProvider: SafeDsSettingsProvider;
-    };
-    runtime: {
-        Runner: SafeDsRunner;
     };
 };
 
@@ -151,6 +151,9 @@ export const SafeDsModule: Module<SafeDsServices, PartialLangiumServices & SafeD
         ScopeComputation: (services) => new SafeDsScopeComputation(services),
         ScopeProvider: (services) => new SafeDsScopeProvider(services),
     },
+    runtime: {
+        Runner: (services) => new SafeDsRunner(services),
+    },
     typing: {
         ClassHierarchy: (services) => new SafeDsClassHierarchy(services),
         CoreTypes: (services) => new SafeDsCoreTypes(services),
@@ -161,9 +164,6 @@ export const SafeDsModule: Module<SafeDsServices, PartialLangiumServices & SafeD
     workspace: {
         PackageManager: (services) => new SafeDsPackageManager(services),
         SettingsProvider: (services) => new SafeDsSettingsProvider(services),
-    },
-    runtime: {
-        Runner: (services) => new SafeDsRunner(services),
     },
 };
 


### PR DESCRIPTION
### Summary of Changes

As a first step for #1002, register logging callbacks in the `Runner` service instead of the extension.
