### PR TITLE
fix: show EDA tool for `TaggedTable` and `TimeSeries`

### DIFF
--- a/packages/safe-ds-vscode/src/extension/mainClient.ts
+++ b/packages/safe-ds-vscode/src/extension/mainClient.ts
@@ -292,7 +292,10 @@ const runEda = function (
         );
         if (
             message.id === pipelineExecutionId &&
-            message.data.type === 'Table' &&
+            // Can be removed altogether if the EDA tool is only triggered via code lenses
+            (message.data.type === 'Table' ||
+                message.data.type === 'TaggedTable' ||
+                message.data.type === 'TimeSeries') &&
             message.data.name === requestedPlaceholderName
         ) {
             lastFinishedPipelineExecutionId = pipelineExecutionId;


### PR DESCRIPTION
### Summary of Changes

The EDA tool does it own additional type checking to ensure it only opens on `Table`s. This should be removed eventually and type checking should be fully delegated to the language server. For now, this PR also allows opening it on `TaggedTable` and `TimeSeries`.