### PR TITLE
docs: clearly differentiate implementation code and stub code

### DIFF
--- a/docs/stdlib/safeds/data/image/containers/Image.md
+++ b/docs/stdlib/safeds/data/image/containers/Image.md
@@ -2,7 +2,7 @@
 
 A container for image data.
 
-??? quote "Source code in `image.sdsstub`"
+??? quote "Stub code in `image.sdsstub`"
 
     ```sds linenums="6"
     class Image {
@@ -328,7 +328,7 @@ The original image is not modified.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The image with added noise. |
 
-??? quote "Source code in `image.sdsstub`"
+??? quote "Stub code in `image.sdsstub`"
 
     ```sds linenums="163"
     @Pure
@@ -358,7 +358,7 @@ The original image is not modified.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The Image with adjusted brightness. |
 
-??? quote "Source code in `image.sdsstub`"
+??? quote "Stub code in `image.sdsstub`"
 
     ```sds linenums="146"
     @Pure
@@ -388,7 +388,7 @@ The original image is not modified.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The new, adjusted image. |
 
-??? quote "Source code in `image.sdsstub`"
+??? quote "Stub code in `image.sdsstub`"
 
     ```sds linenums="203"
     @Pure
@@ -418,7 +418,7 @@ The original image is not modified.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | New image with adjusted contrast. |
 
-??? quote "Source code in `image.sdsstub`"
+??? quote "Stub code in `image.sdsstub`"
 
     ```sds linenums="183"
     @Pure
@@ -448,7 +448,7 @@ The original image is not modified.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The blurred image. |
 
-??? quote "Source code in `image.sdsstub`"
+??? quote "Stub code in `image.sdsstub`"
 
     ```sds linenums="221"
     @Pure
@@ -471,7 +471,7 @@ The original image is not modified.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The grayscale image. |
 
-??? quote "Source code in `image.sdsstub`"
+??? quote "Stub code in `image.sdsstub`"
 
     ```sds linenums="82"
     @Pure
@@ -500,7 +500,7 @@ The original image is not modified.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The cropped image. |
 
-??? quote "Source code in `image.sdsstub`"
+??? quote "Stub code in `image.sdsstub`"
 
     ```sds linenums="98"
     @Pure
@@ -529,7 +529,7 @@ The original image is not modified.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The image with edges found. |
 
-??? quote "Source code in `image.sdsstub`"
+??? quote "Stub code in `image.sdsstub`"
 
     ```sds linenums="287"
     @Pure
@@ -549,7 +549,7 @@ The original image is not modified.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The flipped image. |
 
-??? quote "Source code in `image.sdsstub`"
+??? quote "Stub code in `image.sdsstub`"
 
     ```sds linenums="129"
     @Pure
@@ -569,7 +569,7 @@ The original image is not modified.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The flipped image. |
 
-??? quote "Source code in `image.sdsstub`"
+??? quote "Stub code in `image.sdsstub`"
 
     ```sds linenums="118"
     @Pure
@@ -589,7 +589,7 @@ The original image is not modified.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The image with inverted colors. |
 
-??? quote "Source code in `image.sdsstub`"
+??? quote "Stub code in `image.sdsstub`"
 
     ```sds linenums="254"
     @Pure
@@ -616,7 +616,7 @@ The original image is not modified.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The image with the given width and height. |
 
-??? quote "Source code in `image.sdsstub`"
+??? quote "Stub code in `image.sdsstub`"
 
     ```sds linenums="66"
     @Pure
@@ -641,7 +641,7 @@ The original image is not modified.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The image rotated 90 degrees counter-clockwise. |
 
-??? quote "Source code in `image.sdsstub`"
+??? quote "Stub code in `image.sdsstub`"
 
     ```sds linenums="276"
     @Pure
@@ -661,7 +661,7 @@ The original image is not modified.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The image rotated 90 degrees clockwise. |
 
-??? quote "Source code in `image.sdsstub`"
+??? quote "Stub code in `image.sdsstub`"
 
     ```sds linenums="265"
     @Pure
@@ -687,7 +687,7 @@ The original image is not modified.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The image sharpened by the given factor. |
 
-??? quote "Source code in `image.sdsstub`"
+??? quote "Stub code in `image.sdsstub`"
 
     ```sds linenums="240"
     @Pure
@@ -708,7 +708,7 @@ Save the image as a JPEG file.
 |------|------|-------------|---------|
 | `path` | [`String`][safeds.lang.String] | The path to the JPEG file. | - |
 
-??? quote "Source code in `image.sdsstub`"
+??? quote "Stub code in `image.sdsstub`"
 
     ```sds linenums="39"
     @Impure([ImpurityReason.FileWriteToParameterizedPath("path")])
@@ -728,7 +728,7 @@ Save the image as a PNG file.
 |------|------|-------------|---------|
 | `path` | [`String`][safeds.lang.String] | The path to the PNG file. | - |
 
-??? quote "Source code in `image.sdsstub`"
+??? quote "Stub code in `image.sdsstub`"
 
     ```sds linenums="50"
     @Impure([ImpurityReason.FileWriteToParameterizedPath("path")])
@@ -754,7 +754,7 @@ Create an image from a file.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The image. |
 
-??? quote "Source code in `image.sdsstub`"
+??? quote "Stub code in `image.sdsstub`"
 
     ```sds linenums="28"
     @Impure([ImpurityReason.FileReadFromParameterizedPath("path")])

--- a/docs/stdlib/safeds/data/tabular/containers/Column.md
+++ b/docs/stdlib/safeds/data/tabular/containers/Column.md
@@ -15,7 +15,7 @@ A column is a named collection of values.
 |------|-------------|-------------|---------|
 | `T` | [`Any?`][safeds.lang.Any] | - | [`Any?`][safeds.lang.Any] |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="12"
     class Column<out T = Any?>(
@@ -308,7 +308,7 @@ Check if all values have a given property.
 |------|------|-------------|
 | `result1` | [`Boolean`][safeds.lang.Boolean] | True if all match. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="58"
     @Pure
@@ -333,7 +333,7 @@ Check if any value has a given property.
 |------|------|-------------|
 | `result1` | [`Boolean`][safeds.lang.Boolean] | True if any match. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="70"
     @Pure
@@ -358,7 +358,7 @@ Calculate Pearson correlation between this and another column. Both columns have
 |------|------|-------------|
 | `result1` | [`Float`][safeds.lang.Float] | Correlation between the two columns. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="129"
     @Pure
@@ -378,7 +378,7 @@ Return a list of all unique values in the column.
 |------|------|-------------|
 | `result1` | [`List<T>`][safeds.lang.List] | List of unique values in the column. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="34"
     @Pure
@@ -402,7 +402,7 @@ Return column value at specified index, starting at 0.
 |------|------|-------------|
 | `result1` | `#!sds T` | Value at index in column. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="45"
     @Pure
@@ -422,7 +422,7 @@ Return whether the column has missing values.
 |------|------|-------------|
 | `result1` | [`Boolean`][safeds.lang.Boolean] | True if missing values exist. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="92"
     @Pure
@@ -446,7 +446,7 @@ $$
 |------|------|-------------|
 | `result1` | [`Float`][safeds.lang.Float] | The idness of the column. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="146"
     @Pure
@@ -463,7 +463,7 @@ Return the maximum value of the column. The column has to be numerical.
 |------|------|-------------|
 | `result1` | [`Float`][safeds.lang.Float] | The maximum value. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="154"
     @Pure
@@ -480,7 +480,7 @@ Return the mean value of the column. The column has to be numerical.
 |------|------|-------------|
 | `result1` | [`Float`][safeds.lang.Float] | The mean value. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="162"
     @Pure
@@ -497,7 +497,7 @@ Return the median value of the column. The column has to be numerical.
 |------|------|-------------|
 | `result1` | [`Float`][safeds.lang.Float] | The median value. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="170"
     @Pure
@@ -514,7 +514,7 @@ Return the minimum value of the column. The column has to be numerical.
 |------|------|-------------|
 | `result1` | [`Float`][safeds.lang.Float] | The minimum value. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="178"
     @Pure
@@ -531,7 +531,7 @@ Return the ratio of missing values to the total number of elements in the column
 |------|------|-------------|
 | `result1` | [`Float`][safeds.lang.Float] | The ratio of missing values to the total number of elements in the column. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="186"
     @Pure
@@ -549,7 +549,7 @@ Return the mode of the column.
 |------|------|-------------|
 | `result1` | [`List<T>`][safeds.lang.List] | Returns a list with the most common values. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="195"
     @Pure
@@ -572,7 +572,7 @@ Check if no values has a given property.
 |------|------|-------------|
 | `result1` | [`Boolean`][safeds.lang.Boolean] | True if none match. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="82"
     @Pure
@@ -591,7 +591,7 @@ Plot this column in a boxplot. This function can only plot real numerical data.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The plot as an image. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="244"
     @Pure
@@ -609,7 +609,7 @@ Plot a column in a histogram.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The plot as an image. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="253"
     @Pure
@@ -635,7 +635,7 @@ The original column is not modified.
 |------|------|-------------|
 | `result1` | [`Column<Any?>`][safeds.data.tabular.containers.Column] | A new column with the new name. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="105"
     @Pure
@@ -662,7 +662,7 @@ The stability is not defined for a column with only null values.
 |------|------|-------------|
 | `result1` | [`Float`][safeds.lang.Float] | The stability of the column. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="211"
     @Pure
@@ -679,7 +679,7 @@ Return the standard deviation of the column. The column has to be numerical.
 |------|------|-------------|
 | `result1` | [`Float`][safeds.lang.Float] | The standard deviation of all values. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="219"
     @Pure
@@ -697,7 +697,7 @@ Return the sum of the column. The column has to be numerical.
 |------|------|-------------|
 | `result1` | [`Float`][safeds.lang.Float] | The sum of all values. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="228"
     @Pure
@@ -714,7 +714,7 @@ Return an HTML representation of the column.
 |------|------|-------------|
 | `result1` | [`String`][safeds.lang.String] | The generated HTML. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="262"
     @Pure
@@ -746,7 +746,7 @@ The original column is not modified.
 |------|-------------|-------------|---------|
 | `R` | [`Any?`][safeds.lang.Any] | - | - |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="119"
     @Pure
@@ -765,7 +765,7 @@ Return the variance of the column. The column has to be numerical.
 |------|------|-------------|
 | `result1` | [`Float`][safeds.lang.Float] | The variance of all values. |
 
-??? quote "Source code in `column.sdsstub`"
+??? quote "Stub code in `column.sdsstub`"
 
     ```sds linenums="236"
     @Pure

--- a/docs/stdlib/safeds/data/tabular/containers/Row.md
+++ b/docs/stdlib/safeds/data/tabular/containers/Row.md
@@ -8,7 +8,7 @@ A row is a collection of named values.
 |------|------|-------------|---------|
 | `data` | [`Map<String, List<Any>>?`][safeds.lang.Map] | The data. If None, an empty row is created. | `#!sds null` |
 
-??? quote "Source code in `row.sdsstub`"
+??? quote "Stub code in `row.sdsstub`"
 
     ```sds linenums="10"
     class Row(
@@ -156,7 +156,7 @@ Return the type of the specified column.
 |------|------|-------------|
 | `result1` | [`ColumnType`][safeds.data.tabular.typing.ColumnType] | The type of the column. |
 
-??? quote "Source code in `row.sdsstub`"
+??? quote "Stub code in `row.sdsstub`"
 
     ```sds linenums="72"
     @Pure
@@ -182,7 +182,7 @@ Return the value of a specified column.
 |------|------|-------------|
 | `result1` | [`Any`][safeds.lang.Any] | The column value. |
 
-??? quote "Source code in `row.sdsstub`"
+??? quote "Stub code in `row.sdsstub`"
 
     ```sds linenums="46"
     @Pure
@@ -208,7 +208,7 @@ Check whether the row contains a given column.
 |------|------|-------------|
 | `result1` | [`Boolean`][safeds.lang.Boolean] | True, if the row contains the column, False otherwise. |
 
-??? quote "Source code in `row.sdsstub`"
+??? quote "Stub code in `row.sdsstub`"
 
     ```sds linenums="59"
     @Pure
@@ -228,7 +228,7 @@ Return a dictionary that maps column names to column values.
 |------|------|-------------|
 | `result1` | [`Map<String, Any>`][safeds.lang.Map] | Dictionary representation of the row. |
 
-??? quote "Source code in `row.sdsstub`"
+??? quote "Stub code in `row.sdsstub`"
 
     ```sds linenums="106"
     @Pure
@@ -246,7 +246,7 @@ Return an HTML representation of the row.
 |------|------|-------------|
 | `result1` | [`String`][safeds.lang.String] | The generated HTML. |
 
-??? quote "Source code in `row.sdsstub`"
+??? quote "Stub code in `row.sdsstub`"
 
     ```sds linenums="115"
     @Pure
@@ -270,7 +270,7 @@ Create a row from a dictionary that maps column names to column values.
 |------|------|-------------|
 | `result1` | [`Row`][safeds.data.tabular.containers.Row] | The created row. |
 
-??? quote "Source code in `row.sdsstub`"
+??? quote "Stub code in `row.sdsstub`"
 
     ```sds linenums="33"
     @Pure

--- a/docs/stdlib/safeds/data/tabular/containers/Table.md
+++ b/docs/stdlib/safeds/data/tabular/containers/Table.md
@@ -20,7 +20,7 @@ Note: When removing the last column of the table, the `number_of_columns` proper
 |------|------|-------------|---------|
 | `data` | [`Map<String, List<Any>>?`][safeds.lang.Map] | The data. If None, an empty table is created. | `#!sds null` |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="25"
     class Table(
@@ -780,7 +780,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | The table with the column attached. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="201"
     @Pure
@@ -808,7 +808,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | A new table combining the original table and the given columns. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="216"
     @Pure
@@ -841,7 +841,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | A new table with the added row at the end. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="236"
     @Pure
@@ -872,7 +872,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | A new table which combines the original table and the given rows. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="254"
     @Pure
@@ -900,7 +900,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | A table containing only the rows filtered by the query. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="269"
     @Pure
@@ -926,7 +926,7 @@ Return a column with the data of the specified column.
 |------|------|-------------|
 | `result1` | [`Column<Any?>`][safeds.data.tabular.containers.Column] | The column. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="134"
     @Pure
@@ -954,7 +954,7 @@ Alias for self.schema.get_type_of_column(column_name: str) -> ColumnType.
 |------|------|-------------|
 | `result1` | [`ColumnType`][safeds.data.tabular.typing.ColumnType] | The type of the column. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="164"
     @Pure
@@ -980,7 +980,7 @@ Return the row at a specified index.
 |------|------|-------------|
 | `result1` | [`Row`][safeds.data.tabular.containers.Row] | The row of the table at the index. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="177"
     @Pure
@@ -1014,7 +1014,7 @@ The original table is not modified.
 |------|-------------|-------------|---------|
 | `T` | [`Any?`][safeds.lang.Any] | - | - |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="284"
     @Pure
@@ -1042,7 +1042,7 @@ Alias for self.schema.hasColumn(column_name: str) -> bool.
 |------|------|-------------|
 | `result1` | [`Boolean`][safeds.lang.Boolean] | True if the column exists. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="149"
     @Pure
@@ -1070,7 +1070,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | The original table. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="591"
     @Pure
@@ -1100,7 +1100,7 @@ Note: When removing the last column of the table, the `number_of_columns` proper
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | A table containing only the given column(s). |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="301"
     @Pure
@@ -1120,7 +1120,7 @@ Plot a boxplot for every numerical column.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The plot as an image. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="644"
     @Pure
@@ -1138,7 +1138,7 @@ Plot a correlation heatmap for all numerical columns of this `Table`.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The plot as an image. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="602"
     @Pure
@@ -1156,7 +1156,7 @@ Plot a histogram for every column.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The plot as an image. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="653"
     @Pure
@@ -1184,7 +1184,7 @@ and the lower-transparency area around the line representing the 95% confidence 
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The plot as an image. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="617"
     @Pure
@@ -1212,7 +1212,7 @@ Plot two columns against each other in a scatterplot.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The plot as an image. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="632"
     @Pure
@@ -1243,7 +1243,7 @@ Note: When removing the last column of the table, the `number_of_columns` proper
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | A table without the given columns. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="318"
     @Pure
@@ -1267,7 +1267,7 @@ Note: When removing the last column of the table, the `number_of_columns` proper
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | A table without the columns that contain missing values. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="333"
     @Pure
@@ -1289,7 +1289,7 @@ Note: When removing the last column of the table, the `number_of_columns` proper
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | A table without the columns that contain non-numerical values. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="346"
     @Pure
@@ -1309,7 +1309,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | The table with the duplicate rows removed. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="357"
     @Pure
@@ -1329,7 +1329,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | A table without the rows that contain missing values. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="368"
     @Pure
@@ -1353,7 +1353,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | A new table without rows containing outliers. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="383"
     @Pure
@@ -1380,7 +1380,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | The Table with the renamed column. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="397"
     @Pure
@@ -1412,7 +1412,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | A table with the old column replaced by the new columns. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="416"
     @Pure
@@ -1435,7 +1435,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | The shuffled Table. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="430"
     @Pure
@@ -1463,7 +1463,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | The resulting table. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="445"
     @Pure
@@ -1502,7 +1502,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | A new table with sorted columns. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="471"
     @Pure
@@ -1537,7 +1537,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | A new table with sorted rows. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="493"
     @Pure
@@ -1566,7 +1566,7 @@ The original table is not modified.
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | A tuple containing the two resulting tables. The first table has the specified size, the second table contains the rest of the data. |
 | `result2` | [`Table`][safeds.data.tabular.containers.Table] | A tuple containing the two resulting tables. The first table has the specified size, the second table contains the rest of the data. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="511"
     @Pure
@@ -1588,7 +1588,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | The table with statistics. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="190"
     @Pure
@@ -1615,7 +1615,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A new tagged table with the given target and feature names. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="527"
     @Pure
@@ -1646,7 +1646,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | A new time series with the given target, time and feature names. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="545"
     @Pure
@@ -1668,7 +1668,7 @@ Return a list of the columns.
 |------|------|-------------|
 | `result1` | [`List<Column<Any?>>`][safeds.lang.List] | List of columns. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="723"
     @Pure
@@ -1689,7 +1689,7 @@ overwritten.
 |------|------|-------------|---------|
 | `path` | [`String`][safeds.lang.String] | The path to the output file. | - |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="665"
     @Impure([ImpurityReason.FileWriteToParameterizedPath("path")])
@@ -1709,7 +1709,7 @@ Return a dictionary that maps column names to column values.
 |------|------|-------------|
 | `result1` | [`Map<String, List<Any>>`][safeds.lang.Map] | Dictionary representation of the table. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="705"
     @Pure
@@ -1731,7 +1731,7 @@ overwritten.
 |------|------|-------------|---------|
 | `path` | [`String`][safeds.lang.String] | The path to the output file. | - |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="680"
     @Impure([ImpurityReason.FileWriteToParameterizedPath("path")])
@@ -1751,7 +1751,7 @@ Return an HTML representation of the table.
 |------|------|-------------|
 | `result1` | [`String`][safeds.lang.String] | The generated HTML. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="714"
     @Pure
@@ -1772,7 +1772,7 @@ overwritten.
 |------|------|-------------|---------|
 | `path` | [`String`][safeds.lang.String] | The path to the output file. | - |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="694"
     @Impure([ImpurityReason.FileWriteToParameterizedPath("path")])
@@ -1792,7 +1792,7 @@ Return a list of the rows.
 |------|------|-------------|
 | `result1` | [`List<Row>`][safeds.lang.List] | List of rows. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="732"
     @Pure
@@ -1819,7 +1819,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | The table with the transformed column. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="560"
     @Pure
@@ -1848,7 +1848,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | The transformed table. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="576"
     @Pure
@@ -1874,7 +1874,7 @@ Return a table created from a list of columns.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | The generated table. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="108"
     @Pure
@@ -1900,7 +1900,7 @@ Read data from a CSV file into a table.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | The table created from the CSV file. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="54"
     @Impure([ImpurityReason.FileReadFromParameterizedPath("path")])
@@ -1926,7 +1926,7 @@ Create a table from a dictionary that maps column names to column values.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | The generated table. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="95"
     @Pure
@@ -1954,7 +1954,7 @@ Valid file extensions are `.xls`, `.xlsx`, `.xlsm`, `.xlsb`, `.odf`, `.ods` and 
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | The table created from the Excel file. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="69"
     @Impure([ImpurityReason.FileReadFromParameterizedPath("path")])
@@ -1980,7 +1980,7 @@ Read data from a JSON file into a table.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | The table created from the JSON file. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="82"
     @Impure([ImpurityReason.FileReadFromParameterizedPath("path")])
@@ -2006,7 +2006,7 @@ Return a table created from a list of rows.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | The generated table. |
 
-??? quote "Source code in `table.sdsstub`"
+??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="121"
     @Pure

--- a/docs/stdlib/safeds/data/tabular/containers/TaggedTable.md
+++ b/docs/stdlib/safeds/data/tabular/containers/TaggedTable.md
@@ -12,7 +12,7 @@ A tagged table is a table that additionally knows which columns are features and
 | `targetName` | [`String`][safeds.lang.String] | Name of the target column. | - |
 | `featureNames` | [`List<String>?`][safeds.lang.List] | Names of the feature columns. If None, all columns except the target column are used. | `#!sds null` |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="12"
     class TaggedTable(
@@ -383,7 +383,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The table with the column attached as neither target nor feature column. |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="65"
     @Pure
@@ -411,7 +411,7 @@ the original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The table with the attached feature column. |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="35"
     @Pure
@@ -439,7 +439,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A new table combining the original table and the given columns as neither target nor feature columns. |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="80"
     @Pure
@@ -467,7 +467,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The table with the attached feature columns. |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="50"
     @Pure
@@ -495,7 +495,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A new tagged table with the added row at the end. |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="95"
     @Pure
@@ -523,7 +523,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A new tagged table which combines the original table and the given rows. |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="110"
     @Pure
@@ -551,7 +551,7 @@ The original tagged table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A new tagged table containing only the rows to match the query. |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="125"
     @Pure
@@ -579,7 +579,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A table containing only the given column(s). |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="140"
     @Pure
@@ -607,7 +607,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A table without the given columns. |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="155"
     @Pure
@@ -629,7 +629,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A table without the columns that contain missing values. |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="168"
     @Pure
@@ -649,7 +649,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A table without the columns that contain non-numerical values. |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="179"
     @Pure
@@ -669,7 +669,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The table with the duplicate rows removed. |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="190"
     @Pure
@@ -689,7 +689,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A table without the rows that contain missing values. |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="201"
     @Pure
@@ -713,7 +713,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A new table without rows containing outliers. |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="216"
     @Pure
@@ -740,7 +740,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The Table with the renamed column. |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="230"
     @Pure
@@ -774,7 +774,7 @@ The order of columns is kept. The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A table with the old column replaced by the new column. |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="251"
     @Pure
@@ -797,7 +797,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The shuffled Table. |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="265"
     @Pure
@@ -825,7 +825,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The resulting table. |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="280"
     @Pure
@@ -864,7 +864,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A new table with sorted columns. |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="306"
     @Pure
@@ -899,7 +899,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A new table with sorted rows. |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="328"
     @Pure
@@ -928,7 +928,7 @@ The original table is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The table with the transformed column. |
 
-??? quote "Source code in `tagged_table.sdsstub`"
+??? quote "Stub code in `tagged_table.sdsstub`"
 
     ```sds linenums="341"
     @Pure

--- a/docs/stdlib/safeds/data/tabular/containers/TimeSeries.md
+++ b/docs/stdlib/safeds/data/tabular/containers/TimeSeries.md
@@ -11,7 +11,7 @@
 | `timeName` | [`String`][safeds.lang.String] | Name of the time column | - |
 | `featureNames` | [`List<String>?`][safeds.lang.List] | Names of the feature columns. If None, all columns except the target and time columns are used. | `#!sds null` |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="12"
     class TimeSeries(
@@ -412,7 +412,7 @@ The original time series is not modified.
 |------|------|-------------|
 | `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | The time series with the column attached as neither target nor feature column. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="40"
     @Pure
@@ -440,7 +440,7 @@ the original time series is not modified.
 |------|------|-------------|
 | `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | The time series with the attached feature column. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="55"
     @Pure
@@ -468,7 +468,7 @@ The original time series is not modified.
 |------|------|-------------|
 | `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | A new time series combining the original table and the given columns as neither target nor feature columns. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="85"
     @Pure
@@ -496,7 +496,7 @@ The original time series is not modified.
 |------|------|-------------|
 | `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | The time series with the attached feature columns. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="70"
     @Pure
@@ -524,7 +524,7 @@ The original time series is not modified.
 |------|------|-------------|
 | `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | A new time series with the added row at the end. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="100"
     @Pure
@@ -552,7 +552,7 @@ The original time series is not modified.
 |------|------|-------------|
 | `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | A new time series which combines the original time series and the given rows. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="115"
     @Pure
@@ -580,7 +580,7 @@ The original time series is not modified.
 |------|------|-------------|
 | `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | A time series containing only the rows to match the query. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="130"
     @Pure
@@ -608,7 +608,7 @@ The original time series is not modified.
 |------|------|-------------|
 | `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | A time series containing only the given column(s). |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="145"
     @Pure
@@ -634,7 +634,7 @@ Plot a lagplot for the target column.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The plot as an image. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="330"
     @Pure
@@ -664,7 +664,7 @@ default value for x_column_name.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The plot as an image. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="347"
     @Pure
@@ -695,7 +695,7 @@ default value for y_column_name.
 |------|------|-------------|
 | `result1` | [`Image`][safeds.data.image.containers.Image] | The plot as an image. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="365"
     @Pure
@@ -724,7 +724,7 @@ The original time series is not modified.
 |------|------|-------------|
 | `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | A time series without the given columns. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="160"
     @Pure
@@ -746,7 +746,7 @@ The original time series is not modified.
 |------|------|-------------|
 | `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | A time series without the columns that contain missing values. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="173"
     @Pure
@@ -766,7 +766,7 @@ The original time series is not modified.
 |------|------|-------------|
 | `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | A time series without the columns that contain non-numerical values. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="184"
     @Pure
@@ -786,7 +786,7 @@ The original time series is not modified.
 |------|------|-------------|
 | `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | The time series with the duplicate rows removed. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="195"
     @Pure
@@ -806,7 +806,7 @@ The original time series is not modified.
 |------|------|-------------|
 | `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | A time series without the rows that contain missing values. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="206"
     @Pure
@@ -830,7 +830,7 @@ The original time series is not modified.
 |------|------|-------------|
 | `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | A new time series without rows containing outliers. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="221"
     @Pure
@@ -857,7 +857,7 @@ The original time series is not modified.
 |------|------|-------------|
 | `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | The time series with the renamed column. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="235"
     @Pure
@@ -891,7 +891,7 @@ The order of columns is kept. The original time series is not modified.
 |------|------|-------------|
 | `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | A time series with the old column replaced by the new columns. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="256"
     @Pure
@@ -922,7 +922,7 @@ The original time series is not modified.
 |------|------|-------------|
 | `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | The resulting time series. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="274"
     @Pure
@@ -961,7 +961,7 @@ The original time series is not modified.
 |------|------|-------------|
 | `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | A new time series with sorted columns. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="300"
     @Pure
@@ -990,7 +990,7 @@ The original time series is not modified.
 |------|------|-------------|
 | `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | The time series with the transformed column. |
 
-??? quote "Source code in `time_series.sdsstub`"
+??? quote "Stub code in `time_series.sdsstub`"
 
     ```sds linenums="316"
     @Pure

--- a/docs/stdlib/safeds/data/tabular/transformation/Discretizer.md
+++ b/docs/stdlib/safeds/data/tabular/transformation/Discretizer.md
@@ -10,7 +10,7 @@ The Discretizer bins continuous data into intervals.
 |------|------|-------------|---------|
 | `numberOfBins` | [`Int`][safeds.lang.Int] | The number of bins to be created. | `#!sds 5` |
 
-??? quote "Source code in `discretizer.sdsstub`"
+??? quote "Stub code in `discretizer.sdsstub`"
 
     ```sds linenums="11"
     class Discretizer(
@@ -55,7 +55,7 @@ This transformer is not modified.
 |------|------|-------------|
 | `result1` | [`Discretizer`][safeds.data.tabular.transformation.Discretizer] | The fitted transformer. |
 
-??? quote "Source code in `discretizer.sdsstub`"
+??? quote "Stub code in `discretizer.sdsstub`"
 
     ```sds linenums="26"
     @Pure

--- a/docs/stdlib/safeds/data/tabular/transformation/Imputer.md
+++ b/docs/stdlib/safeds/data/tabular/transformation/Imputer.md
@@ -10,7 +10,7 @@ Replace missing values with the given strategy.
 |------|------|-------------|---------|
 | `strategy` | [`Strategy`][safeds.data.tabular.transformation.Imputer.Strategy] | The strategy used to impute missing values. Use the classes nested inside `Imputer.Strategy` to specify it. | - |
 
-??? quote "Source code in `imputer.sdsstub`"
+??? quote "Stub code in `imputer.sdsstub`"
 
     ```sds linenums="11"
     class Imputer(
@@ -77,7 +77,7 @@ This transformer is not modified.
 |------|------|-------------|
 | `result1` | [`Imputer`][safeds.data.tabular.transformation.Imputer] | The fitted transformer. |
 
-??? quote "Source code in `imputer.sdsstub`"
+??? quote "Stub code in `imputer.sdsstub`"
 
     ```sds linenums="48"
     @Pure
@@ -89,7 +89,7 @@ This transformer is not modified.
 
 ## `#!sds enum` Strategy {#safeds.data.tabular.transformation.Imputer.Strategy data-toc-label='Strategy'}
 
-??? quote "Source code in `imputer.sdsstub`"
+??? quote "Stub code in `imputer.sdsstub`"
 
     ```sds linenums="14"
     enum Strategy {

--- a/docs/stdlib/safeds/data/tabular/transformation/InvertibleTableTransformer.md
+++ b/docs/stdlib/safeds/data/tabular/transformation/InvertibleTableTransformer.md
@@ -4,7 +4,7 @@ A `TableTransformer` that can also undo the learned transformation after it has 
 
 **Parent type:** [`TableTransformer`][safeds.data.tabular.transformation.TableTransformer]
 
-??? quote "Source code in `table_transformer.sdsstub`"
+??? quote "Stub code in `table_transformer.sdsstub`"
 
     ```sds linenums="96"
     class InvertibleTableTransformer sub TableTransformer {
@@ -56,7 +56,7 @@ Learn a transformation for a set of columns in a table.
 |------|------|-------------|
 | `result1` | [`InvertibleTableTransformer`][safeds.data.tabular.transformation.InvertibleTableTransformer] | The fitted transformer. |
 
-??? quote "Source code in `table_transformer.sdsstub`"
+??? quote "Stub code in `table_transformer.sdsstub`"
 
     ```sds linenums="105"
     @Pure
@@ -84,7 +84,7 @@ The table is not modified.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | The original table. |
 
-??? quote "Source code in `table_transformer.sdsstub`"
+??? quote "Stub code in `table_transformer.sdsstub`"
 
     ```sds linenums="120"
     @Pure

--- a/docs/stdlib/safeds/data/tabular/transformation/LabelEncoder.md
+++ b/docs/stdlib/safeds/data/tabular/transformation/LabelEncoder.md
@@ -4,7 +4,7 @@ The LabelEncoder encodes one or more given columns into labels.
 
 **Parent type:** [`InvertibleTableTransformer`][safeds.data.tabular.transformation.InvertibleTableTransformer]
 
-??? quote "Source code in `label_encoder.sdsstub`"
+??? quote "Stub code in `label_encoder.sdsstub`"
 
     ```sds linenums="9"
     class LabelEncoder() sub InvertibleTableTransformer {
@@ -45,7 +45,7 @@ This transformer is not modified.
 |------|------|-------------|
 | `result1` | [`LabelEncoder`][safeds.data.tabular.transformation.LabelEncoder] | The fitted transformer. |
 
-??? quote "Source code in `label_encoder.sdsstub`"
+??? quote "Stub code in `label_encoder.sdsstub`"
 
     ```sds linenums="20"
     @Pure

--- a/docs/stdlib/safeds/data/tabular/transformation/OneHotEncoder.md
+++ b/docs/stdlib/safeds/data/tabular/transformation/OneHotEncoder.md
@@ -27,7 +27,7 @@ One-hot encoding is closely related to dummy variable / indicator variables, whi
 
 **Parent type:** [`InvertibleTableTransformer`][safeds.data.tabular.transformation.InvertibleTableTransformer]
 
-??? quote "Source code in `one_hot_encoder.sdsstub`"
+??? quote "Stub code in `one_hot_encoder.sdsstub`"
 
     ```sds linenums="32"
     class OneHotEncoder() sub InvertibleTableTransformer {
@@ -68,7 +68,7 @@ This transformer is not modified.
 |------|------|-------------|
 | `result1` | [`OneHotEncoder`][safeds.data.tabular.transformation.OneHotEncoder] | The fitted transformer. |
 
-??? quote "Source code in `one_hot_encoder.sdsstub`"
+??? quote "Stub code in `one_hot_encoder.sdsstub`"
 
     ```sds linenums="43"
     @Pure

--- a/docs/stdlib/safeds/data/tabular/transformation/RangeScaler.md
+++ b/docs/stdlib/safeds/data/tabular/transformation/RangeScaler.md
@@ -11,7 +11,7 @@ The RangeScaler transforms column values by scaling each value to a given range.
 | `minimum` | [`Float`][safeds.lang.Float] | The minimum of the new range after the transformation | `#!sds 0.0` |
 | `maximum` | [`Float`][safeds.lang.Float] | The maximum of the new range after the transformation | `#!sds 1.0` |
 
-??? quote "Source code in `range_scaler.sdsstub`"
+??? quote "Stub code in `range_scaler.sdsstub`"
 
     ```sds linenums="12"
     class RangeScaler(
@@ -55,7 +55,7 @@ This transformer is not modified.
 |------|------|-------------|
 | `result1` | [`RangeScaler`][safeds.data.tabular.transformation.RangeScaler] | The fitted transformer. |
 
-??? quote "Source code in `range_scaler.sdsstub`"
+??? quote "Stub code in `range_scaler.sdsstub`"
 
     ```sds linenums="26"
     @Pure

--- a/docs/stdlib/safeds/data/tabular/transformation/StandardScaler.md
+++ b/docs/stdlib/safeds/data/tabular/transformation/StandardScaler.md
@@ -4,7 +4,7 @@ The StandardScaler transforms column values to a range by removing the mean and 
 
 **Parent type:** [`InvertibleTableTransformer`][safeds.data.tabular.transformation.InvertibleTableTransformer]
 
-??? quote "Source code in `standard_scaler.sdsstub`"
+??? quote "Stub code in `standard_scaler.sdsstub`"
 
     ```sds linenums="9"
     class StandardScaler() sub InvertibleTableTransformer {
@@ -45,7 +45,7 @@ This transformer is not modified.
 |------|------|-------------|
 | `result1` | [`StandardScaler`][safeds.data.tabular.transformation.StandardScaler] | The fitted transformer. |
 
-??? quote "Source code in `standard_scaler.sdsstub`"
+??? quote "Stub code in `standard_scaler.sdsstub`"
 
     ```sds linenums="20"
     @Pure

--- a/docs/stdlib/safeds/data/tabular/transformation/TableTransformer.md
+++ b/docs/stdlib/safeds/data/tabular/transformation/TableTransformer.md
@@ -2,7 +2,7 @@
 
 Learn a transformation for a set of columns in a `Table` and transform another `Table` with the same columns.
 
-??? quote "Source code in `table_transformer.sdsstub`"
+??? quote "Stub code in `table_transformer.sdsstub`"
 
     ```sds linenums="8"
     class TableTransformer {
@@ -110,7 +110,7 @@ This transformer is not modified.
 |------|------|-------------|
 | `result1` | [`TableTransformer`][safeds.data.tabular.transformation.TableTransformer] | The fitted transformer. |
 
-??? quote "Source code in `table_transformer.sdsstub`"
+??? quote "Stub code in `table_transformer.sdsstub`"
 
     ```sds linenums="19"
     @Pure
@@ -139,7 +139,7 @@ The table is not modified. If you also need the fitted transformer, use `fit` an
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | The transformed table. |
 
-??? quote "Source code in `table_transformer.sdsstub`"
+??? quote "Stub code in `table_transformer.sdsstub`"
 
     ```sds linenums="85"
     @Pure
@@ -160,7 +160,7 @@ Get the names of all new columns that have been added by the transformer.
 |------|------|-------------|
 | `result1` | [`List<String>`][safeds.lang.List] | A list of names of the added columns, ordered as they will appear in the table. |
 
-??? quote "Source code in `table_transformer.sdsstub`"
+??? quote "Stub code in `table_transformer.sdsstub`"
 
     ```sds linenums="44"
     @Pure
@@ -178,7 +178,7 @@ Get the names of all columns that have been changed by the transformer.
 |------|------|-------------|
 | `result1` | [`List<String>`][safeds.lang.List] | A list of names of changed columns, ordered as they appear in the table. |
 
-??? quote "Source code in `table_transformer.sdsstub`"
+??? quote "Stub code in `table_transformer.sdsstub`"
 
     ```sds linenums="53"
     @Pure
@@ -196,7 +196,7 @@ Get the names of all columns that have been removed by the transformer.
 |------|------|-------------|
 | `result1` | [`List<String>`][safeds.lang.List] | A list of names of the removed columns, ordered as they appear in the table the transformer was fitted on. |
 
-??? quote "Source code in `table_transformer.sdsstub`"
+??? quote "Stub code in `table_transformer.sdsstub`"
 
     ```sds linenums="62"
     @Pure
@@ -214,7 +214,7 @@ Check if the transformer is fitted.
 |------|------|-------------|
 | `result1` | [`Boolean`][safeds.lang.Boolean] | Whether the transformer is fitted. |
 
-??? quote "Source code in `table_transformer.sdsstub`"
+??? quote "Stub code in `table_transformer.sdsstub`"
 
     ```sds linenums="71"
     @Pure
@@ -240,7 +240,7 @@ The table is not modified.
 |------|------|-------------|
 | `result1` | [`Table`][safeds.data.tabular.containers.Table] | The transformed table. |
 
-??? quote "Source code in `table_transformer.sdsstub`"
+??? quote "Stub code in `table_transformer.sdsstub`"
 
     ```sds linenums="34"
     @Pure

--- a/docs/stdlib/safeds/data/tabular/typing/ColumnType.md
+++ b/docs/stdlib/safeds/data/tabular/typing/ColumnType.md
@@ -2,7 +2,7 @@
 
 Abstract base class for column types.
 
-??? quote "Source code in `column_type.sdsstub`"
+??? quote "Stub code in `column_type.sdsstub`"
 
     ```sds linenums="8"
     class ColumnType {
@@ -36,7 +36,7 @@ Return whether the given column type is nullable.
 |------|------|-------------|
 | `result1` | [`Boolean`][safeds.lang.Boolean] | True if the column is nullable. |
 
-??? quote "Source code in `column_type.sdsstub`"
+??? quote "Stub code in `column_type.sdsstub`"
 
     ```sds linenums="14"
     @Pure
@@ -54,7 +54,7 @@ Return whether the given column type is numeric.
 |------|------|-------------|
 | `result1` | [`Boolean`][safeds.lang.Boolean] | True if the column is numeric. |
 
-??? quote "Source code in `column_type.sdsstub`"
+??? quote "Stub code in `column_type.sdsstub`"
 
     ```sds linenums="23"
     @Pure

--- a/docs/stdlib/safeds/data/tabular/typing/Schema.md
+++ b/docs/stdlib/safeds/data/tabular/typing/Schema.md
@@ -2,7 +2,7 @@
 
 Store column names and corresponding data types for a `Table` or `Row`.
 
-??? quote "Source code in `schema.sdsstub`"
+??? quote "Stub code in `schema.sdsstub`"
 
     ```sds linenums="10"
     class Schema {
@@ -70,7 +70,7 @@ Return the type of the given column.
 |------|------|-------------|
 | `result1` | [`ColumnType`][safeds.data.tabular.typing.ColumnType] | The type of the column. |
 
-??? quote "Source code in `schema.sdsstub`"
+??? quote "Stub code in `schema.sdsstub`"
 
     ```sds linenums="36"
     @Pure
@@ -96,7 +96,7 @@ Return whether the schema contains a given column.
 |------|------|-------------|
 | `result1` | [`Boolean`][safeds.lang.Boolean] | True if the schema contains the column. |
 
-??? quote "Source code in `schema.sdsstub`"
+??? quote "Stub code in `schema.sdsstub`"
 
     ```sds linenums="23"
     @Pure
@@ -116,7 +116,7 @@ Return a dictionary that maps column names to column types.
 |------|------|-------------|
 | `result1` | [`Map<String, ColumnType>`][safeds.lang.Map] | Dictionary representation of the schema. |
 
-??? quote "Source code in `schema.sdsstub`"
+??? quote "Stub code in `schema.sdsstub`"
 
     ```sds linenums="47"
     @Pure

--- a/docs/stdlib/safeds/lang/AnnotationTarget.md
+++ b/docs/stdlib/safeds/lang/AnnotationTarget.md
@@ -2,7 +2,7 @@
 
 The declaration types that can be targeted by annotations.
 
-??? quote "Source code in `annotationUsage.sdsstub`"
+??? quote "Stub code in `annotationUsage.sdsstub`"
 
     ```sds linenums="16"
     enum AnnotationTarget {

--- a/docs/stdlib/safeds/lang/Any.md
+++ b/docs/stdlib/safeds/lang/Any.md
@@ -2,7 +2,7 @@
 
 The common superclass of all classes.
 
-??? quote "Source code in `coreClasses.sdsstub`"
+??? quote "Stub code in `coreClasses.sdsstub`"
 
     ```sds linenums="6"
     class Any {
@@ -26,7 +26,7 @@ Returns a string representation of the object.
 |------|------|-------------|
 | `s` | [`String`][safeds.lang.String] | - |
 
-??? quote "Source code in `coreClasses.sdsstub`"
+??? quote "Stub code in `coreClasses.sdsstub`"
 
     ```sds linenums="11"
     @Pure

--- a/docs/stdlib/safeds/lang/Boolean.md
+++ b/docs/stdlib/safeds/lang/Boolean.md
@@ -2,7 +2,7 @@
 
 A truth value.
 
-??? quote "Source code in `coreClasses.sdsstub`"
+??? quote "Stub code in `coreClasses.sdsstub`"
 
     ```sds linenums="24"
     class Boolean

--- a/docs/stdlib/safeds/lang/Deprecated.md
+++ b/docs/stdlib/safeds/lang/Deprecated.md
@@ -23,7 +23,7 @@ The declaration should no longer be used.
 - `Result`
 - `Segment`
 
-??? quote "Source code in `maturity.sdsstub`"
+??? quote "Stub code in `maturity.sdsstub`"
 
     ```sds linenums="22"
     annotation Deprecated(

--- a/docs/stdlib/safeds/lang/Experimental.md
+++ b/docs/stdlib/safeds/lang/Experimental.md
@@ -14,7 +14,7 @@ The declaration might change without a major version bump.
 - `Result`
 - `Segment`
 
-??? quote "Source code in `maturity.sdsstub`"
+??? quote "Stub code in `maturity.sdsstub`"
 
     ```sds linenums="43"
     annotation Experimental

--- a/docs/stdlib/safeds/lang/Expert.md
+++ b/docs/stdlib/safeds/lang/Expert.md
@@ -6,7 +6,7 @@ This parameter should only be used by expert users.
 
 - `Parameter`
 
-??? quote "Source code in `ideIntegration.sdsstub`"
+??? quote "Stub code in `ideIntegration.sdsstub`"
 
     ```sds linenums="8"
     annotation Expert

--- a/docs/stdlib/safeds/lang/Float.md
+++ b/docs/stdlib/safeds/lang/Float.md
@@ -4,7 +4,7 @@ A floating-point number.
 
 **Parent type:** [`Number`][safeds.lang.Number]
 
-??? quote "Source code in `coreClasses.sdsstub`"
+??? quote "Stub code in `coreClasses.sdsstub`"
 
     ```sds linenums="46"
     class Float sub Number {
@@ -27,7 +27,7 @@ Converts this floating-point number to an integer by truncating the fractional p
 |------|------|-------------|
 | `i` | [`Int`][safeds.lang.Int] | - |
 
-??? quote "Source code in `coreClasses.sdsstub`"
+??? quote "Stub code in `coreClasses.sdsstub`"
 
     ```sds linenums="50"
     @Pure

--- a/docs/stdlib/safeds/lang/Impure.md
+++ b/docs/stdlib/safeds/lang/Impure.md
@@ -12,7 +12,7 @@ Indicates that the function has side effects and/or does not always return the s
 
 - `Function`
 
-??? quote "Source code in `purity.sdsstub`"
+??? quote "Stub code in `purity.sdsstub`"
 
     ```sds linenums="22"
     annotation Impure(allReasons: List<ImpurityReason>)

--- a/docs/stdlib/safeds/lang/ImpurityReason.md
+++ b/docs/stdlib/safeds/lang/ImpurityReason.md
@@ -2,7 +2,7 @@
 
 A reason why a function is impure.
 
-??? quote "Source code in `purity.sdsstub`"
+??? quote "Stub code in `purity.sdsstub`"
 
     ```sds linenums="27"
     enum ImpurityReason {

--- a/docs/stdlib/safeds/lang/Int.md
+++ b/docs/stdlib/safeds/lang/Int.md
@@ -4,7 +4,7 @@ An integer.
 
 **Parent type:** [`Number`][safeds.lang.Number]
 
-??? quote "Source code in `coreClasses.sdsstub`"
+??? quote "Stub code in `coreClasses.sdsstub`"
 
     ```sds linenums="34"
     class Int sub Number {
@@ -27,7 +27,7 @@ Converts this integer to a floating-point number.
 |------|------|-------------|
 | `f` | [`Float`][safeds.lang.Float] | - |
 
-??? quote "Source code in `coreClasses.sdsstub`"
+??? quote "Stub code in `coreClasses.sdsstub`"
 
     ```sds linenums="38"
     @Pure

--- a/docs/stdlib/safeds/lang/List.md
+++ b/docs/stdlib/safeds/lang/List.md
@@ -8,7 +8,7 @@ A list of elements.
 |------|-------------|-------------|---------|
 | `E` | [`Any?`][safeds.lang.Any] | - | - |
 
-??? quote "Source code in `coreClasses.sdsstub`"
+??? quote "Stub code in `coreClasses.sdsstub`"
 
     ```sds linenums="58"
     class List<out E> {
@@ -32,7 +32,7 @@ Returns the number of elements in the list.
 |------|------|-------------|
 | `size` | [`Int`][safeds.lang.Int] | - |
 
-??? quote "Source code in `coreClasses.sdsstub`"
+??? quote "Stub code in `coreClasses.sdsstub`"
 
     ```sds linenums="63"
     @Pure

--- a/docs/stdlib/safeds/lang/Map.md
+++ b/docs/stdlib/safeds/lang/Map.md
@@ -9,7 +9,7 @@ A map of keys to values.
 | `K` | [`Any?`][safeds.lang.Any] | - | - |
 | `V` | [`Any?`][safeds.lang.Any] | - | - |
 
-??? quote "Source code in `coreClasses.sdsstub`"
+??? quote "Stub code in `coreClasses.sdsstub`"
 
     ```sds linenums="71"
     class Map<K, out V> {
@@ -47,7 +47,7 @@ Returns the keys of the map.
 |------|------|-------------|
 | `keys` | [`List<K>`][safeds.lang.List] | - |
 
-??? quote "Source code in `coreClasses.sdsstub`"
+??? quote "Stub code in `coreClasses.sdsstub`"
 
     ```sds linenums="83"
     @Pure
@@ -65,7 +65,7 @@ Returns the number of entries in the map.
 |------|------|-------------|
 | `size` | [`Int`][safeds.lang.Int] | - |
 
-??? quote "Source code in `coreClasses.sdsstub`"
+??? quote "Stub code in `coreClasses.sdsstub`"
 
     ```sds linenums="76"
     @Pure
@@ -83,7 +83,7 @@ Returns the values of the map.
 |------|------|-------------|
 | `values` | [`List<V>`][safeds.lang.List] | - |
 
-??? quote "Source code in `coreClasses.sdsstub`"
+??? quote "Stub code in `coreClasses.sdsstub`"
 
     ```sds linenums="90"
     @Pure

--- a/docs/stdlib/safeds/lang/Nothing.md
+++ b/docs/stdlib/safeds/lang/Nothing.md
@@ -2,7 +2,7 @@
 
 The common subclass of all classes.
 
-??? quote "Source code in `coreClasses.sdsstub`"
+??? quote "Stub code in `coreClasses.sdsstub`"
 
     ```sds linenums="19"
     class Nothing

--- a/docs/stdlib/safeds/lang/Number.md
+++ b/docs/stdlib/safeds/lang/Number.md
@@ -2,7 +2,7 @@
 
 A number.
 
-??? quote "Source code in `coreClasses.sdsstub`"
+??? quote "Stub code in `coreClasses.sdsstub`"
 
     ```sds linenums="29"
     class Number

--- a/docs/stdlib/safeds/lang/Pure.md
+++ b/docs/stdlib/safeds/lang/Pure.md
@@ -10,7 +10,7 @@ reordering of calls or parallelization.
 
 - `Function`
 
-??? quote "Source code in `purity.sdsstub`"
+??? quote "Stub code in `purity.sdsstub`"
 
     ```sds linenums="12"
     annotation Pure

--- a/docs/stdlib/safeds/lang/PythonCall.md
+++ b/docs/stdlib/safeds/lang/PythonCall.md
@@ -17,7 +17,7 @@ call. `$this` is replaced by the receiver of the call. `$param` is replaced by t
 
 - `Function`
 
-??? quote "Source code in `codeGeneration.sdsstub`"
+??? quote "Stub code in `codeGeneration.sdsstub`"
 
     ```sds linenums="13"
     annotation PythonCall(

--- a/docs/stdlib/safeds/lang/PythonModule.md
+++ b/docs/stdlib/safeds/lang/PythonModule.md
@@ -12,7 +12,7 @@ The qualified name of the corresponding Python module. By default, this is the q
 
 - `Module`
 
-??? quote "Source code in `codeGeneration.sdsstub`"
+??? quote "Stub code in `codeGeneration.sdsstub`"
 
     ```sds linenums="21"
     annotation PythonModule(

--- a/docs/stdlib/safeds/lang/PythonName.md
+++ b/docs/stdlib/safeds/lang/PythonName.md
@@ -19,7 +19,7 @@ The name of the corresponding API element in Python. By default, this is the nam
 - `Pipeline`
 - `Segment`
 
-??? quote "Source code in `codeGeneration.sdsstub`"
+??? quote "Stub code in `codeGeneration.sdsstub`"
 
     ```sds linenums="38"
     annotation PythonName(

--- a/docs/stdlib/safeds/lang/Repeatable.md
+++ b/docs/stdlib/safeds/lang/Repeatable.md
@@ -6,7 +6,7 @@ The annotation can be called multiple times for the same declaration.
 
 - `Annotation`
 
-??? quote "Source code in `annotationUsage.sdsstub`"
+??? quote "Stub code in `annotationUsage.sdsstub`"
 
     ```sds linenums="83"
     annotation Repeatable

--- a/docs/stdlib/safeds/lang/String.md
+++ b/docs/stdlib/safeds/lang/String.md
@@ -2,7 +2,7 @@
 
 Some text.
 
-??? quote "Source code in `coreClasses.sdsstub`"
+??? quote "Stub code in `coreClasses.sdsstub`"
 
     ```sds linenums="98"
     class String {
@@ -35,7 +35,7 @@ Parses the string to a floating-point number.
 |------|------|-------------|
 | `f` | [`Float`][safeds.lang.Float] | - |
 
-??? quote "Source code in `coreClasses.sdsstub`"
+??? quote "Stub code in `coreClasses.sdsstub`"
 
     ```sds linenums="103"
     @Pure
@@ -59,7 +59,7 @@ Parses the string to an integer.
 |------|------|-------------|
 | `i` | [`Int`][safeds.lang.Int] | - |
 
-??? quote "Source code in `coreClasses.sdsstub`"
+??? quote "Stub code in `coreClasses.sdsstub`"
 
     ```sds linenums="112"
     @Pure

--- a/docs/stdlib/safeds/lang/Target.md
+++ b/docs/stdlib/safeds/lang/Target.md
@@ -12,7 +12,7 @@ The annotation must target only the specified declaration types. By default, any
 
 - `Annotation`
 
-??? quote "Source code in `annotationUsage.sdsstub`"
+??? quote "Stub code in `annotationUsage.sdsstub`"
 
     ```sds linenums="9"
     annotation Target(

--- a/docs/stdlib/safeds/ml/classical/classification/AdaBoostClassifier.md
+++ b/docs/stdlib/safeds/ml/classical/classification/AdaBoostClassifier.md
@@ -12,7 +12,7 @@ Ada Boost classification.
 | `maximumNumberOfLearners` | [`Int`][safeds.lang.Int] | The maximum number of learners at which boosting is terminated. In case of perfect fit, the learning procedure is stopped early. Has to be greater than 0. | `#!sds 50` |
 | `learningRate` | [`Float`][safeds.lang.Float] | Weight applied to each classifier at each boosting iteration. A higher learning rate increases the contribution of each classifier. Has to be greater than 0. | `#!sds 1.0` |
 
-??? quote "Source code in `ada_boost.sdsstub`"
+??? quote "Stub code in `ada_boost.sdsstub`"
 
     ```sds linenums="15"
     class AdaBoostClassifier(
@@ -88,7 +88,7 @@ This classifier is not modified.
 |------|------|-------------|
 | `fittedClassifier` | [`AdaBoostClassifier`][safeds.ml.classical.classification.AdaBoostClassifier] | The fitted classifier. |
 
-??? quote "Source code in `ada_boost.sdsstub`"
+??? quote "Stub code in `ada_boost.sdsstub`"
 
     ```sds linenums="45"
     @Pure

--- a/docs/stdlib/safeds/ml/classical/classification/Classifier.md
+++ b/docs/stdlib/safeds/ml/classical/classification/Classifier.md
@@ -2,7 +2,7 @@
 
 Abstract base class for all classifiers.
 
-??? quote "Source code in `classifier.sdsstub`"
+??? quote "Stub code in `classifier.sdsstub`"
 
     ```sds linenums="8"
     class Classifier {
@@ -117,7 +117,7 @@ Compute the accuracy of the classifier on the given data.
 |------|------|-------------|
 | `accuracy` | [`Float`][safeds.lang.Float] | The calculated accuracy score, i.e. the percentage of equal data. |
 
-??? quote "Source code in `classifier.sdsstub`"
+??? quote "Stub code in `classifier.sdsstub`"
 
     ```sds linenums="51"
     @Pure
@@ -143,7 +143,7 @@ Compute the classifier's $F_1$-score on the given data.
 |------|------|-------------|
 | `f1Score` | [`Float`][safeds.lang.Float] | The calculated $F_1$-score, i.e. the harmonic mean between precision and recall. Return 1 if there are no positive expectations and predictions. |
 
-??? quote "Source code in `classifier.sdsstub`"
+??? quote "Stub code in `classifier.sdsstub`"
 
     ```sds linenums="95"
     @Pure
@@ -172,7 +172,7 @@ This classifier is not modified.
 |------|------|-------------|
 | `fittedClassifier` | [`Classifier`][safeds.ml.classical.classification.Classifier] | The fitted classifier. |
 
-??? quote "Source code in `classifier.sdsstub`"
+??? quote "Stub code in `classifier.sdsstub`"
 
     ```sds linenums="18"
     @Pure
@@ -191,7 +191,7 @@ Check if the classifier is fitted.
 |------|------|-------------|
 | `isFitted` | [`Boolean`][safeds.lang.Boolean] | Whether the classifier is fitted. |
 
-??? quote "Source code in `classifier.sdsstub`"
+??? quote "Stub code in `classifier.sdsstub`"
 
     ```sds linenums="40"
     @Pure
@@ -216,7 +216,7 @@ Compute the classifier's precision on the given data.
 |------|------|-------------|
 | `precision` | [`Float`][safeds.lang.Float] | The calculated precision score, i.e. the ratio of correctly predicted positives to all predicted positives. Return 1 if no positive predictions are made. |
 
-??? quote "Source code in `classifier.sdsstub`"
+??? quote "Stub code in `classifier.sdsstub`"
 
     ```sds linenums="65"
     @Pure
@@ -242,7 +242,7 @@ Predict a target vector using a dataset containing feature vectors. The model ha
 |------|------|-------------|
 | `prediction` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A dataset containing the given feature vectors and the predicted target vector. |
 
-??? quote "Source code in `classifier.sdsstub`"
+??? quote "Stub code in `classifier.sdsstub`"
 
     ```sds linenums="30"
     @Pure
@@ -268,7 +268,7 @@ Compute the classifier's recall on the given data.
 |------|------|-------------|
 | `recall` | [`Float`][safeds.lang.Float] | The calculated recall score, i.e. the ratio of correctly predicted positives to all expected positives. Return 1 if there are no positive expectations. |
 
-??? quote "Source code in `classifier.sdsstub`"
+??? quote "Stub code in `classifier.sdsstub`"
 
     ```sds linenums="80"
     @Pure

--- a/docs/stdlib/safeds/ml/classical/classification/DecisionTreeClassifier.md
+++ b/docs/stdlib/safeds/ml/classical/classification/DecisionTreeClassifier.md
@@ -4,7 +4,7 @@ Decision tree classification.
 
 **Parent type:** [`Classifier`][safeds.ml.classical.classification.Classifier]
 
-??? quote "Source code in `decision_tree.sdsstub`"
+??? quote "Stub code in `decision_tree.sdsstub`"
 
     ```sds linenums="9"
     class DecisionTreeClassifier() sub Classifier {
@@ -42,7 +42,7 @@ This classifier is not modified.
 |------|------|-------------|
 | `fittedClassifier` | [`DecisionTreeClassifier`][safeds.ml.classical.classification.DecisionTreeClassifier] | The fitted classifier. |
 
-??? quote "Source code in `decision_tree.sdsstub`"
+??? quote "Stub code in `decision_tree.sdsstub`"
 
     ```sds linenums="19"
     @Pure

--- a/docs/stdlib/safeds/ml/classical/classification/GradientBoostingClassifier.md
+++ b/docs/stdlib/safeds/ml/classical/classification/GradientBoostingClassifier.md
@@ -11,7 +11,7 @@ Gradient boosting classification.
 | `numberOfTrees` | [`Int`][safeds.lang.Int] | The number of boosting stages to perform. Gradient boosting is fairly robust to over-fitting so a large number usually results in better performance. | `#!sds 100` |
 | `learningRate` | [`Float`][safeds.lang.Float] | The larger the value, the more the model is influenced by each additional tree. If the learning rate is too low, the model might underfit. If the learning rate is too high, the model might overfit. | `#!sds 0.1` |
 
-??? quote "Source code in `gradient_boosting.sdsstub`"
+??? quote "Stub code in `gradient_boosting.sdsstub`"
 
     ```sds linenums="14"
     class GradientBoostingClassifier(
@@ -76,7 +76,7 @@ This classifier is not modified.
 |------|------|-------------|
 | `fittedClassifier` | [`GradientBoostingClassifier`][safeds.ml.classical.classification.GradientBoostingClassifier] | The fitted classifier. |
 
-??? quote "Source code in `gradient_boosting.sdsstub`"
+??? quote "Stub code in `gradient_boosting.sdsstub`"
 
     ```sds linenums="39"
     @Pure

--- a/docs/stdlib/safeds/ml/classical/classification/KNearestNeighborsClassifier.md
+++ b/docs/stdlib/safeds/ml/classical/classification/KNearestNeighborsClassifier.md
@@ -10,7 +10,7 @@ K-nearest-neighbors classification.
 |------|------|-------------|---------|
 | `numberOfNeighbors` | [`Int`][safeds.lang.Int] | The number of neighbors to use for interpolation. Has to be greater than 0 (validated in the constructor) and less than or equal to the sample size (validated when calling `fit`). | - |
 
-??? quote "Source code in `k_nearest_neighbors.sdsstub`"
+??? quote "Stub code in `k_nearest_neighbors.sdsstub`"
 
     ```sds linenums="12"
     class KNearestNeighborsClassifier(
@@ -63,7 +63,7 @@ This classifier is not modified.
 |------|------|-------------|
 | `fittedClassifier` | [`KNearestNeighborsClassifier`][safeds.ml.classical.classification.KNearestNeighborsClassifier] | The fitted classifier. |
 
-??? quote "Source code in `k_nearest_neighbors.sdsstub`"
+??? quote "Stub code in `k_nearest_neighbors.sdsstub`"
 
     ```sds linenums="31"
     @Pure

--- a/docs/stdlib/safeds/ml/classical/classification/LogisticRegressionClassifier.md
+++ b/docs/stdlib/safeds/ml/classical/classification/LogisticRegressionClassifier.md
@@ -4,7 +4,7 @@ Regularized logistic regression.
 
 **Parent type:** [`Classifier`][safeds.ml.classical.classification.Classifier]
 
-??? quote "Source code in `logistic_regression.sdsstub`"
+??? quote "Stub code in `logistic_regression.sdsstub`"
 
     ```sds linenums="9"
     class LogisticRegressionClassifier() sub Classifier {
@@ -42,7 +42,7 @@ This classifier is not modified.
 |------|------|-------------|
 | `fittedClassifier` | [`LogisticRegressionClassifier`][safeds.ml.classical.classification.LogisticRegressionClassifier] | The fitted classifier. |
 
-??? quote "Source code in `logistic_regression.sdsstub`"
+??? quote "Stub code in `logistic_regression.sdsstub`"
 
     ```sds linenums="19"
     @Pure

--- a/docs/stdlib/safeds/ml/classical/classification/RandomForestClassifier.md
+++ b/docs/stdlib/safeds/ml/classical/classification/RandomForestClassifier.md
@@ -10,7 +10,7 @@ Random forest classification.
 |------|------|-------------|---------|
 | `numberOfTrees` | [`Int`][safeds.lang.Int] | The number of trees to be used in the random forest. Has to be greater than 0. | `#!sds 100` |
 
-??? quote "Source code in `random_forest.sdsstub`"
+??? quote "Stub code in `random_forest.sdsstub`"
 
     ```sds linenums="11"
     class RandomForestClassifier(
@@ -63,7 +63,7 @@ This classifier is not modified.
 |------|------|-------------|
 | `fittedClassifier` | [`RandomForestClassifier`][safeds.ml.classical.classification.RandomForestClassifier] | The fitted classifier. |
 
-??? quote "Source code in `random_forest.sdsstub`"
+??? quote "Stub code in `random_forest.sdsstub`"
 
     ```sds linenums="30"
     @Pure

--- a/docs/stdlib/safeds/ml/classical/classification/SupportVectorMachineClassifier.md
+++ b/docs/stdlib/safeds/ml/classical/classification/SupportVectorMachineClassifier.md
@@ -11,7 +11,7 @@ Support vector machine.
 | `c` | [`Float`][safeds.lang.Float] | The strength of regularization. Must be strictly positive. | `#!sds 1.0` |
 | `kernel` | [`Kernel`][safeds.ml.classical.classification.SupportVectorMachineClassifier.Kernel] | The type of kernel to be used. Defaults to None. | `#!sds SupportVectorMachineClassifier.Kernel.RadialBasisFunction` |
 
-??? quote "Source code in `support_vector_machine.sdsstub`"
+??? quote "Stub code in `support_vector_machine.sdsstub`"
 
     ```sds linenums="12"
     class SupportVectorMachineClassifier(
@@ -102,7 +102,7 @@ This classifier is not modified.
 |------|------|-------------|
 | `fittedClassifier` | [`SupportVectorMachineClassifier`][safeds.ml.classical.classification.SupportVectorMachineClassifier] | The fitted classifier. |
 
-??? quote "Source code in `support_vector_machine.sdsstub`"
+??? quote "Stub code in `support_vector_machine.sdsstub`"
 
     ```sds linenums="63"
     @Pure
@@ -115,7 +115,7 @@ This classifier is not modified.
 
 The kernel functions that can be used in the support vector machine.
 
-??? quote "Source code in `support_vector_machine.sdsstub`"
+??? quote "Stub code in `support_vector_machine.sdsstub`"
 
     ```sds linenums="21"
     enum Kernel {

--- a/docs/stdlib/safeds/ml/classical/regression/AdaBoostRegressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/AdaBoostRegressor.md
@@ -12,7 +12,7 @@ Ada Boost regression.
 | `maximumNumberOfLearners` | [`Int`][safeds.lang.Int] | The maximum number of learners at which boosting is terminated. In case of perfect fit, the learning procedure is stopped early. Has to be greater than 0. | `#!sds 50` |
 | `learningRate` | [`Float`][safeds.lang.Float] | Weight applied to each regressor at each boosting iteration. A higher learning rate increases the contribution of each regressor. Has to be greater than 0. | `#!sds 1.0` |
 
-??? quote "Source code in `ada_boost.sdsstub`"
+??? quote "Stub code in `ada_boost.sdsstub`"
 
     ```sds linenums="15"
     class AdaBoostRegressor(
@@ -88,7 +88,7 @@ This regressor is not modified.
 |------|------|-------------|
 | `fittedRegressor` | [`AdaBoostRegressor`][safeds.ml.classical.regression.AdaBoostRegressor] | The fitted regressor. |
 
-??? quote "Source code in `ada_boost.sdsstub`"
+??? quote "Stub code in `ada_boost.sdsstub`"
 
     ```sds linenums="45"
     @Pure

--- a/docs/stdlib/safeds/ml/classical/regression/DecisionTreeRegressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/DecisionTreeRegressor.md
@@ -4,7 +4,7 @@ Decision tree regression.
 
 **Parent type:** [`Regressor`][safeds.ml.classical.regression.Regressor]
 
-??? quote "Source code in `decision_tree.sdsstub`"
+??? quote "Stub code in `decision_tree.sdsstub`"
 
     ```sds linenums="9"
     class DecisionTreeRegressor() sub Regressor {
@@ -42,7 +42,7 @@ This regressor is not modified.
 |------|------|-------------|
 | `fittedRegressor` | [`DecisionTreeRegressor`][safeds.ml.classical.regression.DecisionTreeRegressor] | The fitted regressor. |
 
-??? quote "Source code in `decision_tree.sdsstub`"
+??? quote "Stub code in `decision_tree.sdsstub`"
 
     ```sds linenums="19"
     @Pure

--- a/docs/stdlib/safeds/ml/classical/regression/ElasticNetRegressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/ElasticNetRegressor.md
@@ -11,7 +11,7 @@ Elastic net regression.
 | `alpha` | [`Float`][safeds.lang.Float] | Controls the regularization of the model. The higher the value, the more regularized it becomes. | `#!sds 1.0` |
 | `lassoRatio` | [`Float`][safeds.lang.Float] | Number between 0 and 1 that controls the ratio between Lasso and Ridge regularization. If 0, only Ridge regularization is used. If 1, only Lasso regularization is used. | `#!sds 0.5` |
 
-??? quote "Source code in `elastic_net_regression.sdsstub`"
+??? quote "Stub code in `elastic_net_regression.sdsstub`"
 
     ```sds linenums="13"
     class ElasticNetRegressor(
@@ -77,7 +77,7 @@ This regressor is not modified.
 |------|------|-------------|
 | `fittedRegressor` | [`ElasticNetRegressor`][safeds.ml.classical.regression.ElasticNetRegressor] | The fitted regressor. |
 
-??? quote "Source code in `elastic_net_regression.sdsstub`"
+??? quote "Stub code in `elastic_net_regression.sdsstub`"
 
     ```sds linenums="39"
     @Pure

--- a/docs/stdlib/safeds/ml/classical/regression/GradientBoostingRegressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/GradientBoostingRegressor.md
@@ -11,7 +11,7 @@ Gradient boosting regression.
 | `numberOfTrees` | [`Int`][safeds.lang.Int] | The number of boosting stages to perform. Gradient boosting is fairly robust to over-fitting so a large number usually results in better performance. | `#!sds 100` |
 | `learningRate` | [`Float`][safeds.lang.Float] | The larger the value, the more the model is influenced by each additional tree. If the learning rate is too low, the model might underfit. If the learning rate is too high, the model might overfit. | `#!sds 0.1` |
 
-??? quote "Source code in `gradient_boosting.sdsstub`"
+??? quote "Stub code in `gradient_boosting.sdsstub`"
 
     ```sds linenums="14"
     class GradientBoostingRegressor(
@@ -76,7 +76,7 @@ This regressor is not modified.
 |------|------|-------------|
 | `fittedRegressor` | [`GradientBoostingRegressor`][safeds.ml.classical.regression.GradientBoostingRegressor] | The fitted regressor. |
 
-??? quote "Source code in `gradient_boosting.sdsstub`"
+??? quote "Stub code in `gradient_boosting.sdsstub`"
 
     ```sds linenums="39"
     @Pure

--- a/docs/stdlib/safeds/ml/classical/regression/KNearestNeighborsRegressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/KNearestNeighborsRegressor.md
@@ -10,7 +10,7 @@ K-nearest-neighbors regression.
 |------|------|-------------|---------|
 | `numberOfNeighbors` | [`Int`][safeds.lang.Int] | The number of neighbors to use for interpolation. Has to be greater than 0 (validated in the constructor) and less than or equal to the sample size (validated when calling `fit`). | - |
 
-??? quote "Source code in `k_nearest_neighbors.sdsstub`"
+??? quote "Stub code in `k_nearest_neighbors.sdsstub`"
 
     ```sds linenums="12"
     class KNearestNeighborsRegressor(
@@ -63,7 +63,7 @@ This regressor is not modified.
 |------|------|-------------|
 | `fittedRegressor` | [`KNearestNeighborsRegressor`][safeds.ml.classical.regression.KNearestNeighborsRegressor] | The fitted regressor. |
 
-??? quote "Source code in `k_nearest_neighbors.sdsstub`"
+??? quote "Stub code in `k_nearest_neighbors.sdsstub`"
 
     ```sds linenums="31"
     @Pure

--- a/docs/stdlib/safeds/ml/classical/regression/LassoRegressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/LassoRegressor.md
@@ -10,7 +10,7 @@ Lasso regression.
 |------|------|-------------|---------|
 | `alpha` | [`Float`][safeds.lang.Float] | Controls the regularization of the model. The higher the value, the more regularized it becomes. | `#!sds 1.0` |
 
-??? quote "Source code in `lasso_regression.sdsstub`"
+??? quote "Stub code in `lasso_regression.sdsstub`"
 
     ```sds linenums="11"
     class LassoRegressor(
@@ -63,7 +63,7 @@ This regressor is not modified.
 |------|------|-------------|
 | `fittedRegressor` | [`LassoRegressor`][safeds.ml.classical.regression.LassoRegressor] | The fitted regressor. |
 
-??? quote "Source code in `lasso_regression.sdsstub`"
+??? quote "Stub code in `lasso_regression.sdsstub`"
 
     ```sds linenums="30"
     @Pure

--- a/docs/stdlib/safeds/ml/classical/regression/LinearRegressionRegressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/LinearRegressionRegressor.md
@@ -4,7 +4,7 @@ Linear regression.
 
 **Parent type:** [`Regressor`][safeds.ml.classical.regression.Regressor]
 
-??? quote "Source code in `linear_regression.sdsstub`"
+??? quote "Stub code in `linear_regression.sdsstub`"
 
     ```sds linenums="9"
     class LinearRegressionRegressor() sub Regressor {
@@ -42,7 +42,7 @@ This regressor is not modified.
 |------|------|-------------|
 | `fittedRegressor` | [`LinearRegressionRegressor`][safeds.ml.classical.regression.LinearRegressionRegressor] | The fitted regressor. |
 
-??? quote "Source code in `linear_regression.sdsstub`"
+??? quote "Stub code in `linear_regression.sdsstub`"
 
     ```sds linenums="19"
     @Pure

--- a/docs/stdlib/safeds/ml/classical/regression/RandomForestRegressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/RandomForestRegressor.md
@@ -10,7 +10,7 @@ Random forest regression.
 |------|------|-------------|---------|
 | `numberOfTrees` | [`Int`][safeds.lang.Int] | The number of trees to be used in the random forest. Has to be greater than 0. | `#!sds 100` |
 
-??? quote "Source code in `random_forest.sdsstub`"
+??? quote "Stub code in `random_forest.sdsstub`"
 
     ```sds linenums="11"
     class RandomForestRegressor(
@@ -63,7 +63,7 @@ This regressor is not modified.
 |------|------|-------------|
 | `fittedRegressor` | [`RandomForestRegressor`][safeds.ml.classical.regression.RandomForestRegressor] | The fitted regressor. |
 
-??? quote "Source code in `random_forest.sdsstub`"
+??? quote "Stub code in `random_forest.sdsstub`"
 
     ```sds linenums="30"
     @Pure

--- a/docs/stdlib/safeds/ml/classical/regression/Regressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/Regressor.md
@@ -2,7 +2,7 @@
 
 Abstract base class for all regressors.
 
-??? quote "Source code in `regressor.sdsstub`"
+??? quote "Stub code in `regressor.sdsstub`"
 
     ```sds linenums="8"
     class Regressor {
@@ -87,7 +87,7 @@ This regressor is not modified.
 |------|------|-------------|
 | `fittedRegressor` | [`Regressor`][safeds.ml.classical.regression.Regressor] | The fitted regressor. |
 
-??? quote "Source code in `regressor.sdsstub`"
+??? quote "Stub code in `regressor.sdsstub`"
 
     ```sds linenums="18"
     @Pure
@@ -106,7 +106,7 @@ Check if the classifier is fitted.
 |------|------|-------------|
 | `isFitted` | [`Boolean`][safeds.lang.Boolean] | Whether the regressor is fitted. |
 
-??? quote "Source code in `regressor.sdsstub`"
+??? quote "Stub code in `regressor.sdsstub`"
 
     ```sds linenums="40"
     @Pure
@@ -130,7 +130,7 @@ Compute the mean absolute error (MAE) of the regressor on the given data.
 |------|------|-------------|
 | `meanAbsoluteError` | [`Float`][safeds.lang.Float] | The calculated mean absolute error (the average of the distance of each individual row). |
 
-??? quote "Source code in `regressor.sdsstub`"
+??? quote "Stub code in `regressor.sdsstub`"
 
     ```sds linenums="64"
     @Pure
@@ -156,7 +156,7 @@ Compute the mean squared error (MSE) on the given data.
 |------|------|-------------|
 | `meanSquaredError` | [`Float`][safeds.lang.Float] | The calculated mean squared error (the average of the distance of each individual row squared). |
 
-??? quote "Source code in `regressor.sdsstub`"
+??? quote "Stub code in `regressor.sdsstub`"
 
     ```sds linenums="51"
     @Pure
@@ -182,7 +182,7 @@ Predict a target vector using a dataset containing feature vectors. The model ha
 |------|------|-------------|
 | `prediction` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A dataset containing the given feature vectors and the predicted target vector. |
 
-??? quote "Source code in `regressor.sdsstub`"
+??? quote "Stub code in `regressor.sdsstub`"
 
     ```sds linenums="30"
     @Pure

--- a/docs/stdlib/safeds/ml/classical/regression/RidgeRegressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/RidgeRegressor.md
@@ -10,7 +10,7 @@ Ridge regression.
 |------|------|-------------|---------|
 | `alpha` | [`Float`][safeds.lang.Float] | Controls the regularization of the model. The higher the value, the more regularized it becomes. | `#!sds 1.0` |
 
-??? quote "Source code in `ridge_regression.sdsstub`"
+??? quote "Stub code in `ridge_regression.sdsstub`"
 
     ```sds linenums="11"
     class RidgeRegressor(
@@ -63,7 +63,7 @@ This regressor is not modified.
 |------|------|-------------|
 | `fittedRegressor` | [`RidgeRegressor`][safeds.ml.classical.regression.RidgeRegressor] | The fitted regressor. |
 
-??? quote "Source code in `ridge_regression.sdsstub`"
+??? quote "Stub code in `ridge_regression.sdsstub`"
 
     ```sds linenums="30"
     @Pure

--- a/docs/stdlib/safeds/ml/classical/regression/SupportVectorMachineRegressor.md
+++ b/docs/stdlib/safeds/ml/classical/regression/SupportVectorMachineRegressor.md
@@ -11,7 +11,7 @@ Support vector machine.
 | `c` | [`Float`][safeds.lang.Float] | The strength of regularization. Must be strictly positive. | `#!sds 1.0` |
 | `kernel` | [`Kernel`][safeds.ml.classical.regression.SupportVectorMachineRegressor.Kernel] | The type of kernel to be used. Defaults to None. | `#!sds SupportVectorMachineRegressor.Kernel.RadialBasisFunction` |
 
-??? quote "Source code in `support_vector_machine.sdsstub`"
+??? quote "Stub code in `support_vector_machine.sdsstub`"
 
     ```sds linenums="12"
     class SupportVectorMachineRegressor(
@@ -102,7 +102,7 @@ This regressor is not modified.
 |------|------|-------------|
 | `fittedRegressor` | [`SupportVectorMachineRegressor`][safeds.ml.classical.regression.SupportVectorMachineRegressor] | The fitted regressor. |
 
-??? quote "Source code in `support_vector_machine.sdsstub`"
+??? quote "Stub code in `support_vector_machine.sdsstub`"
 
     ```sds linenums="63"
     @Pure
@@ -115,7 +115,7 @@ This regressor is not modified.
 
 The kernel functions that can be used in the support vector machine.
 
-??? quote "Source code in `support_vector_machine.sdsstub`"
+??? quote "Stub code in `support_vector_machine.sdsstub`"
 
     ```sds linenums="21"
     enum Kernel {

--- a/docs/stdlib/safeds/ml/nn/FNNLayer.md
+++ b/docs/stdlib/safeds/ml/nn/FNNLayer.md
@@ -7,7 +7,7 @@
 | `outputSize` | [`Int`][safeds.lang.Int] | The number of neurons in this layer | - |
 | `inputSize` | [`Int?`][safeds.lang.Int] | The number of neurons in the previous layer | `#!sds null` |
 
-??? quote "Source code in `layer.sdsstub`"
+??? quote "Stub code in `layer.sdsstub`"
 
     ```sds linenums="7"
     class FNNLayer(

--- a/docs/stdlib/safeds/ml/nn/NeuralNetworkClassifier.md
+++ b/docs/stdlib/safeds/ml/nn/NeuralNetworkClassifier.md
@@ -6,7 +6,7 @@
 |------|------|-------------|---------|
 | `layers` | [`List<FNNLayer>`][safeds.lang.List] | - | - |
 
-??? quote "Source code in `classifier.sdsstub`"
+??? quote "Stub code in `classifier.sdsstub`"
 
     ```sds linenums="6"
     class NeuralNetworkClassifier(
@@ -86,7 +86,7 @@ The original model is not modified.
 |------|------|-------------|
 | `fittedClassifier` | [`NeuralNetworkClassifier`][safeds.ml.nn.NeuralNetworkClassifier] | The trained Model |
 
-??? quote "Source code in `classifier.sdsstub`"
+??? quote "Stub code in `classifier.sdsstub`"
 
     ```sds linenums="27"
     @Pure
@@ -120,7 +120,7 @@ The original Model is not modified.
 |------|------|-------------|
 | `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The given test_data with an added "prediction" column at the end |
 
-??? quote "Source code in `classifier.sdsstub`"
+??? quote "Stub code in `classifier.sdsstub`"
 
     ```sds linenums="48"
     @Pure

--- a/docs/stdlib/safeds/ml/nn/NeuralNetworkRegressor.md
+++ b/docs/stdlib/safeds/ml/nn/NeuralNetworkRegressor.md
@@ -6,7 +6,7 @@
 |------|------|-------------|---------|
 | `layers` | [`List<FNNLayer>`][safeds.lang.List] | - | - |
 
-??? quote "Source code in `regressor.sdsstub`"
+??? quote "Stub code in `regressor.sdsstub`"
 
     ```sds linenums="6"
     class NeuralNetworkRegressor(
@@ -86,7 +86,7 @@ The original model is not modified.
 |------|------|-------------|
 | `trainedRegressor` | [`NeuralNetworkRegressor`][safeds.ml.nn.NeuralNetworkRegressor] | The trained Model |
 
-??? quote "Source code in `regressor.sdsstub`"
+??? quote "Stub code in `regressor.sdsstub`"
 
     ```sds linenums="27"
     @Pure
@@ -120,7 +120,7 @@ The original Model is not modified.
 |------|------|-------------|
 | `prediction` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The given test_data with an added "prediction" column at the end |
 
-??? quote "Source code in `regressor.sdsstub`"
+??? quote "Stub code in `regressor.sdsstub`"
 
     ```sds linenums="48"
     @Pure

--- a/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
+++ b/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
@@ -37,6 +37,7 @@ import {
     getQualifiedName,
     getResults,
     getTypeParameters,
+    isImplementedDeclaration,
     isInternal,
     isPrivate,
     isStatic,
@@ -520,11 +521,12 @@ export class SafeDsMarkdownGenerator {
             start: { line: startLine, character: 0 },
             end: cstNode.range.start,
         });
+
         const text = removeLinePrefix(cstNode.text, firstLineIndent);
-
         const fileName = AstUtils.getDocument(node).uri.path.split('/').pop();
+        const kind = isImplementedDeclaration(node) ? 'Implementation' : 'Stub';
 
-        let result = `??? quote "Source code in \`${fileName}\`"\n\n`;
+        let result = `??? quote "${kind} code in \`${fileName}\`"\n\n`;
         result += indent(`\`\`\`sds linenums="${startLine + 1}"\n${text}\n\`\`\``);
 
         return result + '\n';

--- a/packages/safe-ds-lang/src/language/helpers/nodeProperties.ts
+++ b/packages/safe-ds-lang/src/language/helpers/nodeProperties.ts
@@ -20,6 +20,7 @@ import {
     isSdsNamedType,
     isSdsParameter,
     isSdsParameterBound,
+    isSdsPipeline,
     isSdsPlaceholder,
     isSdsQualifiedImport,
     isSdsSegment,
@@ -184,6 +185,20 @@ export namespace TypeParameter {
         return isSdsTypeParameter(node) && !node.variance;
     };
 }
+
+/**
+ * Checks whether the declaration has an implementation.
+ */
+export const isImplementedDeclaration = (declaration: SdsDeclaration): boolean => {
+    return isSdsPipeline(declaration) || isSdsSegment(declaration);
+};
+
+/**
+ * Checks whether the declaration is just a stub.
+ */
+export const isStubDeclaration = (declaration: SdsDeclaration): boolean => {
+    return !isSdsPipeline(declaration) && !isSdsSegment(declaration);
+};
 
 // -------------------------------------------------------------------------------------------------
 // Accessors for list elements

--- a/packages/safe-ds-lang/src/language/validation/names.ts
+++ b/packages/safe-ds-lang/src/language/validation/names.ts
@@ -38,11 +38,12 @@ import {
     getParameters,
     getResults,
     getTypeParameters,
+    isImplementedDeclaration,
+    isStubDeclaration,
     streamBlockLambdaResults,
     streamPlaceholders,
 } from '../helpers/nodeProperties.js';
 import { SafeDsServices } from '../safe-ds-module.js';
-import { declarationIsAllowedInPipelineFile, declarationIsAllowedInStubFile } from './other/modules.js';
 
 export const CODE_NAME_CODEGEN_PREFIX = 'name/codegen-prefix';
 export const CODE_NAME_CORE_DECLARATION = 'name/core-declaration';
@@ -317,14 +318,14 @@ export const moduleMustContainUniqueNames = (node: SdsModule, accept: Validation
             getModuleMembers(node),
             (name) => `A declaration with name '${name}' exists already in this file.`,
             accept,
-            declarationIsAllowedInPipelineFile,
+            isImplementedDeclaration,
         );
     } else if (isInStubFile(node)) {
         namesMustBeUnique(
             getModuleMembers(node),
             (name) => `A declaration with name '${name}' exists already in this file.`,
             accept,
-            declarationIsAllowedInStubFile,
+            isStubDeclaration,
         );
     } else if (isInTestFile(node)) {
         namesMustBeUnique(

--- a/packages/safe-ds-lang/src/language/validation/other/modules.ts
+++ b/packages/safe-ds-lang/src/language/validation/other/modules.ts
@@ -1,7 +1,7 @@
 import { ValidationAcceptor } from 'langium';
-import { isSdsDeclaration, isSdsPipeline, isSdsSegment, SdsDeclaration, SdsModule } from '../../generated/ast.js';
+import { isSdsDeclaration, SdsModule } from '../../generated/ast.js';
 import { isInPipelineFile, isInStubFile } from '../../helpers/fileExtensions.js';
-import { getModuleMembers } from '../../helpers/nodeProperties.js';
+import { getModuleMembers, isImplementedDeclaration, isStubDeclaration } from '../../helpers/nodeProperties.js';
 import { BUILTINS_ROOT_PACKAGE } from '../../builtins/packageNames.js';
 
 export const CODE_MODULE_FORBIDDEN_IN_PIPELINE_FILE = 'module/forbidden-in-pipeline-file';
@@ -14,7 +14,7 @@ export const moduleDeclarationsMustMatchFileKind = (node: SdsModule, accept: Val
 
     if (isInPipelineFile(node)) {
         for (const declaration of declarations) {
-            if (!declarationIsAllowedInPipelineFile(declaration)) {
+            if (!isImplementedDeclaration(declaration)) {
                 accept('error', 'A pipeline file must only declare pipelines and segments.', {
                     node: declaration,
                     property: 'name',
@@ -24,7 +24,7 @@ export const moduleDeclarationsMustMatchFileKind = (node: SdsModule, accept: Val
         }
     } else if (isInStubFile(node)) {
         for (const declaration of declarations) {
-            if (!declarationIsAllowedInStubFile(declaration)) {
+            if (!isStubDeclaration(declaration)) {
                 accept('error', 'A stub file must not declare pipelines or segments.', {
                     node: declaration,
                     property: 'name',
@@ -33,14 +33,6 @@ export const moduleDeclarationsMustMatchFileKind = (node: SdsModule, accept: Val
             }
         }
     }
-};
-
-export const declarationIsAllowedInPipelineFile = (declaration: SdsDeclaration): boolean => {
-    return isSdsPipeline(declaration) || isSdsSegment(declaration);
-};
-
-export const declarationIsAllowedInStubFile = (declaration: SdsDeclaration): boolean => {
-    return !isSdsPipeline(declaration) && !isSdsSegment(declaration);
 };
 
 export const moduleWithDeclarationsMustStatePackage = (node: SdsModule, accept: ValidationAcceptor): void => {

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/deprecated/generated/tests/generation/markdown/annotations/deprecated/MyAnnotation1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/deprecated/generated/tests/generation/markdown/annotations/deprecated/MyAnnotation1.md
@@ -19,7 +19,7 @@
 - `Segment`
 - `TypeParameter`
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="4"
     annotation MyAnnotation1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/tests/generation/markdown/annotations/documented/MyAnnotation1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/tests/generation/markdown/annotations/documented/MyAnnotation1.md
@@ -17,7 +17,7 @@ Description of MyAnnotation1.
 - `Segment`
 - `TypeParameter`
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="6"
     annotation MyAnnotation1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/tests/generation/markdown/annotations/documented/MyAnnotation2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/tests/generation/markdown/annotations/documented/MyAnnotation2.md
@@ -24,7 +24,7 @@ Description of MyAnnotation2.
 - `Segment`
 - `TypeParameter`
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="14"
     annotation MyAnnotation2(param1: MyEnum1, param2: Float = 1.0)

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/tests/generation/markdown/annotations/documented/MyAnnotation3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/tests/generation/markdown/annotations/documented/MyAnnotation3.md
@@ -2,7 +2,7 @@
 
 Description of MyAnnotation3.
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="20"
     annotation MyAnnotation3

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/tests/generation/markdown/annotations/documented/MyEnum1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/tests/generation/markdown/annotations/documented/MyEnum1.md
@@ -1,6 +1,6 @@
 # `#!sds enum` MyEnum1 {#tests.generation.markdown.annotations.documented.MyEnum1 data-toc-label='MyEnum1'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="22"
     enum MyEnum1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/experimental/generated/tests/generation/markdown/annotations/experimental/MyAnnotation1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/experimental/generated/tests/generation/markdown/annotations/experimental/MyAnnotation1.md
@@ -15,7 +15,7 @@
 - `Segment`
 - `TypeParameter`
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="4"
     annotation MyAnnotation1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/undocumented/generated/tests/generation/markdown/annotations/undocumented/MyAnnotation1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/undocumented/generated/tests/generation/markdown/annotations/undocumented/MyAnnotation1.md
@@ -15,7 +15,7 @@
 - `Segment`
 - `TypeParameter`
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="3"
     annotation MyAnnotation1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/undocumented/generated/tests/generation/markdown/annotations/undocumented/MyAnnotation2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/undocumented/generated/tests/generation/markdown/annotations/undocumented/MyAnnotation2.md
@@ -22,7 +22,7 @@
 - `Segment`
 - `TypeParameter`
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="5"
     annotation MyAnnotation2(param1: Int, param2: Float = 1.0)

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/undocumented/generated/tests/generation/markdown/annotations/undocumented/MyAnnotation3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/undocumented/generated/tests/generation/markdown/annotations/undocumented/MyAnnotation3.md
@@ -1,6 +1,6 @@
 # `#!sds annotation` MyAnnotation3 {#tests.generation.markdown.annotations.undocumented.MyAnnotation3 data-toc-label='MyAnnotation3'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="8"
     annotation MyAnnotation3

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/deprecated/generated/tests/generation/markdown/classes/deprecated/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/deprecated/generated/tests/generation/markdown/classes/deprecated/MyClass1.md
@@ -4,7 +4,7 @@
 
     This class is deprecated.
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="4"
     class MyClass1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass1.md
@@ -2,7 +2,7 @@
 
 Description of MyClass1.
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="6"
     class MyClass1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass2.md
@@ -2,7 +2,7 @@
 
 Description of MyClass2.
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="11"
     class MyClass2()

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass3.md
@@ -10,7 +10,7 @@ Description of MyClass3.
 | `TypeParam2` | [`MyClass1`][tests.generation.markdown.classes.documented.MyClass1] | Description of TypeParam2. | - |
 | `TypeParam3` | `#!sds Any?` | Description of TypeParam3. | [`MyClass1`][tests.generation.markdown.classes.documented.MyClass1] |
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="20"
     class MyClass3<TypeParam1, TypeParam2 sub MyClass1, TypeParam3 = MyClass1>

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass4.md
@@ -9,7 +9,7 @@ Description of MyClass4.
 | `param1` | [`MyClass1`][tests.generation.markdown.classes.documented.MyClass1] | Description of param1. | - |
 | `param2` | `#!sds Float` | Description of param2. | `#!sds 1.0` |
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="28"
     class MyClass4(param1: MyClass1, param2: Float = 1.0)

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass5.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass5.md
@@ -4,7 +4,7 @@ Description of MyClass5.
 
 **Parent type:** [`MyClass1`][tests.generation.markdown.classes.documented.MyClass1]
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="33"
     class MyClass5 sub MyClass1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass6.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass6.md
@@ -2,7 +2,7 @@
 
 Description of MyClass6.
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="38"
     class MyClass6 {
@@ -55,7 +55,7 @@ Description of myAttribute1.
 
 Description of myFunction1.
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="61"
     @Pure fun myFunction1()
@@ -71,7 +71,7 @@ Description of myAttribute2.
 
 Description of myFunction2.
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="65"
     @Pure static fun myFunction2()
@@ -81,7 +81,7 @@ Description of myFunction2.
 
 Description of MyClass7.
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="42"
     class MyClass7 {
@@ -112,7 +112,7 @@ Description of myAttribute3.
 
 Description of MyEnum1.
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="56"
     enum MyEnum1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/experimental/generated/tests/generation/markdown/classes/experimental/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/experimental/generated/tests/generation/markdown/classes/experimental/MyClass1.md
@@ -1,6 +1,6 @@
 # :test_tube:{ title="Experimental" } `#!sds abstract class` MyClass1 {#tests.generation.markdown.classes.experimental.MyClass1 data-toc-label='MyClass1'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="4"
     class MyClass1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass1.md
@@ -1,6 +1,6 @@
 # `#!sds abstract class` MyClass1 {#tests.generation.markdown.classes.undocumented.MyClass1 data-toc-label='MyClass1'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="3"
     class MyClass1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass2.md
@@ -1,6 +1,6 @@
 # `#!sds class` MyClass2 {#tests.generation.markdown.classes.undocumented.MyClass2 data-toc-label='MyClass2'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="5"
     class MyClass2()

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass3.md
@@ -8,7 +8,7 @@
 | `TypeParam2` | `#!sds Int` | - | - |
 | `TypeParam3` | `#!sds Any?` | - | `#!sds Int` |
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="7"
     class MyClass3<TypeParam1, TypeParam2 sub Int, TypeParam3 = Int>

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass4.md
@@ -7,7 +7,7 @@
 | `param1` | `#!sds Int` | - | - |
 | `param2` | `#!sds Float` | - | `#!sds 1.0` |
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="9"
     class MyClass4(param1: Int, param2: Float = 1.0)

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass5.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass5.md
@@ -2,7 +2,7 @@
 
 **Parent type:** [`MyClass1`][tests.generation.markdown.classes.undocumented.MyClass1]
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="11"
     class MyClass5 sub MyClass1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass6.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass6.md
@@ -1,6 +1,6 @@
 # `#!sds abstract class` MyClass6 {#tests.generation.markdown.classes.undocumented.MyClass6 data-toc-label='MyClass6'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="13"
     class MyClass6 {
@@ -21,7 +21,7 @@
 
 ## `#!sds fun` myFunction1 {#tests.generation.markdown.classes.undocumented.MyClass6.myFunction1 data-toc-label='myFunction1'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="17"
     @Pure fun myFunction1()
@@ -33,7 +33,7 @@
 
 ## `#!sds static fun` myFunction2 {#tests.generation.markdown.classes.undocumented.MyClass6.myFunction2 data-toc-label='myFunction2'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="18"
     @Pure static fun myFunction2()
@@ -41,7 +41,7 @@
 
 ## `#!sds abstract class` MyClass7 {#tests.generation.markdown.classes.undocumented.MyClass6.MyClass7 data-toc-label='MyClass7'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="20"
     class MyClass7
@@ -49,7 +49,7 @@
 
 ## `#!sds enum` MyEnum1 {#tests.generation.markdown.classes.undocumented.MyClass6.MyEnum1 data-toc-label='MyEnum1'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="21"
     enum MyEnum1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema1.md
@@ -4,7 +4,7 @@
 
     This schema is deprecated.
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="4"
     schema MySchema1 {}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema2.md
@@ -6,7 +6,7 @@
 
     - **Alternative:** Something else
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="9"
     schema MySchema2 {}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema3.md
@@ -6,7 +6,7 @@
 
     - **Reason:** To annoy you
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="14"
     schema MySchema3 {}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema4.md
@@ -4,7 +4,7 @@
 
     This schema is deprecated since version **1.0.0**.
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="19"
     schema MySchema4 {}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema5.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema5.md
@@ -4,7 +4,7 @@
 
     This schema is deprecated and will be removed in version **2.0.0**.
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="24"
     schema MySchema5 {}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema6.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema6.md
@@ -7,7 +7,7 @@
     - **Alternative:** Something else
     - **Reason:** To annoy you
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="32"
     schema MySchema6 {}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/deprecated/generated/tests/generation/markdown/enums/deprecated/MyEnum1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/deprecated/generated/tests/generation/markdown/enums/deprecated/MyEnum1.md
@@ -4,7 +4,7 @@
 
     This enum is deprecated.
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="4"
     enum MyEnum1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyClass1.md
@@ -1,6 +1,6 @@
 # `#!sds abstract class` MyClass1 {#tests.generation.markdown.enums.documented.MyClass1 data-toc-label='MyClass1'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="26"
     class MyClass1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyEnum1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyEnum1.md
@@ -2,7 +2,7 @@
 
 Description of MyEnum1.
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="6"
     enum MyEnum1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyEnum2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyEnum2.md
@@ -2,7 +2,7 @@
 
 Description of MyEnum2.
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="11"
     enum MyEnum2 {

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/experimental/generated/tests/generation/markdown/enums/experimental/MyEnum1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/experimental/generated/tests/generation/markdown/enums/experimental/MyEnum1.md
@@ -1,6 +1,6 @@
 # :test_tube:{ title="Experimental" } `#!sds enum` MyEnum1 {#tests.generation.markdown.enums.experimental.MyEnum1 data-toc-label='MyEnum1'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="4"
     enum MyEnum1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/undocumented/generated/tests/generation/markdown/enums/undocumented/MyEnum1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/undocumented/generated/tests/generation/markdown/enums/undocumented/MyEnum1.md
@@ -1,6 +1,6 @@
 # `#!sds enum` MyEnum1 {#tests.generation.markdown.enums.undocumented.MyEnum1 data-toc-label='MyEnum1'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="3"
     enum MyEnum1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/undocumented/generated/tests/generation/markdown/enums/undocumented/MyEnum2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/undocumented/generated/tests/generation/markdown/enums/undocumented/MyEnum2.md
@@ -1,6 +1,6 @@
 # `#!sds enum` MyEnum2 {#tests.generation.markdown.enums.undocumented.MyEnum2 data-toc-label='MyEnum2'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="5"
     enum MyEnum2 {

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/deprecated/generated/tests/generation/markdown/functions/deprecated/myFunction1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/deprecated/generated/tests/generation/markdown/functions/deprecated/myFunction1.md
@@ -4,7 +4,7 @@
 
     This function is deprecated.
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="5"
     fun myFunction1()

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/MyClass1.md
@@ -1,6 +1,6 @@
 # `#!sds abstract class` MyClass1 {#tests.generation.markdown.functions.documented.MyClass1 data-toc-label='MyClass1'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="41"
     class MyClass1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/myFunction1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/myFunction1.md
@@ -2,7 +2,7 @@
 
 Description of myFunction1.
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="7"
     fun myFunction1()

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/myFunction2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/myFunction2.md
@@ -18,7 +18,7 @@ Description of myFunction2.
 | `TypeParam2` | [`MyClass1`][tests.generation.markdown.functions.documented.MyClass1] | Description of TypeParam2. | - |
 | `TypeParam3` | `#!sds Any?` | Description of TypeParam3. | [`MyClass1`][tests.generation.markdown.functions.documented.MyClass1] |
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="17"
     fun myFunction2<TypeParam1, TypeParam2 sub MyClass1, TypeParam3 = MyClass1>(

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/myFunction3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/myFunction3.md
@@ -9,7 +9,7 @@ Description of myFunction3.
 | `param1` | [`MyClass1`][tests.generation.markdown.functions.documented.MyClass1] | Description of param1. | - |
 | `param2` | `#!sds Float` | Description of param2. | `#!sds 1.0` |
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="30"
     fun myFunction3(param1: MyClass1, param2: Float = 1.0)

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/myFunction4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/myFunction4.md
@@ -9,7 +9,7 @@ Description of myFunction4.
 | `result1` | [`MyClass1`][tests.generation.markdown.functions.documented.MyClass1] | Description of result1. |
 | `result2` | `#!sds Float` | Description of result2. |
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="39"
     fun myFunction4() -> (result1: MyClass1, result2: Float)

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/experimental/generated/tests/generation/markdown/functions/experimental/myFunction1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/experimental/generated/tests/generation/markdown/functions/experimental/myFunction1.md
@@ -1,6 +1,6 @@
 # :test_tube:{ title="Experimental" } `#!sds fun` myFunction1 {#tests.generation.markdown.functions.experimental.myFunction1 data-toc-label='myFunction1'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="5"
     fun myFunction1()

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/undocumented/generated/tests/generation/markdown/functions/undocumented/myFunction1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/undocumented/generated/tests/generation/markdown/functions/undocumented/myFunction1.md
@@ -1,6 +1,6 @@
 # `#!sds fun` myFunction1 {#tests.generation.markdown.functions.undocumented.myFunction1 data-toc-label='myFunction1'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="4"
     fun myFunction1()

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/undocumented/generated/tests/generation/markdown/functions/undocumented/myFunction2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/undocumented/generated/tests/generation/markdown/functions/undocumented/myFunction2.md
@@ -16,7 +16,7 @@
 | `TypeParam2` | `#!sds Int` | - | - |
 | `TypeParam3` | `#!sds Any?` | - | `#!sds Int` |
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="7"
     fun myFunction2<TypeParam1, TypeParam2 sub Int, TypeParam3 = Int>(

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/undocumented/generated/tests/generation/markdown/functions/undocumented/myFunction3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/undocumented/generated/tests/generation/markdown/functions/undocumented/myFunction3.md
@@ -7,7 +7,7 @@
 | `param1` | `#!sds Int` | - | - |
 | `param2` | `#!sds Float` | - | `#!sds 1.0` |
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="14"
     fun myFunction3(param1: Int, param2: Float = 1.0)

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/undocumented/generated/tests/generation/markdown/functions/undocumented/myFunction4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/undocumented/generated/tests/generation/markdown/functions/undocumented/myFunction4.md
@@ -7,7 +7,7 @@
 | `result1` | `#!sds Int` | - |
 | `result2` | `#!sds Float` | - |
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="17"
     fun myFunction4() -> (result1: Int, result2: Float)

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/link tag/generated/tests/generation/markdown/linkTag/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/link tag/generated/tests/generation/markdown/linkTag/MyClass1.md
@@ -10,7 +10,7 @@ Broken.
 |------|------|-------------|---------|
 | `param1` | `#!sds Int` | Description of param1. [MyClass2][tests.generation.markdown.linkTag.MyClass2]. | - |
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="10"
     class MyClass1(param1: Int)

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/link tag/generated/tests/generation/markdown/linkTag/MyClass2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/link tag/generated/tests/generation/markdown/linkTag/MyClass2.md
@@ -1,6 +1,6 @@
 # `#!sds abstract class` MyClass2 {#tests.generation.markdown.linkTag.MyClass2 data-toc-label='MyClass2'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="12"
     class MyClass2

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/multiline/generated/tests/generation/markdown/multiline/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/multiline/generated/tests/generation/markdown/multiline/MyClass1.md
@@ -6,7 +6,7 @@ $$
 n
 $$
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="10"
     class MyClass1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/multiline/generated/tests/generation/markdown/multiline/MyClass2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/multiline/generated/tests/generation/markdown/multiline/MyClass2.md
@@ -9,7 +9,7 @@ Description of MyClass2.
 | `param1` | `#!sds Int` | Description of param1. That spans multiple lines. | - |
 | `param2` | `#!sds Int` | Description of param2. That spans multiple lines. | - |
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="26"
     class MyClass2(param1: Int, param2: Int)

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/pipelines/generated/tests/generation/markdown/pipelines/mySegment1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/pipelines/generated/tests/generation/markdown/pipelines/mySegment1.md
@@ -1,6 +1,6 @@
 # `#!sds segment` mySegment1 {#tests.generation.markdown.pipelines.mySegment1 data-toc-label='mySegment1'}
 
-??? quote "Source code in `main.sdspipe`"
+??? quote "Implementation code in `main.sdspipe`"
 
     ```sds linenums="6"
     segment mySegment1() {}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/deprecated/generated/tests/generation/markdown/schemas/deprecated/MySchema1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/deprecated/generated/tests/generation/markdown/schemas/deprecated/MySchema1.md
@@ -4,7 +4,7 @@
 
     This schema is deprecated.
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="4"
     schema MySchema1 {}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/tests/generation/markdown/schemas/documented/MyClass.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/tests/generation/markdown/schemas/documented/MyClass.md
@@ -1,6 +1,6 @@
 # `#!sds abstract class` MyClass {#tests.generation.markdown.schemas.documented.MyClass data-toc-label='MyClass'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="18"
     class MyClass

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/tests/generation/markdown/schemas/documented/MySchema1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/tests/generation/markdown/schemas/documented/MySchema1.md
@@ -2,7 +2,7 @@
 
 Description of MySchema1.
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="8"
     schema MySchema1 {}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/tests/generation/markdown/schemas/documented/MySchema2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/tests/generation/markdown/schemas/documented/MySchema2.md
@@ -9,7 +9,7 @@ Description of MySchema2.
 | `column1` | [`MyClass`][tests.generation.markdown.schemas.documented.MyClass] |
 | `column2` | `#!sds Int` |
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="13"
     schema MySchema2 {

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/experimental/generated/tests/generation/markdown/schemas/experimental/MySchema1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/experimental/generated/tests/generation/markdown/schemas/experimental/MySchema1.md
@@ -1,6 +1,6 @@
 # :test_tube:{ title="Experimental" } `#!sds schema` MySchema1 {#tests.generation.markdown.schemas.experimental.MySchema1 data-toc-label='MySchema1'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="4"
     schema MySchema1 {}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/undocumented/generated/tests/generation/markdown/schemas/undocumented/MySchema1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/undocumented/generated/tests/generation/markdown/schemas/undocumented/MySchema1.md
@@ -1,6 +1,6 @@
 # `#!sds schema` MySchema1 {#tests.generation.markdown.schemas.undocumented.MySchema1 data-toc-label='MySchema1'}
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="3"
     schema MySchema1 {}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/undocumented/generated/tests/generation/markdown/schemas/undocumented/MySchema2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/undocumented/generated/tests/generation/markdown/schemas/undocumented/MySchema2.md
@@ -7,7 +7,7 @@
 | `column1` | `#!sds String` |
 | `column2` | `#!sds Int` |
 
-??? quote "Source code in `main.sdsstub`"
+??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="5"
     schema MySchema2 {

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/deprecated/generated/tests/generation/markdown/segments/deprecated/mySegment1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/deprecated/generated/tests/generation/markdown/segments/deprecated/mySegment1.md
@@ -4,7 +4,7 @@
 
     This segment is deprecated.
 
-??? quote "Source code in `main.sdspipe`"
+??? quote "Implementation code in `main.sdspipe`"
 
     ```sds linenums="4"
     segment mySegment1() {}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/MyClass1.md
@@ -1,6 +1,6 @@
 # `#!sds class` MyClass1 {#tests.generation.markdown.segments.documented.MyClass1 data-toc-label='MyClass1'}
 
-??? quote "Source code in `resources.sdsstub`"
+??? quote "Stub code in `resources.sdsstub`"
 
     ```sds linenums="3"
     class MyClass1()

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment1.md
@@ -2,7 +2,7 @@
 
 Description of mySegment1.
 
-??? quote "Source code in `main.sdspipe`"
+??? quote "Implementation code in `main.sdspipe`"
 
     ```sds linenums="6"
     segment mySegment1() {}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment3.md
@@ -2,7 +2,7 @@
 
 Description of mySegment3.
 
-??? quote "Source code in `main.sdspipe`"
+??? quote "Implementation code in `main.sdspipe`"
 
     ```sds linenums="16"
     internal segment mySegment3() {}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment4.md
@@ -9,7 +9,7 @@ Description of mySegment3.
 | `param1` | [`MyClass1`][tests.generation.markdown.segments.documented.MyClass1] | Description of param1. | - |
 | `param2` | `#!sds Float` | Description of param2. | `#!sds 1.0` |
 
-??? quote "Source code in `main.sdspipe`"
+??? quote "Implementation code in `main.sdspipe`"
 
     ```sds linenums="24"
     segment mySegment4(param1: MyClass1, param2: Float = 1.0) {}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment5.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment5.md
@@ -9,7 +9,7 @@ Description of mySegment4.
 | `result1` | [`MyClass1`][tests.generation.markdown.segments.documented.MyClass1] | Description of result1. |
 | `result2` | `#!sds Float` | Description of result2. |
 
-??? quote "Source code in `main.sdspipe`"
+??? quote "Implementation code in `main.sdspipe`"
 
     ```sds linenums="32"
     segment mySegment5() -> (result1: MyClass1, result2: Float) {

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/experimental/generated/tests/generation/markdown/segments/experimental/mySegment1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/experimental/generated/tests/generation/markdown/segments/experimental/mySegment1.md
@@ -1,6 +1,6 @@
 # :test_tube:{ title="Experimental" } `#!sds segment` mySegment1 {#tests.generation.markdown.segments.experimental.mySegment1 data-toc-label='mySegment1'}
 
-??? quote "Source code in `main.sdspipe`"
+??? quote "Implementation code in `main.sdspipe`"
 
     ```sds linenums="4"
     segment mySegment1() {}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/undocumented/generated/tests/generation/markdown/segments/undocumented/mySegment1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/undocumented/generated/tests/generation/markdown/segments/undocumented/mySegment1.md
@@ -1,6 +1,6 @@
 # `#!sds segment` mySegment1 {#tests.generation.markdown.segments.undocumented.mySegment1 data-toc-label='mySegment1'}
 
-??? quote "Source code in `main.sdspipe`"
+??? quote "Implementation code in `main.sdspipe`"
 
     ```sds linenums="3"
     segment mySegment1() {}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/undocumented/generated/tests/generation/markdown/segments/undocumented/mySegment3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/undocumented/generated/tests/generation/markdown/segments/undocumented/mySegment3.md
@@ -1,6 +1,6 @@
 # `#!sds internal segment` mySegment3 {#tests.generation.markdown.segments.undocumented.mySegment3 data-toc-label='mySegment3'}
 
-??? quote "Source code in `main.sdspipe`"
+??? quote "Implementation code in `main.sdspipe`"
 
     ```sds linenums="7"
     internal segment mySegment3() {}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/undocumented/generated/tests/generation/markdown/segments/undocumented/mySegment4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/undocumented/generated/tests/generation/markdown/segments/undocumented/mySegment4.md
@@ -7,7 +7,7 @@
 | `param1` | `#!sds Int` | - | - |
 | `param2` | `#!sds Float` | - | `#!sds 1.0` |
 
-??? quote "Source code in `main.sdspipe`"
+??? quote "Implementation code in `main.sdspipe`"
 
     ```sds linenums="9"
     segment mySegment4(param1: Int, param2: Float = 1.0) {}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/undocumented/generated/tests/generation/markdown/segments/undocumented/mySegment5.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/undocumented/generated/tests/generation/markdown/segments/undocumented/mySegment5.md
@@ -7,7 +7,7 @@
 | `result1` | `#!sds Int` | - |
 | `result2` | `#!sds Float` | - |
 
-??? quote "Source code in `main.sdspipe`"
+??? quote "Implementation code in `main.sdspipe`"
 
     ```sds linenums="11"
     segment mySegment5() -> (result1: Int, result2: Float) {

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/MyClass1.md
@@ -1,6 +1,6 @@
 # `#!sds abstract class` MyClass1 {#tests.generation.markdown.summary.package1.MyClass1 data-toc-label='MyClass1'}
 
-??? quote "Source code in `package1_module1.sdsstub`"
+??? quote "Stub code in `package1_module1.sdsstub`"
 
     ```sds linenums="3"
     class MyClass1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/MyClass2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/MyClass2.md
@@ -1,6 +1,6 @@
 # `#!sds abstract class` MyClass2 {#tests.generation.markdown.summary.package1.MyClass2 data-toc-label='MyClass2'}
 
-??? quote "Source code in `package1_module1.sdsstub`"
+??? quote "Stub code in `package1_module1.sdsstub`"
 
     ```sds linenums="5"
     class MyClass2

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/MyClass3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/MyClass3.md
@@ -1,6 +1,6 @@
 # `#!sds abstract class` MyClass3 {#tests.generation.markdown.summary.package1.MyClass3 data-toc-label='MyClass3'}
 
-??? quote "Source code in `package1_module2.sdsstub`"
+??? quote "Stub code in `package1_module2.sdsstub`"
 
     ```sds linenums="3"
     class MyClass3

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/subpackage/MyClass5.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/subpackage/MyClass5.md
@@ -1,6 +1,6 @@
 # `#!sds abstract class` MyClass5 {#tests.generation.markdown.summary.package1.subpackage.MyClass5 data-toc-label='MyClass5'}
 
-??? quote "Source code in `package3.sdsstub`"
+??? quote "Stub code in `package3.sdsstub`"
 
     ```sds linenums="3"
     class MyClass5

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package2/MyClass4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package2/MyClass4.md
@@ -1,6 +1,6 @@
 # `#!sds abstract class` MyClass4 {#tests.generation.markdown.summary.package2.MyClass4 data-toc-label='MyClass4'}
 
-??? quote "Source code in `package2.sdsstub`"
+??? quote "Stub code in `package2.sdsstub`"
 
     ```sds linenums="3"
     class MyClass4


### PR DESCRIPTION
Closes #1034

### Summary of Changes

In the library docs, replace the words "source code" with either "stub code" or "implementation code" depending on whether a declaration has an implementation in Safe-DS (pipeline/segment).
