### PR TITLE
feat: support for examples in documentation comments

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -25,7 +25,7 @@ To run Safe-DS programs, you also need the [Safe-DS Runner](https://github.com/S
 2. **Open VS Code**.
 3. **Open the command palette** (Menu bar > View > Command Palette).
 4. **Type `Install the Safe-DS Runner`**.
-5. **Press ++enter++**. Installation may take a few minutes, since it downloads and installs several large libraries
+5. **Press Enter**. Installation may take a few minutes, since it downloads and installs several large libraries
    like PyTorch.
 
 ## Documentation

--- a/docs/api/safeds/data/tabular/containers/Column.md
+++ b/docs/api/safeds/data/tabular/containers/Column.md
@@ -15,9 +15,17 @@ A column is a named collection of values.
 |------|-------------|-------------|---------|
 | `T` | [`Any?`][safeds.lang.Any] | - | [`Any?`][safeds.lang.Any] |
 
+**Examples:**
+
+```sds
+pipeline example {
+    val column = Column("test", [1, 2, 3]);
+}
+```
+
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="12"
+    ```sds linenums="17"
     class Column<out T = Any?>(
         name: String,
         data: List<T> = []
@@ -310,7 +318,7 @@ Check if all values have a given property.
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="58"
+    ```sds linenums="63"
     @Pure
     fun all(
         predicate: (param1: T) -> param2: Boolean
@@ -335,7 +343,7 @@ Check if any value has a given property.
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="70"
+    ```sds linenums="75"
     @Pure
     fun any(
         predicate: (param1: T) -> param2: Boolean
@@ -360,7 +368,7 @@ Calculate Pearson correlation between this and another column. Both columns have
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="129"
+    ```sds linenums="134"
     @Pure
     @PythonName("correlation_with")
     fun correlationWith(
@@ -380,7 +388,7 @@ Return a list of all unique values in the column.
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="34"
+    ```sds linenums="39"
     @Pure
     @PythonName("get_unique_values")
     fun getUniqueValues() -> result1: List<T>
@@ -404,7 +412,7 @@ Return column value at specified index, starting at 0.
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="45"
+    ```sds linenums="50"
     @Pure
     @PythonName("get_value")
     fun getValue(
@@ -424,7 +432,7 @@ Return whether the column has missing values.
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="92"
+    ```sds linenums="97"
     @Pure
     @PythonName("has_missing_values")
     fun hasMissingValues() -> result1: Boolean
@@ -448,7 +456,7 @@ $$
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="146"
+    ```sds linenums="151"
     @Pure
     fun idness() -> result1: Float
     ```
@@ -465,7 +473,7 @@ Return the maximum value of the column. The column has to be numerical.
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="154"
+    ```sds linenums="159"
     @Pure
     fun maximum() -> result1: Float
     ```
@@ -482,7 +490,7 @@ Return the mean value of the column. The column has to be numerical.
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="162"
+    ```sds linenums="167"
     @Pure
     fun mean() -> result1: Float
     ```
@@ -499,7 +507,7 @@ Return the median value of the column. The column has to be numerical.
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="170"
+    ```sds linenums="175"
     @Pure
     fun median() -> result1: Float
     ```
@@ -516,7 +524,7 @@ Return the minimum value of the column. The column has to be numerical.
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="178"
+    ```sds linenums="183"
     @Pure
     fun minimum() -> result1: Float
     ```
@@ -533,7 +541,7 @@ Return the ratio of missing values to the total number of elements in the column
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="186"
+    ```sds linenums="191"
     @Pure
     @PythonName("missing_value_ratio")
     fun missingValueRatio() -> result1: Float
@@ -551,7 +559,7 @@ Return the mode of the column.
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="195"
+    ```sds linenums="200"
     @Pure
     fun mode() -> result1: List<T>
     ```
@@ -574,7 +582,7 @@ Check if no values has a given property.
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="82"
+    ```sds linenums="87"
     @Pure
     fun none(
         predicate: (param1: T) -> param2: Boolean
@@ -593,7 +601,7 @@ Plot this column in a boxplot. This function can only plot real numerical data.
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="244"
+    ```sds linenums="249"
     @Pure
     @PythonName("plot_boxplot")
     fun plotBoxplot() -> result1: Image
@@ -611,7 +619,7 @@ Plot a column in a histogram.
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="253"
+    ```sds linenums="258"
     @Pure
     @PythonName("plot_histogram")
     fun plotHistogram() -> result1: Image
@@ -637,7 +645,7 @@ The original column is not modified.
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="105"
+    ```sds linenums="110"
     @Pure
     fun rename(
         @PythonName("new_name") newName: String
@@ -664,7 +672,7 @@ The stability is not defined for a column with only null values.
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="211"
+    ```sds linenums="216"
     @Pure
     fun stability() -> result1: Float
     ```
@@ -681,7 +689,7 @@ Return the standard deviation of the column. The column has to be numerical.
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="219"
+    ```sds linenums="224"
     @Pure
     @PythonName("standard_deviation")
     fun standardDeviation() -> result1: Float
@@ -699,7 +707,7 @@ Return the sum of the column. The column has to be numerical.
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="228"
+    ```sds linenums="233"
     @Pure
     fun sum() -> result1: Float
     ```
@@ -716,7 +724,7 @@ Return an HTML representation of the column.
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="262"
+    ```sds linenums="267"
     @Pure
     @PythonName("to_html")
     fun toHtml() -> result1: String
@@ -748,7 +756,7 @@ The original column is not modified.
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="119"
+    ```sds linenums="124"
     @Pure
     fun transform<R>(
         transformer: (param1: T) -> param2: R
@@ -767,7 +775,7 @@ Return the variance of the column. The column has to be numerical.
 
 ??? quote "Stub code in `column.sdsstub`"
 
-    ```sds linenums="236"
+    ```sds linenums="241"
     @Pure
     fun variance() -> result1: Float
     ```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -21,9 +21,9 @@ nav:
     - Pipelines: pipeline-language/pipelines.md
     - Statements: pipeline-language/statements.md
     - Expressions: pipeline-language/expressions.md
-    - Comments: pipeline-language/comments.md
     - Segments: pipeline-language/segments.md
     - Types: pipeline-language/types.md
+    - Comments: pipeline-language/comments.md
     - Imports: pipeline-language/imports.md
   - API Reference: api/
   - Integrating New Libraries:

--- a/docs/pipeline-language/README.md
+++ b/docs/pipeline-language/README.md
@@ -14,9 +14,9 @@ This remaining documentation provides a detailed reference for the concepts of t
 - [Pipelines][pipelines] define the entry point of a program.
 - [Statements][statements] are the instructions that are executed as part of a program.
 - [Expressions][expressions] are computations that produce some value.
-- [Comments][comments] document the code.
 - [Segments][segments] encapsulate parts of program and make them reusable.
 - [Types][types] describe the kind of data that a declaration can hold.
+- [Comments][comments] document the code.
 - [Imports][imports] make declarations in other packages accessible.
 
 
@@ -24,7 +24,7 @@ This remaining documentation provides a detailed reference for the concepts of t
 [pipelines]: pipelines.md
 [statements]: statements.md
 [expressions]: expressions.md
-[comments]: comments.md
 [segments]: segments.md
 [types]: types.md
+[comments]: comments.md
 [imports]: imports.md

--- a/docs/pipeline-language/README.md
+++ b/docs/pipeline-language/README.md
@@ -16,7 +16,7 @@ This remaining documentation provides a detailed reference for the concepts of t
 - [Expressions][expressions] are computations that produce some value.
 - [Comments][comments] document the code.
 - [Segments][segments] encapsulate parts of program and make them reusable.
-- [Types][types] describe the kind of data that a declaration accepts.
+- [Types][types] describe the kind of data that a declaration can hold.
 - [Imports][imports] make declarations in other packages accessible.
 
 

--- a/docs/pipeline-language/comments.md
+++ b/docs/pipeline-language/comments.md
@@ -53,11 +53,13 @@ Documentation comments are special [block comments](#block-comments) that are us
 documentation is used in various places, e.g. when hovering over a declaration or one of its usage in VS Code. Here is
 an example:
 
-```sds
+```sds hl_lines="1 2 3"
 /**
  * This is a documentation comment.
  */
-class C
+segment sum(a: Int, b: Int) -> sum: Int {
+    yield sum = a + b;
+}
 ```
 
 They start with `#!sds /**` and end with `#!sds */`. There must be no spaces inside the delimiters. Documentation
@@ -74,7 +76,9 @@ Documentation comments support [Markdown](https://www.markdownguide.org/) to for
 /**
  * This is a documentation comment with **bold** and *italic* text.
  */
-class C
+segment sum(a: Int, b: Int) -> sum: Int {
+    yield sum = a + b;
+}
 ```
 
 ### Tags
@@ -90,44 +94,32 @@ an argument:
 /**
  * Computes the sum of two {@link Int}s.
  */
-fun sum(a: Int, b: Int): sum: Int
-```
-
-To point to a member of a [class][class] or an [enum variant][enum-variant] of an [enum][enum], write the name of the
-containing declaration followed by a dot and the name of the member or enum variant:
-
-```sds hl_lines="2"
-/**
- * To create a Configuration, use {@link Configuration.fromFile}.
- */
-class Configuration {
-
-    /**
-     * Creates a Configuration from a file.
-     */
-    fun fromFile(file: String) -> result: Configuration
+segment sum(a: Int, b: Int) -> sum: Int {
+    yield sum = a + b;
 }
 ```
 
 #### `@param`
 
-Use `@param` to document a [parameter][parameter] of a callable declaration. This tag takes the name of the parameter
-and its description as arguments. Since a callable can have multiple parameters, this tag can be used multiple times.
+Use `@param` to document a [parameter][parameter] of a [segment][segment]. This tag takes the name of the parameter
+and its description as arguments. Since a segment can have multiple parameters, this tag can be used multiple times.
 
 ```sds  hl_lines="4 5"
 /**
  * ...
  *
- * @param a The first integer.
- * @param b The second integer.
+ * @param a The first summand.
+ * @param b The second summand.
  */
-fun sum(a: Int, b: Int): sum: Int
+segment sum(a: Int, b: Int) -> sum: Int {
+    yield sum = a + b;
+}
 ```
 
 #### `@result`
 
-Use `@result` to document a [result][result] of a callable declaration. This tag takes the name of the result and its
-description as arguments. Since a callable can have multiple results, this tag can be used multiple times.
+Use `@result` to document a [result][result] of a [segment][segment]. This tag takes the name of the result and its
+description as arguments. Since a segment can have multiple results, this tag can be used multiple times.
 
 ```sds hl_lines="4"
 /**
@@ -135,8 +127,33 @@ description as arguments. Since a callable can have multiple results, this tag c
  *
  * @result sum The sum of `a` and `b`.
  */
-fun sum(a: Int, b: Int): sum: Int
+segment sum(a: Int, b: Int) -> sum: Int {
+    yield sum = a + b;
+}
 ```
+
+#### `@example`
+
+Use `@example` to provide an example of how to use a declaration. This tag takes the example code as an argument.
+
+```sds hl_lines="4 5 6 7"
+/**
+ * ...
+ *
+ * @example
+ * pipeline main {
+ *     val result = sum(1, 2);
+ * }
+ */
+segment sum(a: Int, b: Int) -> sum: Int {
+    yield sum = a + b;
+}
+```
+
+!!! warning "Limitation"
+
+    The example code must not contain any blank lines. Otherwise, only the code up to the first blank line is
+    considered.
 
 #### `@since`
 
@@ -149,16 +166,15 @@ used only once.
  *
  * @since 1.0.0
  */
-fun sum(a: Int, b: Int): sum: Int
+segment sum(a: Int, b: Int) -> sum: Int {
+    yield sum = a + b;
+}
 ```
 
-[^1]: Except [parameter][parameter], [results][result], and [type parameters][type-parameter], which are documented with
-the [`@param`](#param), [`@result`](#result), and [`@typeParam`](#typeparam) tags on the containing declaration,
-respectively.
+[^1]: Except [parameter][parameter] and [results][result], which are documented with the [`@param`](#param) and
+      [`@result`](#result) tags on the containing declaration, respectively.
 
-[class]: ../stub-language/classes.md
-[enum]: ../stub-language/enumerations.md
-[enum-variant]: ../stub-language/enumerations.md#enum-variants
+
+[segment]: segments.md
 [parameter]: segments.md#parameters
 [result]: segments.md#results
-[type-parameter]: ../stub-language/type-parameters.md

--- a/docs/src/lexer/safe_ds_lexer/_safe_ds_lexer.py
+++ b/docs/src/lexer/safe_ds_lexer/_safe_ds_lexer.py
@@ -72,7 +72,7 @@ qualified_name_regex = rf"({identifier_regex})(\.({identifier_regex}))*"
 
 
 class SafeDsLexer(RegexLexer):
-    name = "safe-ds"
+    name = "safe-ds-dev"
     aliases = [
         "Safe-DS",
         "safe-ds",

--- a/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
+++ b/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
@@ -49,6 +49,7 @@ import { SafeDsTypeComputer } from '../typing/safe-ds-type-computer.js';
 import { NamedType, Type, TypeParameterType } from '../typing/model.js';
 import path from 'path';
 import { addLinePrefix, removeLinePrefix } from '../../helpers/strings.js';
+import { expandToStringLF } from 'langium/generate';
 
 const INDENTATION = '    ';
 const LIB = path.join('packages', 'safe-ds-lang', 'lib', 'resources');
@@ -178,6 +179,12 @@ export class SafeDsMarkdownGenerator {
             });
         }
 
+        // Examples
+        const examples = this.renderExamples(node);
+        if (examples) {
+            result += `\n**Examples:**\n\n${examples}`;
+        }
+
         // Source code
         const sourceCode = this.renderSourceCode(node);
         if (sourceCode) {
@@ -194,6 +201,12 @@ export class SafeDsMarkdownGenerator {
         // Type
         const type = this.typeComputer.computeType(node.type);
         result += `\n**Type:** ${this.renderType(type, knownPaths)}\n`;
+
+        // Examples
+        const examples = this.renderExamples(node);
+        if (examples) {
+            result += `\n**Examples:**\n\n${examples}`;
+        }
 
         return result;
     }
@@ -219,6 +232,12 @@ export class SafeDsMarkdownGenerator {
         const typeParameters = this.renderTypeParameters(getTypeParameters(node), knownPaths);
         if (typeParameters) {
             result += `\n**Type parameters:**\n\n${typeParameters}`;
+        }
+
+        // Examples
+        const examples = this.renderExamples(node);
+        if (examples) {
+            result += `\n**Examples:**\n\n${examples}`;
         }
 
         // Source code
@@ -249,6 +268,12 @@ export class SafeDsMarkdownGenerator {
     private describeEnum(node: SdsEnum, level: number, knownPaths: Set<string>): string {
         let result = this.renderPreamble(node, level, 'enum');
 
+        // Examples
+        const examples = this.renderExamples(node);
+        if (examples) {
+            result += `\n**Examples:**\n\n${examples}`;
+        }
+
         // Source code
         const sourceCode = this.renderSourceCode(node);
         if (sourceCode) {
@@ -274,6 +299,12 @@ export class SafeDsMarkdownGenerator {
             result += `\n**Parameters:**\n\n${parameters}`;
         }
 
+        // Examples
+        const examples = this.renderExamples(node);
+        if (examples) {
+            result += `\n**Examples:**\n\n${examples}`;
+        }
+
         return result;
     }
 
@@ -297,6 +328,12 @@ export class SafeDsMarkdownGenerator {
         const typeParameters = this.renderTypeParameters(getTypeParameters(node), knownPaths);
         if (typeParameters) {
             result += `\n**Type parameters:**\n\n${typeParameters}`;
+        }
+
+        // Examples
+        const examples = this.renderExamples(node);
+        if (examples) {
+            result += `\n**Examples:**\n\n${examples}`;
         }
 
         // Source code
@@ -326,6 +363,12 @@ export class SafeDsMarkdownGenerator {
             }
         }
 
+        // Examples
+        const examples = this.renderExamples(node);
+        if (examples) {
+            result += `\n**Examples:**\n\n${examples}`;
+        }
+
         // Source code
         const sourceCode = this.renderSourceCode(node);
         if (sourceCode) {
@@ -349,6 +392,12 @@ export class SafeDsMarkdownGenerator {
         const results = this.renderResults(getResults(node.resultList), knownPaths);
         if (results) {
             result += `\n**Results:**\n\n${results}`;
+        }
+
+        // Examples
+        const examples = this.renderExamples(node);
+        if (examples) {
+            result += `\n**Examples:**\n\n${examples}`;
         }
 
         // Source code
@@ -507,6 +556,26 @@ export class SafeDsMarkdownGenerator {
         }
 
         return `\`#!sds ${type}\``;
+    }
+
+    private renderExamples(node: SdsDeclaration): string {
+        const examples = this.documentationProvider.getExamples(node);
+        if (isEmpty(examples)) {
+            return '';
+        }
+
+        const result = examples
+            .map(
+                (example) =>
+                    expandToStringLF`
+                        \`\`\`sds
+                        ${example}
+                        \`\`\`
+                    `,
+            )
+            .join('\n');
+
+        return result + '\n';
     }
 
     private renderSourceCode(node: SdsDeclaration): string {

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/data/tabular/containers/column.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/data/tabular/containers/column.sdsstub
@@ -8,6 +8,11 @@ from safeds.data.tabular.typing import ColumnType
  *
  * @param name The name of the column.
  * @param data The data.
+ *
+ * @example
+ * pipeline example {
+ *     val column = Column("test", [1, 2, 3]);
+ * }
  */
 class Column<out T = Any?>(
     name: String,

--- a/packages/safe-ds-lang/tests/language/builtins/builtinFilesCorrectness.test.ts
+++ b/packages/safe-ds-lang/tests/language/builtins/builtinFilesCorrectness.test.ts
@@ -46,6 +46,7 @@ describe('source code', () => {
             ) ?? [];
 
         if (!isEmpty(errorsOrWarnings)) {
+            // eslint-disable-next-line @typescript-eslint/no-throw-literal
             throw new InvalidBuiltinFileError(errorsOrWarnings, uri);
         }
     });
@@ -82,6 +83,7 @@ describe('examples', () => {
                 );
 
                 if (!isEmpty(errorsOrWarnings)) {
+                    // eslint-disable-next-line @typescript-eslint/no-throw-literal
                     throw new InvalidExampleError(errorsOrWarnings, uri, range);
                 }
             } finally {

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/SUMMARY.md
@@ -11,4 +11,5 @@ search:
                     - [MyAnnotation1](tests/generation/markdown/annotations/documented/MyAnnotation1.md)
                     - [MyAnnotation2](tests/generation/markdown/annotations/documented/MyAnnotation2.md)
                     - [MyAnnotation3](tests/generation/markdown/annotations/documented/MyAnnotation3.md)
+                    - [MyAnnotation4](tests/generation/markdown/annotations/documented/MyAnnotation4.md)
                     - [MyEnum1](tests/generation/markdown/annotations/documented/MyEnum1.md)

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/tests/generation/markdown/annotations/documented/MyAnnotation4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/tests/generation/markdown/annotations/documented/MyAnnotation4.md
@@ -1,0 +1,30 @@
+# `#!sds annotation` MyAnnotation4 {#tests.generation.markdown.annotations.documented.MyAnnotation4 data-toc-label='MyAnnotation4'}
+
+Description of MyAnnotation4.
+
+**Targets:**
+
+- `Annotation`
+- `Attribute`
+- `Class`
+- `Enum`
+- `EnumVariant`
+- `Function`
+- `Module`
+- `Parameter`
+- `Pipeline`
+- `Result`
+- `Segment`
+- `TypeParameter`
+
+**Examples:**
+
+```sds
+// Example of MyAnnotation4.
+```
+
+??? quote "Stub code in `main.sdsstub`"
+
+    ```sds linenums="29"
+    annotation MyAnnotation4
+    ```

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/main.sdsstub
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/main.sdsstub
@@ -20,3 +20,10 @@ annotation MyAnnotation2(param1: MyEnum1, param2: Float = 1.0)
 annotation MyAnnotation3
 
 enum MyEnum1
+
+/**
+ * Description of MyAnnotation4.
+ *
+ * @example // Example of MyAnnotation4.
+ */
+annotation MyAnnotation4

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/SUMMARY.md
@@ -14,3 +14,4 @@ search:
                     - [MyClass4](tests/generation/markdown/classes/documented/MyClass4.md)
                     - [MyClass5](tests/generation/markdown/classes/documented/MyClass5.md)
                     - [MyClass6](tests/generation/markdown/classes/documented/MyClass6.md)
+                    - [MyClass7](tests/generation/markdown/classes/documented/MyClass7.md)

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass6.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass6.md
@@ -16,6 +16,8 @@ Description of MyClass6.
             attr myAttribut4: Int
             /**
              * Description of myAttribute3.
+             *
+             * @example // Example of myAttribute3.
              */
             attr myAttribute3: Int
         }
@@ -57,7 +59,7 @@ Description of myFunction1.
 
 ??? quote "Stub code in `main.sdsstub`"
 
-    ```sds linenums="61"
+    ```sds linenums="63"
     @Pure fun myFunction1()
     ```
 
@@ -73,7 +75,7 @@ Description of myFunction2.
 
 ??? quote "Stub code in `main.sdsstub`"
 
-    ```sds linenums="65"
+    ```sds linenums="67"
     @Pure static fun myFunction2()
     ```
 
@@ -91,6 +93,8 @@ Description of MyClass7.
         attr myAttribut4: Int
         /**
          * Description of myAttribute3.
+         *
+         * @example // Example of myAttribute3.
          */
         attr myAttribute3: Int
     }
@@ -108,12 +112,18 @@ Description of myAttribute3.
 
 **Type:** `#!sds Int`
 
+**Examples:**
+
+```sds
+// Example of myAttribute3.
+```
+
 ## `#!sds enum` MyEnum1 {#tests.generation.markdown.classes.documented.MyClass6.MyEnum1 data-toc-label='MyEnum1'}
 
 Description of MyEnum1.
 
 ??? quote "Stub code in `main.sdsstub`"
 
-    ```sds linenums="56"
+    ```sds linenums="58"
     enum MyEnum1
     ```

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass7.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass7.md
@@ -1,0 +1,15 @@
+# `#!sds abstract class` MyClass7 {#tests.generation.markdown.classes.documented.MyClass7 data-toc-label='MyClass7'}
+
+Description of MyClass7.
+
+**Examples:**
+
+```sds
+// Example of MyClass7.
+```
+
+??? quote "Stub code in `main.sdsstub`"
+
+    ```sds linenums="84"
+    class MyClass7
+    ```

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/main.sdsstub
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/main.sdsstub
@@ -46,6 +46,8 @@ class MyClass6 {
         attr myAttribut4: Int
         /**
          * Description of myAttribute3.
+         *
+         * @example // Example of myAttribute3.
          */
         attr myAttribute3: Int
     }
@@ -73,3 +75,10 @@ class MyClass6 {
      */
     static attr myAttribute2: Float
 }
+
+/**
+ * Description of MyClass7.
+ *
+ * @example // Example of MyClass7.
+ */
+class MyClass7

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/SUMMARY.md
@@ -11,3 +11,4 @@ search:
                     - [MyClass1](tests/generation/markdown/enums/documented/MyClass1.md)
                     - [MyEnum1](tests/generation/markdown/enums/documented/MyEnum1.md)
                     - [MyEnum2](tests/generation/markdown/enums/documented/MyEnum2.md)
+                    - [MyEnum3](tests/generation/markdown/enums/documented/MyEnum3.md)

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyClass1.md
@@ -2,6 +2,6 @@
 
 ??? quote "Stub code in `main.sdsstub`"
 
-    ```sds linenums="26"
+    ```sds linenums="33"
     class MyClass1
     ```

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyEnum2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyEnum2.md
@@ -18,6 +18,13 @@ Description of MyEnum2.
          * Description of MyVariant1.
          */
         MyVariant1
+    
+        /**
+         * Description of MyVariant3.
+         *
+         * @example // Example of MyVariant3.
+         */
+        MyVariant3
     }
     ```
 
@@ -35,3 +42,13 @@ Description of MyVariant2.
 |------|------|-------------|---------|
 | `param1` | [`MyClass1`][tests.generation.markdown.enums.documented.MyClass1] | Description of param1. | - |
 | `param2` | `#!sds Float` | Description of param2. | `#!sds 1.0` |
+
+## MyVariant3 {#tests.generation.markdown.enums.documented.MyEnum2.MyVariant3 data-toc-label='MyVariant3'}
+
+Description of MyVariant3.
+
+**Examples:**
+
+```sds
+// Example of MyVariant3.
+```

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyEnum3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyEnum3.md
@@ -1,0 +1,15 @@
+# `#!sds enum` MyEnum3 {#tests.generation.markdown.enums.documented.MyEnum3 data-toc-label='MyEnum3'}
+
+Description of MyEnum3.
+
+**Examples:**
+
+```sds
+// Example of MyEnum3.
+```
+
+??? quote "Stub code in `main.sdsstub`"
+
+    ```sds linenums="40"
+    enum MyEnum3
+    ```

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/main.sdsstub
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/main.sdsstub
@@ -21,6 +21,20 @@ enum MyEnum2 {
      * Description of MyVariant1.
      */
     MyVariant1
+
+    /**
+     * Description of MyVariant3.
+     *
+     * @example // Example of MyVariant3.
+     */
+    MyVariant3
 }
 
 class MyClass1
+
+/**
+ * Description of MyEnum3.
+ *
+ * @example // Example of MyEnum3.
+ */
+enum MyEnum3

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/SUMMARY.md
@@ -13,3 +13,4 @@ search:
                     - [myFunction2](tests/generation/markdown/functions/documented/myFunction2.md)
                     - [myFunction3](tests/generation/markdown/functions/documented/myFunction3.md)
                     - [myFunction4](tests/generation/markdown/functions/documented/myFunction4.md)
+                    - [myFunction5](tests/generation/markdown/functions/documented/myFunction5.md)

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/MyClass1.md
@@ -2,6 +2,6 @@
 
 ??? quote "Stub code in `main.sdsstub`"
 
-    ```sds linenums="41"
+    ```sds linenums="49"
     class MyClass1
     ```

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/myFunction5.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/myFunction5.md
@@ -1,0 +1,15 @@
+# `#!sds fun` myFunction5 {#tests.generation.markdown.functions.documented.myFunction5 data-toc-label='myFunction5'}
+
+Description of myFunction5.
+
+**Examples:**
+
+```sds
+// Example of myFunction5.
+```
+
+??? quote "Stub code in `main.sdsstub`"
+
+    ```sds linenums="47"
+    fun myFunction5()
+    ```

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/main.sdsstub
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/main.sdsstub
@@ -38,4 +38,12 @@ fun myFunction3(param1: MyClass1, param2: Float = 1.0)
 @Pure
 fun myFunction4() -> (result1: MyClass1, result2: Float)
 
+/**
+ * Description of myFunction5.
+ *
+ * @example // Example of myFunction5.
+ */
+@Pure
+fun myFunction5()
+
 class MyClass1

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/SUMMARY.md
@@ -11,3 +11,4 @@ search:
                     - [MyClass](tests/generation/markdown/schemas/documented/MyClass.md)
                     - [MySchema1](tests/generation/markdown/schemas/documented/MySchema1.md)
                     - [MySchema2](tests/generation/markdown/schemas/documented/MySchema2.md)
+                    - [MySchema3](tests/generation/markdown/schemas/documented/MySchema3.md)

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/tests/generation/markdown/schemas/documented/MyClass.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/tests/generation/markdown/schemas/documented/MyClass.md
@@ -2,6 +2,6 @@
 
 ??? quote "Stub code in `main.sdsstub`"
 
-    ```sds linenums="18"
+    ```sds linenums="25"
     class MyClass
     ```

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/tests/generation/markdown/schemas/documented/MySchema3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/tests/generation/markdown/schemas/documented/MySchema3.md
@@ -1,0 +1,15 @@
+# `#!sds schema` MySchema3 {#tests.generation.markdown.schemas.documented.MySchema3 data-toc-label='MySchema3'}
+
+Description of MySchema3.
+
+**Examples:**
+
+```sds
+// Example of MySchema3.
+```
+
+??? quote "Stub code in `main.sdsstub`"
+
+    ```sds linenums="23"
+    schema MySchema3 {}
+    ```

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/main.sdsstub
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/main.sdsstub
@@ -15,4 +15,11 @@ schema MySchema2 {
     "column2": Int,
 }
 
+/**
+ * Description of MySchema3.
+ *
+ * @example // Example of MySchema3.
+ */
+schema MySchema3 {}
+
 class MyClass

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/SUMMARY.md
@@ -13,3 +13,4 @@ search:
                     - [mySegment3](tests/generation/markdown/segments/documented/mySegment3.md)
                     - [mySegment4](tests/generation/markdown/segments/documented/mySegment4.md)
                     - [mySegment5](tests/generation/markdown/segments/documented/mySegment5.md)
+                    - [mySegment6](tests/generation/markdown/segments/documented/mySegment6.md)

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment4.md
@@ -1,6 +1,6 @@
 # `#!sds segment` mySegment4 {#tests.generation.markdown.segments.documented.mySegment4 data-toc-label='mySegment4'}
 
-Description of mySegment3.
+Description of mySegment4.
 
 **Parameters:**
 

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment5.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment5.md
@@ -1,6 +1,6 @@
 # `#!sds segment` mySegment5 {#tests.generation.markdown.segments.documented.mySegment5 data-toc-label='mySegment5'}
 
-Description of mySegment4.
+Description of mySegment5.
 
 **Results:**
 

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment6.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment6.md
@@ -1,0 +1,15 @@
+# `#!sds segment` mySegment6 {#tests.generation.markdown.segments.documented.mySegment6 data-toc-label='mySegment6'}
+
+Description of mySegment6.
+
+**Examples:**
+
+```sds
+// Example of mySegment6.
+```
+
+??? quote "Implementation code in `main.sds`"
+
+    ```sds linenums="42"
+    segment mySegment6() {}
+    ```

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/main.sds
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/main.sds
@@ -16,7 +16,7 @@ private segment mySegment2() {}
 internal segment mySegment3() {}
 
 /**
- * Description of mySegment3.
+ * Description of mySegment4.
  *
  * @param param1 Description of param1.
  * @param param2 Description of param2.
@@ -24,7 +24,7 @@ internal segment mySegment3() {}
 segment mySegment4(param1: MyClass1, param2: Float = 1.0) {}
 
 /**
- * Description of mySegment4.
+ * Description of mySegment5.
  *
  * @result result1 Description of result1.
  * @result result2 Description of result2.
@@ -33,3 +33,10 @@ segment mySegment5() -> (result1: MyClass1, result2: Float) {
     yield result1 = MyClass1();
     yield result2 = 2.0;
 }
+
+/**
+ * Description of mySegment6.
+ *
+ * @example // Example of mySegment6.
+ */
+segment mySegment6() {}

--- a/packages/safe-ds-vscode/README.md
+++ b/packages/safe-ds-vscode/README.md
@@ -20,7 +20,7 @@ To run Safe-DS programs, you also need the [Safe-DS Runner](https://github.com/S
 2. **Open VS Code**.
 3. **Open the command palette** (Menu bar > View > Command Palette).
 4. **Type `Install the Safe-DS Runner`**.
-5. **Press ++enter++**. Installation may take a few minutes, since it downloads and installs several large libraries
+5. **Press Enter**. Installation may take a few minutes, since it downloads and installs several large libraries
    like PyTorch.
 
 ## Documentation

--- a/packages/safe-ds-vscode/syntaxes/safe-ds-dev.tmLanguage.json
+++ b/packages/safe-ds-vscode/syntaxes/safe-ds-dev.tmLanguage.json
@@ -13,6 +13,10 @@
         {
             "name": "storage.modifier.safe-ds-dev",
             "match": "\\b(const|in|internal|out|private|static)\\b"
+        },
+        {
+            "name": "keyword.operator.expression.safe-ds-dev",
+            "match": "\\b(and|not|or|sub)\\b"
         }
     ]
 }

--- a/packages/safe-ds-vscode/syntaxes/safe-ds-stub.tmLanguage.json
+++ b/packages/safe-ds-vscode/syntaxes/safe-ds-stub.tmLanguage.json
@@ -13,6 +13,10 @@
         {
             "name": "storage.modifier.safe-ds-stub",
             "match": "\\b(const|in|out|static)\\b"
+        },
+        {
+            "name": "keyword.operator.expression.safe-ds-stub",
+            "match": "\\b(and|not|or|sub)\\b"
         }
     ]
 }

--- a/packages/safe-ds-vscode/syntaxes/safe-ds.tmLanguage.json
+++ b/packages/safe-ds-vscode/syntaxes/safe-ds.tmLanguage.json
@@ -14,6 +14,10 @@
         {
             "name": "storage.modifier.safe-ds",
             "match": "\\b(const|internal|private)\\b"
+        },
+        {
+            "name": "keyword.operator.expression.safe-ds",
+            "match": "\\b(and|not|or)\\b"
         }
     ],
     "repository": {
@@ -26,10 +30,6 @@
                 {
                     "name": "constant.language.safe-ds",
                     "match": "\\b(false|null|true|unknown)\\b"
-                },
-                {
-                    "name": "keyword.operator.expression.safe-ds",
-                    "match": "\\b(and|not|or)\\b"
                 },
                 {
                     "name": "keyword.other.safe-ds",

--- a/packages/safe-ds-vscode/syntaxes/safe-ds.tmLanguage.json
+++ b/packages/safe-ds-vscode/syntaxes/safe-ds.tmLanguage.json
@@ -78,6 +78,10 @@
                     "end": "\\*/",
                     "patterns": [
                         {
+                            "match": "(@example)\\b",
+                            "name": "keyword.other.safe-ds"
+                        },
+                        {
                             "match": "(@param|@result)\\s+([_a-zA-Z][_a-zA-Z0-9]*)?",
                             "captures": {
                                 "1": {


### PR DESCRIPTION
Closes partially #1027

### Summary of Changes

Documentation comments can now contain an `@example` tag. Any text in the following Markdown paragraph is treated as Safe-DS code. It is shown in tooltips and included in the generated API documentation. 

There are tests to ensure the correctness of examples in the builtin stubs.
