### PR TITLE
docs: improve navigation

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,38 @@
+# Safe-DS DSL
+
+[![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/safe-ds.safe-ds)](https://marketplace.visualstudio.com/items?itemName=safe-ds.safe-ds)
+[![Main](https://github.com/Safe-DS/DSL/actions/workflows/main.yml/badge.svg)](https://github.com/Safe-DS/DSL/actions/workflows/main.yml)
+[![codecov](https://codecov.io/gh/Safe-DS/DSL/branch/main/graph/badge.svg?token=ma0ytglhO1)](https://codecov.io/gh/Safe-DS/DSL)
+[![Documentation Status](https://readthedocs.org/projects/safe-ds-dsl/badge/?version=stable)](https://dsl.safeds.com)
+
+Safely develop Data Science programs with a statically checked domain specific language (DSL) and integrated tools for data
+inspection.
+
+![demo](../docs/img/readme/demo.gif)
+
+## Installation
+
+1. Get the latest extension for [Visual Studio Code](https://code.visualstudio.com/) from the
+   [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=safe-ds.safe-ds). This sets up a
+   complete _development environment_ for Safe-DS programs.
+2. To _execute_ Safe-DS programs, the [Safe-DS Runner](https://github.com/Safe-DS/Runner) has to be installed and
+   configured additionally:
+    1. Install [Python](https://www.python.org/) (3.11 or 3.12).
+    2. Run `pip install "safe-ds-runner>=0.10.0,<0.11.0"` in a command line to download the latest matching Runner version
+       from [PyPI](https://pypi.org/project/safe-ds-runner/).
+    3. If the Visual Studio Code extension cannot start the runner, adjust the setting `safe-ds.runner.command`.
+       Enter the absolute path to the Runner executable.
+
+## Documentation
+
+You can find the full documentation [here](https://dsl.safeds.com).
+
+## Contributing
+
+We welcome contributions from everyone. As a starting point, check the following resources:
+
+* [Contributing page](https://github.com/Safe-DS/DSL/contribute)
+
+If you need further help, please [use our discussion forum][forum].
+
+[forum]: https://github.com/orgs/Safe-DS/discussions

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,14 @@
-# Safe-DS DSL
+---
+hide:
+  - navigation
+---
 
-[![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/safe-ds.safe-ds)](https://marketplace.visualstudio.com/items?itemName=safe-ds.safe-ds)
-[![Main](https://github.com/Safe-DS/DSL/actions/workflows/main.yml/badge.svg)](https://github.com/Safe-DS/DSL/actions/workflows/main.yml)
-[![codecov](https://codecov.io/gh/Safe-DS/DSL/branch/main/graph/badge.svg?token=ma0ytglhO1)](https://codecov.io/gh/Safe-DS/DSL)
-[![Documentation Status](https://readthedocs.org/projects/safe-ds-dsl/badge/?version=stable)](https://dsl.safeds.com)
+# Safe-DS DSL
 
 Safely develop Data Science programs with a statically checked domain specific language (DSL) and integrated tools for data
 inspection.
 
-![demo](img/readme/demo.gif)
+![demo](img/readme/demo.gif){ max-width="400" }
 
 ## Installation
 
@@ -20,12 +20,8 @@ inspection.
     1. Install [Python](https://www.python.org/) (3.11 or 3.12).
     2. Run `pip install "safe-ds-runner>=0.10.0,<0.11.0"` in a command line to download the latest matching Runner version
        from [PyPI](https://pypi.org/project/safe-ds-runner/).
-   3. If the Visual Studio Code extension cannot start the runner, adjust the setting `safe-ds.runner.command`.
-      Enter the absolute path to the Runner executable.
-
-## Documentation
-
-You can find the full documentation [here](https://dsl.safeds.com).
+    3. If the Visual Studio Code extension cannot start the runner, adjust the setting `safe-ds.runner.command`.
+       Enter the absolute path to the Runner executable.
 
 ## Contributing
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -72,11 +72,15 @@ theme:
   features:
     - content.code.copy
     - content.tooltips
-    - navigation.tabs
     - navigation.indexes
     - navigation.instant
+    - navigation.instant.progress
+    - navigation.prune
     - navigation.sections
+    - navigation.tabs
+    - navigation.tabs.sticky
     - navigation.top
+    - toc.follow
 
 plugins:
   - literate-nav:


### PR DESCRIPTION
### Summary of Changes

* Separate README for GitHub
* Remove recursive link to full documentation from README of full documentation
* Hide navigation of home page to emphasize the navigation bar at the top
* Some other tweaks the navigation settings