### PR TITLE
docs: exclude summary page from search

### DIFF
--- a/docs/stdlib/SUMMARY.md
+++ b/docs/stdlib/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - safeds
     - data
         - image

--- a/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
+++ b/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
@@ -544,7 +544,9 @@ export class SafeDsMarkdownGenerator {
             options.destination,
             details.map((document) => URI.parse(document.uri)),
         );
-        const content = this.describeSummary('', summary);
+
+        const frontMatter = `---\nsearch:\n  exclude: true\n---\n\n`;
+        const content = frontMatter + this.describeSummary('', summary);
 
         return TextDocument.create(uri, 'md', 0, content);
     }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/deprecated/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/deprecated/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/experimental/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/experimental/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/undocumented/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/undocumented/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/deprecated/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/deprecated/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/experimental/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/experimental/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/deprecated/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/deprecated/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/experimental/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/experimental/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/undocumented/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/undocumented/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/deprecated/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/deprecated/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/experimental/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/experimental/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/undocumented/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/undocumented/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/link tag/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/link tag/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/multiline/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/multiline/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/pipelines/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/pipelines/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/deprecated/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/deprecated/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/experimental/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/experimental/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/undocumented/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/undocumented/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/deprecated/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/deprecated/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/experimental/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/experimental/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/undocumented/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/undocumented/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/SUMMARY.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 - tests
     - generation
         - markdown


### PR DESCRIPTION
### Summary of Changes

The summary page is only needed for navigation. It should never be accessed directly. This PR excludes the page from the search.