### PR TITLE
refactor: configure messaging when creating services

### DIFF
--- a/packages/safe-ds-lang/src/language/lsp/safe-ds-messaging-provider.ts
+++ b/packages/safe-ds-lang/src/language/lsp/safe-ds-messaging-provider.ts
@@ -1,4 +1,4 @@
-import { SafeDsServices } from '../safe-ds-module.js';
+import { Logger, SafeDsServices } from '../safe-ds-module.js';
 import { Connection } from 'vscode-languageserver';
 import { Disposable } from 'vscode-languageserver-protocol';
 
@@ -9,17 +9,27 @@ import { Disposable } from 'vscode-languageserver-protocol';
  */
 export class SafeDsMessagingProvider {
     private readonly connection: Connection | undefined;
+    private logger: Logger | undefined = undefined;
 
     constructor(services: SafeDsServices) {
         this.connection = services.shared.lsp.Connection;
     }
 
     /**
+     * Set the logger to use for logging messages.
+     */
+    setLogger(logger: Logger) {
+        this.logger = logger;
+    }
+
+    /**
      * Log the given data to the trace log.
      */
     trace(tag: string, message: string, verbose?: string): void {
-        if (this.connection) {
-            const text = this.formatLogMessage(tag, message);
+        const text = this.formatLogMessage(tag, message);
+        if (this.logger?.trace) {
+            this.logger.trace(text, verbose);
+        } else if (this.connection) {
             this.connection.tracer.log(text, verbose);
         }
     }
@@ -28,8 +38,10 @@ export class SafeDsMessagingProvider {
      * Log a debug message.
      */
     debug(tag: string, message: string): void {
-        if (this.connection) {
-            const text = this.formatLogMessage(tag, message);
+        const text = this.formatLogMessage(tag, message);
+        if (this.logger?.debug) {
+            this.logger.debug(text);
+        } else if (this.connection) {
             this.connection.console.debug(text);
         }
     }
@@ -38,8 +50,10 @@ export class SafeDsMessagingProvider {
      * Log an information message.
      */
     info(tag: string, message: string): void {
-        if (this.connection) {
-            const text = this.formatLogMessage(tag, message);
+        const text = this.formatLogMessage(tag, message);
+        if (this.logger?.info) {
+            this.logger.info(text);
+        } else if (this.connection) {
             this.connection.console.info(text);
         }
     }
@@ -48,8 +62,10 @@ export class SafeDsMessagingProvider {
      * Log a warning message.
      */
     warn(tag: string, message: string): void {
-        if (this.connection) {
-            const text = this.formatLogMessage(tag, message);
+        const text = this.formatLogMessage(tag, message);
+        if (this.logger?.warn) {
+            this.logger.warn(text);
+        } else if (this.connection) {
             this.connection.console.warn(text);
         }
     }
@@ -58,8 +74,10 @@ export class SafeDsMessagingProvider {
      * Log an error message.
      */
     error(tag: string, message: string): void {
-        if (this.connection) {
-            const text = this.formatLogMessage(tag, message);
+        const text = this.formatLogMessage(tag, message);
+        if (this.logger?.error) {
+            this.logger.error(text);
+        } else if (this.connection) {
             this.connection.console.error(text);
         }
     }

--- a/packages/safe-ds-lang/src/language/lsp/safe-ds-messaging-provider.ts
+++ b/packages/safe-ds-lang/src/language/lsp/safe-ds-messaging-provider.ts
@@ -1,4 +1,4 @@
-import { Logger, SafeDsServices } from '../safe-ds-module.js';
+import { Logger, SafeDsServices, UserMessageProvider } from '../safe-ds-module.js';
 import { Connection } from 'vscode-languageserver';
 import { Disposable } from 'vscode-languageserver-protocol';
 
@@ -10,16 +10,10 @@ import { Disposable } from 'vscode-languageserver-protocol';
 export class SafeDsMessagingProvider {
     private readonly connection: Connection | undefined;
     private logger: Logger | undefined = undefined;
+    private userMessageProvider: UserMessageProvider | undefined = undefined;
 
     constructor(services: SafeDsServices) {
         this.connection = services.shared.lsp.Connection;
-    }
-
-    /**
-     * Set the logger to use for logging messages.
-     */
-    setLogger(logger: Logger) {
-        this.logger = logger;
     }
 
     /**
@@ -93,7 +87,9 @@ export class SafeDsMessagingProvider {
      * notification center.
      */
     showInformationMessage(message: string): void {
-        if (this.connection) {
+        if (this.userMessageProvider?.showInformationMessage) {
+            this.userMessageProvider.showInformationMessage(message);
+        } else if (this.connection) {
             this.connection.window.showInformationMessage(message);
         }
     }
@@ -105,7 +101,9 @@ export class SafeDsMessagingProvider {
      * notification center.
      */
     showWarningMessage(message: string): void {
-        if (this.connection) {
+        if (this.userMessageProvider?.showWarningMessage) {
+            this.userMessageProvider.showWarningMessage(message);
+        } else if (this.connection) {
             this.connection.window.showWarningMessage(message);
         }
     }
@@ -117,7 +115,9 @@ export class SafeDsMessagingProvider {
      * notification center.
      */
     showErrorMessage(message: string): void {
-        if (this.connection) {
+        if (this.userMessageProvider?.showErrorMessage) {
+            this.userMessageProvider.showErrorMessage(message);
+        } else if (this.connection) {
             this.connection.window.showErrorMessage(message);
         }
     }
@@ -148,6 +148,20 @@ export class SafeDsMessagingProvider {
         if (this.connection) {
             await this.connection.sendNotification(method, params);
         }
+    }
+
+    /**
+     * Set the logger to use for logging messages.
+     */
+    setLogger(logger: Logger) {
+        this.logger = logger;
+    }
+
+    /**
+     * Set the user message provider to use for showing messages to the user.
+     */
+    setUserMessageProvider(userMessageProvider: UserMessageProvider) {
+        this.userMessageProvider = userMessageProvider;
     }
 }
 

--- a/packages/safe-ds-lang/src/language/lsp/safe-ds-messaging-provider.ts
+++ b/packages/safe-ds-lang/src/language/lsp/safe-ds-messaging-provider.ts
@@ -1,4 +1,4 @@
-import { Logger, SafeDsServices, UserMessageProvider } from '../safe-ds-module.js';
+import { SafeDsServices } from '../safe-ds-module.js';
 import { Connection } from 'vscode-languageserver';
 import { Disposable } from 'vscode-languageserver-protocol';
 
@@ -166,3 +166,53 @@ export class SafeDsMessagingProvider {
 }
 
 /* c8 ignore stop */
+
+/**
+ * A logging provider.
+ */
+export interface Logger {
+    /**
+     * Log the given data to the trace log.
+     */
+    trace?: (message: string, verbose?: string) => void;
+
+    /**
+     * Log a debug message.
+     */
+    debug?: (message: string) => void;
+
+    /**
+     * Log an information message.
+     */
+    info?: (message: string) => void;
+
+    /**
+     * Log a warning message.
+     */
+    warn?: (message: string) => void;
+
+    /**
+     * Log an error message.
+     */
+    error?: (message: string) => void;
+}
+
+/**
+ * A service for showing messages to the user.
+ */
+export interface UserMessageProvider {
+    /**
+     * Prominently show an information message. The message should be short and human-readable.
+     */
+    showInformationMessage?: (message: string) => void;
+
+    /**
+     * Prominently show a warning message. The message should be short and human-readable.
+     */
+    showWarningMessage?: (message: string) => void;
+
+    /**
+     * Prominently show an error message. The message should be short and human-readable.
+     */
+    showErrorMessage?: (message: string) => void;
+}

--- a/packages/safe-ds-lang/src/language/runner/safe-ds-runner.ts
+++ b/packages/safe-ds-lang/src/language/runner/safe-ds-runner.ts
@@ -34,7 +34,6 @@ export class SafeDsRunner {
     private readonly generator: SafeDsPythonGenerator;
     private readonly messaging: SafeDsMessagingProvider;
 
-    private logging: RunnerLoggingOutput;
     private runnerCommand: string = 'safe-ds-runner';
     private runnerProcess: child_process.ChildProcessWithoutNullStreams | undefined = undefined;
     private port: number | undefined = undefined;
@@ -58,10 +57,6 @@ export class SafeDsRunner {
         this.annotations = services.builtins.Annotations;
         this.generator = services.generation.PythonGenerator;
         this.messaging = services.lsp.MessagingProvider;
-
-        this.logging = {
-            displayError(_value: string) {},
-        };
 
         // Register listeners
         this.registerMessageLoggingCallbacks();
@@ -137,15 +132,6 @@ export class SafeDsRunner {
     }
 
     /**
-     * Change the output functions for runner logging and error information to those provided.
-     *
-     * @param logging New Runner output functions.
-     */
-    public updateRunnerLogging(logging: RunnerLoggingOutput): void {
-        this.logging = logging;
-    }
-
-    /**
      * Start the python server on the next usable port, starting at 5000.
      * Uses the 'safe-ds.runner.command' setting to execute the process.
      */
@@ -159,7 +145,7 @@ export class SafeDsRunner {
             const versionString = await this.getPythonServerVersion(pythonServerTest);
             if (!semver.satisfies(versionString, npmVersionRange)) {
                 this.error(`Installed runner version ${versionString} does not meet requirements: ${pipVersionRange}`);
-                this.logging.displayError(
+                this.messaging.showErrorMessage(
                     `The installed runner version ${versionString} is not compatible with this version of the extension. The installed version should match these requirements: ${pipVersionRange}. Please update to a matching version.`,
                 );
                 return;
@@ -168,7 +154,7 @@ export class SafeDsRunner {
             }
         } catch (error) {
             this.error(`Could not start runner: ${error instanceof Error ? error.message : error}`);
-            this.logging.displayError(
+            this.messaging.showErrorMessage(
                 `The runner process could not be started: ${error instanceof Error ? error.message : error}`,
             );
             return;
@@ -595,13 +581,6 @@ export class SafeDsRunner {
     private error(message: string) {
         this.messaging.error(RUNNER_TAG, message);
     }
-}
-
-/**
- * Runner Logging interface
- */
-export interface RunnerLoggingOutput {
-    displayError: (value: string) => void;
 }
 
 /**

--- a/packages/safe-ds-lang/src/language/runner/safe-ds-runner.ts
+++ b/packages/safe-ds-lang/src/language/runner/safe-ds-runner.ts
@@ -574,6 +574,7 @@ export class SafeDsRunner {
         });
     }
 
+    /* c8 ignore start */
     private info(message: string) {
         this.messaging.info(RUNNER_TAG, message);
     }
@@ -581,6 +582,7 @@ export class SafeDsRunner {
     private error(message: string) {
         this.messaging.error(RUNNER_TAG, message);
     }
+    /* c8 ignore stop */
 }
 
 /**

--- a/packages/safe-ds-lang/src/language/safe-ds-module.ts
+++ b/packages/safe-ds-lang/src/language/safe-ds-module.ts
@@ -242,7 +242,11 @@ export const createSafeDsServices = async function (
     }
     if (options?.runnerCommand) {
         /* c8 ignore next 2 */
-        SafeDs.runtime.Runner.updateRunnerCommand(options?.runnerCommand);
+        SafeDs.runtime.Runner.updateRunnerCommand(options.runnerCommand);
+    }
+    if (options?.userMessageProvider) {
+        /* c8 ignore next 2 */
+        SafeDs.lsp.MessagingProvider.setUserMessageProvider(options.userMessageProvider);
     }
 
     return { shared, SafeDs };
@@ -267,6 +271,12 @@ export interface ModuleOptions {
      * Command to start the runner.
      */
     runnerCommand?: string;
+
+    /**
+     * A service for showing messages to the user. If the provider lacks a capability, we fall back to the language
+     * server connection, if available.
+     */
+    userMessageProvider?: UserMessageProvider;
 }
 
 /**
@@ -297,4 +307,24 @@ export interface Logger {
      * Log an error message.
      */
     error?: (message: string) => void;
+}
+
+/**
+ * A service for showing messages to the user.
+ */
+export interface UserMessageProvider {
+    /**
+     * Prominently show an information message. The message should be short and human-readable.
+     */
+    showInformationMessage?: (message: string) => void;
+
+    /**
+     * Prominently show a warning message. The message should be short and human-readable.
+     */
+    showWarningMessage?: (message: string) => void;
+
+    /**
+     * Prominently show an error message. The message should be short and human-readable.
+     */
+    showErrorMessage?: (message: string) => void;
 }

--- a/packages/safe-ds-lang/src/language/safe-ds-module.ts
+++ b/packages/safe-ds-lang/src/language/safe-ds-module.ts
@@ -45,7 +45,7 @@ import { SafeDsTypeFactory } from './typing/safe-ds-type-factory.js';
 import { SafeDsMarkdownGenerator } from './generation/safe-ds-markdown-generator.js';
 import { SafeDsCompletionProvider } from './lsp/safe-ds-completion-provider.js';
 import { SafeDsFuzzyMatcher } from './lsp/safe-ds-fuzzy-matcher.js';
-import { SafeDsMessagingProvider } from './lsp/safe-ds-messaging-provider.js';
+import { type Logger, SafeDsMessagingProvider, type UserMessageProvider } from './lsp/safe-ds-messaging-provider.js';
 import { SafeDsConfigurationProvider } from './workspace/safe-ds-configuration-provider.js';
 
 /**
@@ -277,54 +277,4 @@ export interface ModuleOptions {
      * server connection, if available.
      */
     userMessageProvider?: UserMessageProvider;
-}
-
-/**
- * A logging provider.
- */
-export interface Logger {
-    /**
-     * Log the given data to the trace log.
-     */
-    trace?: (message: string, verbose?: string) => void;
-
-    /**
-     * Log a debug message.
-     */
-    debug?: (message: string) => void;
-
-    /**
-     * Log an information message.
-     */
-    info?: (message: string) => void;
-
-    /**
-     * Log a warning message.
-     */
-    warn?: (message: string) => void;
-
-    /**
-     * Log an error message.
-     */
-    error?: (message: string) => void;
-}
-
-/**
- * A service for showing messages to the user.
- */
-export interface UserMessageProvider {
-    /**
-     * Prominently show an information message. The message should be short and human-readable.
-     */
-    showInformationMessage?: (message: string) => void;
-
-    /**
-     * Prominently show a warning message. The message should be short and human-readable.
-     */
-    showWarningMessage?: (message: string) => void;
-
-    /**
-     * Prominently show an error message. The message should be short and human-readable.
-     */
-    showErrorMessage?: (message: string) => void;
 }

--- a/packages/safe-ds-lang/src/language/safe-ds-module.ts
+++ b/packages/safe-ds-lang/src/language/safe-ds-module.ts
@@ -233,6 +233,10 @@ export const createSafeDsServices = async function (
     }
 
     // Apply options
+    if (options?.logger) {
+        /* c8 ignore next 2 */
+        SafeDs.lsp.MessagingProvider.setLogger(options.logger);
+    }
     if (!options?.omitBuiltins) {
         await shared.workspace.WorkspaceManager.initializeWorkspace([]);
     }
@@ -249,6 +253,12 @@ export const createSafeDsServices = async function (
  */
 export interface ModuleOptions {
     /**
+     * A logging provider. If the logger lacks a capability, we fall back to the logger provided by the language server
+     * connection, if available.
+     */
+    logger?: Logger;
+
+    /**
      * By default, builtins are loaded into the workspace. If this option is set to true, builtins are omitted.
      */
     omitBuiltins?: boolean;
@@ -257,4 +267,34 @@ export interface ModuleOptions {
      * Command to start the runner.
      */
     runnerCommand?: string;
+}
+
+/**
+ * A logging provider.
+ */
+export interface Logger {
+    /**
+     * Log the given data to the trace log.
+     */
+    trace?: (message: string, verbose?: string) => void;
+
+    /**
+     * Log a debug message.
+     */
+    debug?: (message: string) => void;
+
+    /**
+     * Log an information message.
+     */
+    info?: (message: string) => void;
+
+    /**
+     * Log a warning message.
+     */
+    warn?: (message: string) => void;
+
+    /**
+     * Log an error message.
+     */
+    error?: (message: string) => void;
 }

--- a/packages/safe-ds-lang/src/language/workspace/safe-ds-settings-provider.ts
+++ b/packages/safe-ds-lang/src/language/workspace/safe-ds-settings-provider.ts
@@ -84,12 +84,7 @@ export class SafeDsSettingsProvider {
     }
 }
 
-interface SettingsWatcher<T> {
-    accessor: (settings: DeepPartial<Settings>) => T;
-    callback: (newValue: T) => void;
-}
-
-interface Settings {
+export interface Settings {
     inlayHints: InlayHintsSettings;
     runner: RunnerSettings;
     validation: ValidationSettings;
@@ -124,4 +119,9 @@ interface ValidationSettings {
     nameConvention: {
         enabled: boolean;
     };
+}
+
+interface SettingsWatcher<T> {
+    accessor: (settings: DeepPartial<Settings>) => T;
+    callback: (newValue: T) => void;
 }

--- a/packages/safe-ds-vscode/src/extension/mainClient.ts
+++ b/packages/safe-ds-vscode/src/extension/mainClient.ts
@@ -32,13 +32,11 @@ export const activate = async function (context: vscode.ExtensionContext) {
                 error: logError,
             },
             runnerCommand: runnerCommandSetting,
+            userMessageProvider: {
+                showErrorMessage: vscode.window.showErrorMessage,
+            },
         })
     ).SafeDs;
-    services.runtime.Runner.updateRunnerLogging({
-        displayError(value: string): void {
-            vscode.window.showErrorMessage(value);
-        },
-    });
     await services.runtime.Runner.startPythonServer();
     acceptRunRequests(context);
 };

--- a/packages/safe-ds-vscode/src/extension/mainClient.ts
+++ b/packages/safe-ds-vscode/src/extension/mainClient.ts
@@ -25,16 +25,18 @@ export const activate = async function (context: vscode.ExtensionContext) {
     initializeLog();
     client = startLanguageClient(context);
     const runnerCommandSetting = vscode.workspace.getConfiguration('safe-ds.runner').get<string>('command')!; // Default is set
-    services = (await createSafeDsServices(NodeFileSystem, { runnerCommand: runnerCommandSetting })).SafeDs;
+    services = (
+        await createSafeDsServices(NodeFileSystem, {
+            logger: {
+                info: logOutput,
+                error: logError,
+            },
+            runnerCommand: runnerCommandSetting,
+        })
+    ).SafeDs;
     services.runtime.Runner.updateRunnerLogging({
         displayError(value: string): void {
             vscode.window.showErrorMessage(value);
-        },
-        outputError(value: string): void {
-            logError(value);
-        },
-        outputInfo(value: string): void {
-            logOutput(value);
         },
     });
     await services.runtime.Runner.startPythonServer();


### PR DESCRIPTION
Closes #1002

### Summary of Changes

* It's now possible to configure messaging (logging/user messaging) for when creating services.
* The runner now uses the `MessagingProvider` instead of handling messaging on its own.
