### PR TITLE
fix: consumption of source maps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12431,7 +12431,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
             "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -14351,7 +14350,7 @@
                 "glob": "^10.3.12",
                 "langium": "^3.0.0",
                 "semver": "^7.6.0",
-                "source-map": "^0.7.4",
+                "source-map-js": "^1.2.0",
                 "tree-kill": "^1.2.2",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.11",
@@ -14365,14 +14364,6 @@
             },
             "engines": {
                 "node": ">=18.0.0"
-            }
-        },
-        "packages/safe-ds-lang/node_modules/source-map": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-            "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-            "engines": {
-                "node": ">= 8"
             }
         },
         "packages/safe-ds-vscode": {

--- a/packages/safe-ds-lang/package.json
+++ b/packages/safe-ds-lang/package.json
@@ -47,7 +47,7 @@
         "glob": "^10.3.12",
         "langium": "^3.0.0",
         "semver": "^7.6.0",
-        "source-map": "^0.7.4",
+        "source-map-js": "^1.2.0",
         "tree-kill": "^1.2.2",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.11",

--- a/packages/safe-ds-lang/src/language/runner/safe-ds-runner.ts
+++ b/packages/safe-ds-lang/src/language/runner/safe-ds-runner.ts
@@ -12,7 +12,7 @@ import {
     RuntimeErrorBacktraceFrame,
     RuntimeErrorMessage,
 } from './messages.js';
-import { BasicSourceMapConsumer, SourceMapConsumer } from 'source-map';
+import { SourceMapConsumer } from 'source-map-js';
 import treeKill from 'tree-kill';
 import { SafeDsAnnotations } from '../builtins/safe-ds-annotations.js';
 import { SafeDsPythonGenerator } from '../generation/safe-ds-python-generator.js';
@@ -318,7 +318,7 @@ export class SafeDsRunner {
         if (!execInfo.sourceMappings.has(sourceMapKey)) {
             const sourceMapObject = JSON.parse(execInfo.generatedSource.get(sourceMapKey)!);
             sourceMapObject.sourcesContent = [execInfo.source];
-            const consumer = await new SourceMapConsumer(sourceMapObject);
+            const consumer = new SourceMapConsumer(sourceMapObject);
             execInfo.sourceMappings.set(sourceMapKey, consumer);
         }
         const outputPosition = execInfo.sourceMappings.get(sourceMapKey)!.originalPositionFor({
@@ -365,7 +365,7 @@ export class SafeDsRunner {
         // Store information about the run
         this.executionInformation.set(id, {
             generatedSource: lastGeneratedSources,
-            sourceMappings: new Map<string, BasicSourceMapConsumer>(),
+            sourceMappings: new Map<string, SourceMapConsumer>(),
             path: pipelineDocument.uri.fsPath,
             source: pipelineDocument.textDocument.getText(),
             calculatedPlaceholders: new Map<string, string>(),
@@ -599,7 +599,7 @@ export interface RunnerLoggingOutput {
 export interface PipelineExecutionInformation {
     source: string;
     generatedSource: Map<string, string>;
-    sourceMappings: Map<string, BasicSourceMapConsumer>;
+    sourceMappings: Map<string, SourceMapConsumer>;
     path: string;
     /**
      * Maps placeholder name to placeholder type

--- a/packages/safe-ds-vscode/esbuild.mjs
+++ b/packages/safe-ds-vscode/esbuild.mjs
@@ -40,13 +40,6 @@ const plugins = [
         },
         watch,
     }),
-    // Needed to resolve source-maps in the extension
-    copy({
-        assets: {
-            from: ['../../node_modules/source-map/lib/mappings.wasm'],
-            to: ['./extension'],
-        },
-    }),
     {
         name: 'watch-plugin',
         setup(build) {


### PR DESCRIPTION
### Summary of Changes

Previously, source maps were not displayed for me, since the required `wasm` file was not downloaded from NPM. Using `source-maps-js` instead of `source-maps` to consume them, fixes this issue.
