### PR TITLE
fix: start runner if configuration did not change after installation

### DIFF
--- a/packages/safe-ds-lang/src/language/index.ts
+++ b/packages/safe-ds-lang/src/language/index.ts
@@ -1,4 +1,4 @@
-import { pipVersionRange, RPC_RUNNER_INSTALL, RPC_RUNNER_STARTED } from './runner/safe-ds-runner.js';
+import { pipVersionRange, RPC_RUNNER_INSTALL, RPC_RUNNER_START, RPC_RUNNER_STARTED } from './runner/safe-ds-runner.js';
 
 // Services
 export type { SafeDsServices } from './safe-ds-module.js';
@@ -23,6 +23,7 @@ export * as messages from './runner/messages.js';
 // Remote procedure calls
 export const rpc = {
     runnerInstall: RPC_RUNNER_INSTALL,
+    runnerStart: RPC_RUNNER_START,
     runnerStarted: RPC_RUNNER_STARTED,
 };
 

--- a/packages/safe-ds-lang/src/language/safe-ds-module.ts
+++ b/packages/safe-ds-lang/src/language/safe-ds-module.ts
@@ -64,6 +64,9 @@ export type SafeDsAddedServices = {
         Enums: SafeDsEnums;
         ImpurityReasons: SafeDsImpurityReasons;
     };
+    communication: {
+        MessagingProvider: SafeDsMessagingProvider;
+    };
     documentation: {
         DocumentationProvider: SafeDsDocumentationProvider;
     };
@@ -81,7 +84,6 @@ export type SafeDsAddedServices = {
         NodeMapper: SafeDsNodeMapper;
     };
     lsp: {
-        MessagingProvider: SafeDsMessagingProvider;
         NodeInfoProvider: SafeDsNodeInfoProvider;
     };
     purity: {
@@ -132,6 +134,9 @@ export const SafeDsModule: Module<SafeDsServices, PartialLangiumServices & SafeD
         Enums: (services) => new SafeDsEnums(services),
         ImpurityReasons: (services) => new SafeDsImpurityReasons(services),
     },
+    communication: {
+        MessagingProvider: (services) => new SafeDsMessagingProvider(services),
+    },
     documentation: {
         CommentProvider: (services) => new SafeDsCommentProvider(services),
         DocumentationProvider: (services) => new SafeDsDocumentationProvider(services),
@@ -156,7 +161,6 @@ export const SafeDsModule: Module<SafeDsServices, PartialLangiumServices & SafeD
         DocumentSymbolProvider: (services) => new SafeDsDocumentSymbolProvider(services),
         Formatter: () => new SafeDsFormatter(),
         InlayHintProvider: (services) => new SafeDsInlayHintProvider(services),
-        MessagingProvider: (services) => new SafeDsMessagingProvider(services),
         NodeInfoProvider: (services) => new SafeDsNodeInfoProvider(services),
         RenameProvider: (services) => new SafeDsRenameProvider(services),
         SemanticTokenProvider: (services) => new SafeDsSemanticTokenProvider(services),
@@ -242,11 +246,11 @@ export const createSafeDsServices = async function (
     // Apply options
     if (options?.logger) {
         /* c8 ignore next 2 */
-        SafeDs.lsp.MessagingProvider.setLogger(options.logger);
+        SafeDs.communication.MessagingProvider.setLogger(options.logger);
     }
     if (options?.messageBroker) {
         /* c8 ignore next 2 */
-        SafeDs.lsp.MessagingProvider.setMessageBroker(options.messageBroker);
+        SafeDs.communication.MessagingProvider.setMessageBroker(options.messageBroker);
     }
     if (!options?.omitBuiltins) {
         await shared.workspace.WorkspaceManager.initializeWorkspace([]);
@@ -257,7 +261,7 @@ export const createSafeDsServices = async function (
     }
     if (options?.userMessageProvider) {
         /* c8 ignore next 2 */
-        SafeDs.lsp.MessagingProvider.setUserMessageProvider(options.userMessageProvider);
+        SafeDs.communication.MessagingProvider.setUserMessageProvider(options.userMessageProvider);
     }
 
     return { shared, SafeDs };

--- a/packages/safe-ds-vscode/src/extension/mainClient.ts
+++ b/packages/safe-ds-vscode/src/extension/mainClient.ts
@@ -47,7 +47,7 @@ export const activate = async function (context: vscode.ExtensionContext) {
 
 const registerNotificationListeners = function (context: vscode.ExtensionContext) {
     client.onNotification(rpc.runnerInstall, async () => {
-        await installRunner(context, services)();
+        await installRunner(context, client, services)();
     });
     client.onNotification(rpc.runnerStarted, async (port: number) => {
         await services.runtime.Runner.connectToPort(port);
@@ -112,7 +112,7 @@ const registerVSCodeCommands = function (context: vscode.ExtensionContext) {
 
     context.subscriptions.push(vscode.commands.registerCommand('safe-ds.dumpDiagnostics', dumpDiagnostics(context)));
     context.subscriptions.push(
-        vscode.commands.registerCommand('safe-ds.installRunner', installRunner(context, services)),
+        vscode.commands.registerCommand('safe-ds.installRunner', installRunner(context, client, services)),
     );
     context.subscriptions.push(
         vscode.commands.registerCommand('safe-ds.openDiagnosticsDumps', openDiagnosticsDumps(context)),


### PR DESCRIPTION
### Summary of Changes

Previously, the runner was not started immediately if the installer did not have to change the runner command, since no event was fired. Now we always force a startup attempt.
