### PR TITLE
feat: better error if `+` is used for string concatenation

### DIFF
--- a/packages/safe-ds-lang/src/language/validation/types.ts
+++ b/packages/safe-ds-lang/src/language/validation/types.ts
@@ -176,11 +176,25 @@ export const infixOperationOperandsMustHaveCorrectType = (services: SafeDsServic
                     });
                 }
                 return;
+            case '+':
+                if (
+                    typeChecker.isSubtypeOf(leftType, coreTypes.String) ||
+                    typeChecker.isSubtypeOf(rightType, coreTypes.String)
+                ) {
+                    accept('error', `Use template strings for concatenation.`, {
+                        node,
+                        code: CODE_TYPE_MISMATCH,
+                        codeDescription: {
+                            href: 'https://dsl.safeds.com/en/stable/language/pipeline-language/expressions/#template-strings',
+                        },
+                    });
+                    return;
+                }
+            // fallthrough
             case '<':
             case '<=':
             case '>=':
             case '>':
-            case '+':
             case '-':
             case '*':
             case '/':

--- a/packages/safe-ds-lang/tests/resources/validation/types/checking/infix operations/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/validation/types/checking/infix operations/main.sdsdev
@@ -29,9 +29,9 @@ pipeline myPipeline {
     // $TEST$ no error r"Expected type 'Float' or 'Int' but got .*\."
     // $TEST$ no error r"Expected type 'Float' or 'Int' but got .*\."
     »0« + »0«;
-    // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<"">'."
-    // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<"">'."
-    »""« + »""«;
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<true>'."
+    // $TEST$ error "Expected type 'Float' or 'Int' but got 'literal<false>'."
+    »true« + »false«;
     // $TEST$ error "Expected type 'Float' or 'Int' but got 'unknown'."
     // $TEST$ error "Expected type 'Float' or 'Int' but got 'unknown'."
     »unresolved« + »unresolved«;
@@ -166,3 +166,12 @@ class MyClass<T sub Any>(
     // $TEST$ error "Expected type 'Float' or 'Int' but got 'T'."
     c4: Any? = »p1« > »p1«,
 )
+
+pipeline stringConcatenation {
+    // $TEST$ error "Use template strings for concatenation."
+    »"" + 0.0«;
+    // $TEST$ error "Use template strings for concatenation."
+    »0 + ""«;
+    // $TEST$ error "Use template strings for concatenation."
+    »"" + ""«;
+}

--- a/packages/safe-ds-vscode/package.json
+++ b/packages/safe-ds-vscode/package.json
@@ -113,8 +113,8 @@
             },
             {
                 "language": "safe-ds-dev",
-                "scopeName": "source.safe-ds-stub",
-                "path": "./syntaxes/safe-ds-stub.tmLanguage.json"
+                "scopeName": "source.safe-ds-dev",
+                "path": "./syntaxes/safe-ds-dev.tmLanguage.json"
             }
         ],
         "snippets": [


### PR DESCRIPTION
### Summary of Changes

If `+` is used for string concatenation, users are now pointed to template strings.
