### PR TITLE
fix: substitute type parameters for lambda parameters

### DIFF
--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -144,13 +144,26 @@ export class SafeDsTypeComputer {
      * simplified as much as possible.
      */
     computeType(node: AstNode | undefined, substitutions: TypeParameterSubstitutions = NO_SUBSTITUTIONS): Type {
+        return this.computeTypeWithRecursionCheck(node, {}, substitutions);
+    }
+
+    computeTypeWithRecursionCheck(
+        node: AstNode | undefined,
+        state: ComputeTypeState,
+        substitutions: TypeParameterSubstitutions = NO_SUBSTITUTIONS,
+    ): Type {
         if (!node) {
             return UnknownType;
         }
 
+        // Don't cache the result if we are inferring type of lambda parameter from context
+        if (state?.computingSubstitutionsForCall) {
+            return this.doComputeTypeWithRecursionCheck(node, state).simplify();
+        }
+
         // Ignore type parameter substitutions for caching
         const unsubstitutedType = this.nodeTypeCache.get(this.getNodeId(node), () =>
-            this.doComputeType(node).simplify(),
+            this.doComputeTypeWithRecursionCheck(node, {}).simplify(),
         );
         if (isEmpty(substitutions)) {
             return unsubstitutedType;
@@ -169,23 +182,23 @@ export class SafeDsTypeComputer {
         return `${documentUri}~${nodePath}`;
     }
 
-    private doComputeType(node: AstNode): Type {
+    private doComputeTypeWithRecursionCheck(node: AstNode | undefined, state: ComputeTypeState): Type {
         if (isSdsAssignee(node)) {
-            return this.computeTypeOfAssignee(node);
+            return this.computeTypeOfAssignee(node, state);
         } else if (isSdsDeclaration(node)) {
-            return this.computeTypeOfDeclaration(node);
+            return this.computeTypeOfDeclaration(node, state);
         } else if (isSdsExpression(node)) {
-            return this.computeTypeOfExpression(node);
+            return this.computeTypeOfExpression(node, state);
         } else if (isSdsType(node)) {
-            return this.computeTypeOfType(node);
+            return this.computeTypeOfType(node, state);
         } else if (isSdsTypeArgument(node)) {
-            return this.computeTypeOfType(node.value);
+            return this.computeTypeOfType(node.value, state);
         } /* c8 ignore start */ else {
             return UnknownType;
         } /* c8 ignore stop */
     }
 
-    private computeTypeOfAssignee(node: SdsAssignee): Type {
+    private computeTypeOfAssignee(node: SdsAssignee, state: ComputeTypeState): Type {
         const containingAssignment = AstUtils.getContainerOfType(node, isSdsAssignment);
         if (!containingAssignment) {
             /* c8 ignore next 2 */
@@ -193,7 +206,7 @@ export class SafeDsTypeComputer {
         }
 
         const assigneePosition = node.$containerIndex ?? -1;
-        const expressionType = this.computeType(containingAssignment?.expression);
+        const expressionType = this.computeTypeWithRecursionCheck(containingAssignment?.expression, state);
         if (expressionType instanceof NamedTupleType) {
             return expressionType.getTypeOfEntryByIndex(assigneePosition);
         } else if (assigneePosition === 0) {
@@ -203,10 +216,10 @@ export class SafeDsTypeComputer {
         return UnknownType;
     }
 
-    private computeTypeOfDeclaration(node: SdsDeclaration): Type {
+    private computeTypeOfDeclaration(node: SdsDeclaration, state: ComputeTypeState): Type {
         if (isSdsAnnotation(node)) {
             const parameterEntries = getParameters(node).map(
-                (it) => new NamedTupleEntry(it, it.name, this.computeType(it.type)),
+                (it) => new NamedTupleEntry(it, it.name, this.computeTypeWithRecursionCheck(it.type, state)),
             );
 
             return this.factory.createCallableType(
@@ -216,7 +229,7 @@ export class SafeDsTypeComputer {
                 this.factory.createNamedTupleType(),
             );
         } else if (isSdsAttribute(node)) {
-            return this.computeType(node.type);
+            return this.computeTypeWithRecursionCheck(node.type, state);
         } else if (isSdsClass(node)) {
             return this.factory.createClassType(node, NO_SUBSTITUTIONS, false);
         } else if (isSdsEnum(node)) {
@@ -224,17 +237,17 @@ export class SafeDsTypeComputer {
         } else if (isSdsEnumVariant(node)) {
             return this.factory.createEnumVariantType(node, false);
         } else if (isSdsFunction(node)) {
-            return this.computeTypeOfCallableWithManifestTypes(node);
+            return this.computeTypeOfCallableWithManifestTypes(node, state);
         } else if (isSdsParameter(node)) {
-            return this.computeTypeOfParameter(node);
+            return this.computeTypeOfParameter(node, state);
         } else if (isSdsPipeline(node)) {
             return UnknownType;
         } else if (isSdsResult(node)) {
-            return this.computeType(node.type);
+            return this.computeTypeWithRecursionCheck(node.type, state);
         } else if (isSdsSchema(node)) {
             return UnknownType;
         } else if (isSdsSegment(node)) {
-            return this.computeTypeOfCallableWithManifestTypes(node);
+            return this.computeTypeOfCallableWithManifestTypes(node, state);
         } else if (isSdsTypeParameter(node)) {
             return this.factory.createTypeParameterType(node, false);
         } /* c8 ignore start */ else {
@@ -242,12 +255,15 @@ export class SafeDsTypeComputer {
         } /* c8 ignore stop */
     }
 
-    private computeTypeOfCallableWithManifestTypes(node: SdsFunction | SdsSegment | SdsCallableType): Type {
+    private computeTypeOfCallableWithManifestTypes(
+        node: SdsFunction | SdsSegment | SdsCallableType,
+        state: ComputeTypeState,
+    ): Type {
         const parameterEntries = getParameters(node).map(
-            (it) => new NamedTupleEntry(it, it.name, this.computeType(it.type)),
+            (it) => new NamedTupleEntry(it, it.name, this.computeTypeWithRecursionCheck(it.type, state)),
         );
         const resultEntries = getResults(node.resultList).map(
-            (it) => new NamedTupleEntry(it, it.name, this.computeType(it.type)),
+            (it) => new NamedTupleEntry(it, it.name, this.computeTypeWithRecursionCheck(it.type, state)),
         );
 
         return this.factory.createCallableType(
@@ -258,15 +274,15 @@ export class SafeDsTypeComputer {
         );
     }
 
-    private computeTypeOfParameter(node: SdsParameter): Type {
+    private computeTypeOfParameter(node: SdsParameter, state: ComputeTypeState): Type {
         // Manifest type
         if (node.type) {
-            const type = this.computeType(node.type);
+            const type = this.computeTypeWithRecursionCheck(node.type, state);
             return this.rememberParameterInCallableType(node, type);
         }
 
         // Infer type from context
-        const contextType = this.computeTypeOfParameterContext(node);
+        const contextType = this.computeTypeOfParameterContext(node, state);
         if (!(contextType instanceof CallableType)) {
             return UnknownType;
         }
@@ -276,7 +292,7 @@ export class SafeDsTypeComputer {
         return this.rememberParameterInCallableType(node, type);
     }
 
-    private computeTypeOfParameterContext(node: SdsParameter): Type {
+    private computeTypeOfParameterContext(node: SdsParameter, state: ComputeTypeState): Type {
         const containingCallable = AstUtils.getContainerOfType(node, isSdsCallable);
         if (!isSdsLambda(containingCallable)) {
             return UnknownType;
@@ -290,12 +306,27 @@ export class SafeDsTypeComputer {
             if (!parameter) {
                 return UnknownType;
             }
-            return this.computeType(parameter?.type);
+
+            // Don't continue if we are already computing substitutions for a call. Otherwise, we would end up in an
+            // infinite loop.
+            const parameterType = this.computeTypeWithRecursionCheck(parameter, state);
+            if (state?.computingSubstitutionsForCall) {
+                return parameterType;
+            }
+
+            // Compute substitutions for containing call
+            const containingCall = AstUtils.getContainerOfType(containerOfLambda, isSdsCall);
+            if (!containingCall) {
+                return parameterType;
+            }
+
+            const substitutions = this.computeSubstitutionsForCall(containingCall);
+            return parameterType.substituteTypeParameters(substitutions);
         }
 
         // Lambda passed as default value
         if (isSdsParameter(containerOfLambda)) {
-            return this.computeType(containerOfLambda);
+            return this.computeTypeWithRecursionCheck(containerOfLambda, state);
         }
 
         // Yielded lambda
@@ -304,7 +335,7 @@ export class SafeDsTypeComputer {
             if (!isSdsYield(firstAssignee)) {
                 return UnknownType;
             }
-            return this.computeType(firstAssignee.result?.ref);
+            return this.computeTypeWithRecursionCheck(firstAssignee.result?.ref, state);
         }
 
         return UnknownType;
@@ -318,10 +349,10 @@ export class SafeDsTypeComputer {
         }
     }
 
-    private computeTypeOfExpression(node: SdsExpression): Type {
+    private computeTypeOfExpression(node: SdsExpression, state: ComputeTypeState): Type {
         // Type cast
         if (isSdsTypeCast(node)) {
-            return this.computeType(node.type);
+            return this.computeTypeWithRecursionCheck(node.type, state);
         }
 
         // Partial evaluation (definitely handles SdsBoolean, SdsFloat, SdsInt, SdsNull, and SdsString)
@@ -332,10 +363,14 @@ export class SafeDsTypeComputer {
 
         // Terminal cases
         if (isSdsList(node)) {
-            const elementType = this.lowestCommonSupertype(node.elements.map((it) => this.computeType(it)));
+            const elementType = this.lowestCommonSupertype(
+                node.elements.map((it) => this.computeTypeWithRecursionCheck(it, state)),
+            );
             return this.coreTypes.List(elementType);
         } else if (isSdsMap(node)) {
-            let keyType = this.lowestCommonSupertype(node.entries.map((it) => this.computeType(it.key)));
+            let keyType = this.lowestCommonSupertype(
+                node.entries.map((it) => this.computeTypeWithRecursionCheck(it.key, state)),
+            );
 
             // Keeping literal types for keys is too strict: We would otherwise infer the key type of `{"a": 1, "b": 2}`
             // as `Literal<"a", "b">`. But then we would be unable to pass an unknown `String` as the key in an indexed
@@ -343,7 +378,9 @@ export class SafeDsTypeComputer {
             // evaluator.
             keyType = this.computeClassTypeForLiteralType(keyType);
 
-            const valueType = this.lowestCommonSupertype(node.entries.map((it) => this.computeType(it.value)));
+            const valueType = this.lowestCommonSupertype(
+                node.entries.map((it) => this.computeTypeWithRecursionCheck(it.value, state)),
+            );
             return this.coreTypes.Map(keyType, valueType);
         } else if (isSdsTemplateString(node)) {
             return this.coreTypes.String;
@@ -353,15 +390,15 @@ export class SafeDsTypeComputer {
 
         // Recursive cases
         else if (isSdsArgument(node)) {
-            return this.computeType(node.value);
+            return this.computeTypeWithRecursionCheck(node.value, state);
         } else if (isSdsBlockLambda(node)) {
-            return this.computeTypeOfBlockLambda(node);
+            return this.computeTypeOfBlockLambda(node, state);
         } else if (isSdsCall(node)) {
-            return this.computeTypeOfCall(node);
+            return this.computeTypeOfCall(node, state);
         } else if (isSdsExpressionLambda(node)) {
-            return this.computeTypeOfExpressionLambda(node);
+            return this.computeTypeOfExpressionLambda(node, state);
         } else if (isSdsIndexedAccess(node)) {
-            return this.computeTypeOfIndexedAccess(node);
+            return this.computeTypeOfIndexedAccess(node, state);
         } else if (isSdsInfixOperation(node)) {
             switch (node.operator) {
                 // Boolean operators
@@ -388,11 +425,11 @@ export class SafeDsTypeComputer {
                 case '-':
                 case '*':
                 case '/':
-                    return this.computeTypeOfArithmeticInfixOperation(node);
+                    return this.computeTypeOfArithmeticInfixOperation(node, state);
 
                 // Elvis operator
                 case '?:':
-                    return this.computeTypeOfElvisOperation(node);
+                    return this.computeTypeOfElvisOperation(node, state);
 
                 // Unknown operator
                 /* c8 ignore next 2 */
@@ -400,15 +437,15 @@ export class SafeDsTypeComputer {
                     return UnknownType;
             }
         } else if (isSdsMemberAccess(node)) {
-            return this.computeTypeOfMemberAccess(node);
+            return this.computeTypeOfMemberAccess(node, state);
         } else if (isSdsParenthesizedExpression(node)) {
-            return this.computeType(node.expression);
+            return this.computeTypeWithRecursionCheck(node.expression, state);
         } else if (isSdsPrefixOperation(node)) {
             switch (node.operator) {
                 case 'not':
                     return this.coreTypes.Boolean;
                 case '-':
-                    return this.computeTypeOfArithmeticPrefixOperation(node);
+                    return this.computeTypeOfArithmeticPrefixOperation(node, state);
 
                 // Unknown operator
                 /* c8 ignore next 2 */
@@ -416,18 +453,18 @@ export class SafeDsTypeComputer {
                     return UnknownType;
             }
         } else if (isSdsReference(node)) {
-            return this.computeTypeOfReference(node);
+            return this.computeTypeOfReference(node, state);
         } /* c8 ignore start */ else {
             return UnknownType;
         } /* c8 ignore stop */
     }
 
-    private computeTypeOfBlockLambda(node: SdsBlockLambda): Type {
+    private computeTypeOfBlockLambda(node: SdsBlockLambda, state: ComputeTypeState): Type {
         const parameterEntries = getParameters(node).map(
-            (it) => new NamedTupleEntry(it, it.name, this.computeType(it)),
+            (it) => new NamedTupleEntry(it, it.name, this.computeTypeWithRecursionCheck(it, state)),
         );
         const resultEntries = streamBlockLambdaResults(node)
-            .map((it) => new NamedTupleEntry(it, it.name, this.computeType(it)))
+            .map((it) => new NamedTupleEntry(it, it.name, this.computeTypeWithRecursionCheck(it, state)))
             .toArray();
 
         return this.factory.createCallableType(
@@ -438,8 +475,8 @@ export class SafeDsTypeComputer {
         );
     }
 
-    private computeTypeOfCall(node: SdsCall): Type {
-        const receiverType = this.computeType(node.receiver);
+    private computeTypeOfCall(node: SdsCall, state: ComputeTypeState): Type {
+        const receiverType = this.computeTypeWithRecursionCheck(node.receiver, state);
         const nonNullableReceiverType = this.computeNonNullableType(receiverType);
         let result: Type = UnknownType;
 
@@ -475,12 +512,16 @@ export class SafeDsTypeComputer {
         return result.withExplicitNullability(receiverType.isExplicitlyNullable && node.isNullSafe);
     }
 
-    private computeTypeOfExpressionLambda(node: SdsExpressionLambda): Type {
+    private computeTypeOfExpressionLambda(node: SdsExpressionLambda, state: ComputeTypeState): Type {
         const parameterEntries = getParameters(node).map(
-            (it) => new NamedTupleEntry(it, it.name, this.computeType(it)),
+            (it) => new NamedTupleEntry(it, it.name, this.computeTypeWithRecursionCheck(it, state)),
         );
         const resultEntries = [
-            new NamedTupleEntry<SdsAbstractResult>(undefined, 'result', this.computeType(node.result)),
+            new NamedTupleEntry<SdsAbstractResult>(
+                undefined,
+                'result',
+                this.computeTypeWithRecursionCheck(node.result, state),
+            ),
         ];
 
         return this.factory.createCallableType(
@@ -491,8 +532,8 @@ export class SafeDsTypeComputer {
         );
     }
 
-    private computeTypeOfIndexedAccess(node: SdsIndexedAccess): Type {
-        const receiverType = this.computeType(node.receiver);
+    private computeTypeOfIndexedAccess(node: SdsIndexedAccess, state: ComputeTypeState): Type {
+        const receiverType = this.computeTypeWithRecursionCheck(node.receiver, state);
         if (!(receiverType instanceof ClassType) && !(receiverType instanceof TypeParameterType)) {
             return UnknownType;
         }
@@ -516,9 +557,9 @@ export class SafeDsTypeComputer {
         return UnknownType;
     }
 
-    private computeTypeOfArithmeticInfixOperation(node: SdsInfixOperation): Type {
-        const leftOperandType = this.computeType(node.leftOperand);
-        const rightOperandType = this.computeType(node.rightOperand);
+    private computeTypeOfArithmeticInfixOperation(node: SdsInfixOperation, state: ComputeTypeState): Type {
+        const leftOperandType = this.computeTypeWithRecursionCheck(node.leftOperand, state);
+        const rightOperandType = this.computeTypeWithRecursionCheck(node.rightOperand, state);
 
         if (
             this.typeChecker.isSubtypeOf(leftOperandType, this.coreTypes.Int) &&
@@ -530,18 +571,18 @@ export class SafeDsTypeComputer {
         }
     }
 
-    private computeTypeOfElvisOperation(node: SdsInfixOperation): Type {
-        const leftOperandType = this.computeType(node.leftOperand);
+    private computeTypeOfElvisOperation(node: SdsInfixOperation, state: ComputeTypeState): Type {
+        const leftOperandType = this.computeTypeWithRecursionCheck(node.leftOperand, state);
         if (leftOperandType.isExplicitlyNullable) {
-            const rightOperandType = this.computeType(node.rightOperand);
+            const rightOperandType = this.computeTypeWithRecursionCheck(node.rightOperand, state);
             return this.lowestCommonSupertype([leftOperandType.withExplicitNullability(false), rightOperandType]);
         } else {
             return leftOperandType;
         }
     }
 
-    private computeTypeOfMemberAccess(node: SdsMemberAccess) {
-        const memberType = this.computeType(node.member);
+    private computeTypeOfMemberAccess(node: SdsMemberAccess, state: ComputeTypeState) {
+        const memberType = this.computeTypeWithRecursionCheck(node.member, state);
 
         // A member access of an enum variant without parameters always yields an instance, even if it is not in a call
         if (memberType instanceof StaticType && !isSdsCall(node.$container)) {
@@ -552,18 +593,12 @@ export class SafeDsTypeComputer {
             }
         }
 
-        const receiverType = this.computeType(node.receiver);
+        const receiverType = this.computeTypeWithRecursionCheck(node.receiver, state);
         let result: Type = memberType;
 
-        // Substitute type parameters (must also work for inherited members)
-        if (receiverType instanceof ClassType) {
-            const classContainingMember = AstUtils.getContainerOfType(node.member?.target.ref, isSdsClass);
-            const typeContainingMember = this.computeMatchingSupertype(receiverType, classContainingMember);
-
-            if (typeContainingMember) {
-                result = result.substituteTypeParameters(typeContainingMember.substitutions);
-            }
-        }
+        // Substitute type parameters
+        const substitutions = this.computeSubstitutionsForMemberAccess(node);
+        result = result.substituteTypeParameters(substitutions);
 
         // Update nullability
         return result.withExplicitNullability(
@@ -571,8 +606,8 @@ export class SafeDsTypeComputer {
         );
     }
 
-    private computeTypeOfArithmeticPrefixOperation(node: SdsPrefixOperation): Type {
-        const operandType = this.computeType(node.operand);
+    private computeTypeOfArithmeticPrefixOperation(node: SdsPrefixOperation, state: ComputeTypeState): Type {
+        const operandType = this.computeTypeWithRecursionCheck(node.operand, state);
 
         if (this.typeChecker.isSubtypeOf(operandType, this.coreTypes.Int)) {
             return this.coreTypes.Int;
@@ -581,9 +616,9 @@ export class SafeDsTypeComputer {
         }
     }
 
-    private computeTypeOfReference(node: SdsReference): Type {
+    private computeTypeOfReference(node: SdsReference, state: ComputeTypeState): Type {
         const target = node.target.ref;
-        const instanceType = this.computeType(target);
+        const instanceType = this.computeTypeWithRecursionCheck(target, state);
 
         if (isSdsNamedTypeDeclaration(target) && instanceType instanceof NamedType) {
             return this.factory.createStaticType(instanceType.withExplicitNullability(false));
@@ -592,19 +627,19 @@ export class SafeDsTypeComputer {
         }
     }
 
-    private computeTypeOfType(node: SdsType): Type {
+    private computeTypeOfType(node: SdsType, state: ComputeTypeState): Type {
         if (isSdsCallableType(node)) {
-            return this.computeTypeOfCallableWithManifestTypes(node);
+            return this.computeTypeOfCallableWithManifestTypes(node, state);
         } else if (isSdsLiteralType(node)) {
             return this.computeTypeOfLiteralType(node);
         } else if (isSdsMemberType(node)) {
-            return this.computeType(node.member);
+            return this.computeTypeWithRecursionCheck(node.member, state);
         } else if (isSdsNamedType(node)) {
-            return this.computeTypeOfNamedType(node);
+            return this.computeTypeOfNamedType(node, state);
         } else if (isSdsUnionType(node)) {
             const typeArguments = getTypeArguments(node.typeArgumentList);
             return this.factory.createUnionType(
-                ...typeArguments.map((typeArgument) => this.computeType(typeArgument.value)),
+                ...typeArguments.map((typeArgument) => this.computeTypeWithRecursionCheck(typeArgument.value, state)),
             );
         } else if (isSdsUnknownType(node)) {
             return UnknownType;
@@ -622,8 +657,11 @@ export class SafeDsTypeComputer {
         } /* c8 ignore stop */
     }
 
-    private computeTypeOfNamedType(node: SdsNamedType) {
-        const unparameterizedType = this.computeType(node.declaration?.ref).withExplicitNullability(node.isNullable);
+    private computeTypeOfNamedType(node: SdsNamedType, state: ComputeTypeState) {
+        const unparameterizedType = this.computeTypeWithRecursionCheck(
+            node.declaration?.ref,
+            state,
+        ).withExplicitNullability(node.isNullable);
         if (!(unparameterizedType instanceof ClassType)) {
             return unparameterizedType;
         }
@@ -754,10 +792,16 @@ export class SafeDsTypeComputer {
      * @returns The computed substitutions for the type parameters of the callable.
      */
     computeSubstitutionsForCall(call: SdsCall): TypeParameterSubstitutions {
+        // Compute substitutions for member access
+        const substitutionsFromReceiver = isSdsMemberAccess(call.receiver)
+            ? this.computeSubstitutionsForMemberAccess(call.receiver)
+            : NO_SUBSTITUTIONS;
+
+        // Compute substitutions for arguments
         const callable = this.nodeMapper.callToCallable(call);
         const typeParameters = getTypeParameters(callable);
         if (isEmpty(typeParameters)) {
-            return NO_SUBSTITUTIONS;
+            return substitutionsFromReceiver;
         }
 
         const parameters = getParameters(callable);
@@ -766,10 +810,19 @@ export class SafeDsTypeComputer {
         const parametersToArguments = this.nodeMapper.parametersToArguments(parameters, args);
         const parameterTypesToArgumentTypes: [Type, Type][] = parameters.map((parameter) => {
             const argument = parametersToArguments.get(parameter);
-            return [this.computeType(parameter.type), this.computeType(argument?.value ?? parameter.defaultValue)];
+            return [
+                this.computeType(parameter.type),
+                this.computeTypeWithRecursionCheck(argument?.value ?? parameter.defaultValue, {
+                    computingSubstitutionsForCall: true,
+                }),
+            ];
         });
+        const substitutionsFromArguments = this.computeSubstitutionsForArguments(
+            typeParameters,
+            parameterTypesToArgumentTypes,
+        );
 
-        return this.computeSubstitutionsForArguments(typeParameters, parameterTypesToArgumentTypes);
+        return new Map([...substitutionsFromReceiver, ...substitutionsFromArguments]);
     }
 
     /**
@@ -799,6 +852,21 @@ export class SafeDsTypeComputer {
         }
 
         return this.computeSubstitutionsForArguments(ownTypeParameters, ownTypesToOverriddenTypes);
+    }
+
+    private computeSubstitutionsForMemberAccess(node: SdsMemberAccess): TypeParameterSubstitutions {
+        const receiverType = this.computeType(node.receiver);
+        if (receiverType instanceof ClassType) {
+            // Must also work for inherited members
+            const classContainingMember = AstUtils.getContainerOfType(node.member?.target.ref, isSdsClass);
+            const typeContainingMember = this.computeMatchingSupertype(receiverType, classContainingMember);
+
+            if (typeContainingMember) {
+                return typeContainingMember.substitutions;
+            }
+        }
+
+        return NO_SUBSTITUTIONS;
     }
 
     private computeSubstitutionsForNamedType(node: SdsNamedType, clazz: SdsClass): TypeParameterSubstitutions {
@@ -1607,6 +1675,18 @@ interface ComputeUpperBoundOptions {
      * for the type parameter types recursively.
      */
     stopAtTypeParameterType?: boolean;
+}
+
+interface ComputeTypeState {
+    /**
+     * Indicates that we are currently computing substitutions for a call. This is used to avoid infinite recursion:
+     *
+     * 1. The type of the lambda parameter gets inferred from the context. If the lambda is passed as an argument, the
+     *    result might include type parameters.
+     * 2. Substitutions are computed for the type parameters from the context (i.e. the call). This involves
+     *    computing the type of the lambda parameter.
+     */
+    computingSubstitutionsForCall?: boolean;
 }
 
 interface ComputeSubstitutionsForParametersState {

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -317,6 +317,7 @@ export class SafeDsTypeComputer {
             // Compute substitutions for containing call
             const containingCall = AstUtils.getContainerOfType(containerOfLambda, isSdsCall);
             if (!containingCall) {
+                /* c8 ignore next 2 */
                 return parameterType;
             }
 

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of block lambdas/that are passed as arguments/with type parameters.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of block lambdas/that are passed as arguments/with type parameters.sdsdev
@@ -1,0 +1,22 @@
+package tests.typing.declarations.parameters.ofBlockLambdas.thatArePassedAsArguments.withTypeParameters
+
+class MySuperclass<T> {
+    @Pure fun myInheritedMethod(callback: (p: T) -> ())
+}
+
+class MyClass<T>(param: T) sub MySuperclass<T> {
+    @Pure fun myMethod(callback: (p: T) -> ())
+}
+
+@Pure fun myFunction<T>(p: T, callback: (p: T) -> ())
+
+segment mySegment() {
+    // $TEST$ serialization literal<1>
+    MyClass(1).myMethod((»p«) {});
+
+    // $TEST$ serialization literal<1>
+    MyClass(1).myInheritedMethod((»p«) {});
+
+    // $TEST$ serialization literal<1>
+    myFunction(1, (»p«) {});
+}

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of expression lambdas/that are passed as arguments/with type parameters.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of expression lambdas/that are passed as arguments/with type parameters.sdsdev
@@ -1,0 +1,22 @@
+package tests.typing.declarations.parameters.ofExpressionLambdas.thatArePassedAsArguments.withTypeParameters
+
+class MySuperclass<T> {
+    @Pure fun myInheritedMethod(callback: (p: T) -> ())
+}
+
+class MyClass<T>(param: T) sub MySuperclass<T> {
+    @Pure fun myMethod(callback: (p: T) -> ())
+}
+
+@Pure fun myFunction<T>(p: T, callback: (p: T) -> ())
+
+segment mySegment() {
+    // $TEST$ serialization literal<1>
+    MyClass(1).myMethod((»p«) -> "");
+
+    // $TEST$ serialization literal<1>
+    MyClass(1).myInheritedMethod((»p«) -> "");
+
+    // $TEST$ serialization literal<1>
+    myFunction(1, (»p«) -> "");
+}

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/block lambdas/that are passed as arguments/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/block lambdas/that are passed as arguments/main.sdsdev
@@ -1,9 +1,9 @@
 package tests.typing.expressions.blockLambdas.thatArePassedAsArguments
 
-fun higherOrderFunction1(param: (p: String) -> (r: Int, s: String))
-fun higherOrderFunction2(param: () -> ())
-fun normalFunction(param: Int)
-fun parameterlessFunction()
+@Pure fun higherOrderFunction1(param: (p: String) -> (r: Int, s: String))
+@Pure fun higherOrderFunction2(param: () -> ())
+@Pure fun normalFunction(param: Int)
+@Pure fun parameterlessFunction()
 
 segment mySegment() {
     // $TEST$ serialization (p: String) -> (r: literal<1>, s: literal<"">)

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/block lambdas/that are passed as arguments/with type parameters.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/block lambdas/that are passed as arguments/with type parameters.sdsdev
@@ -1,0 +1,28 @@
+package tests.typing.expressions.blockLambdas.thatArePassedAsArguments.withTypeParameters
+
+class MySuperclass<T> {
+    @Pure fun myInheritedMethod(callback: (p: T) -> ())
+}
+
+class MyClass<T>(param: T) sub MySuperclass<T> {
+    @Pure fun myMethod(callback: (p: T) -> ())
+}
+
+@Pure fun myFunction<T>(p: T, id: (p: T) -> (r: T))
+
+segment mySegment() {
+    // $TEST$ serialization (p: literal<1>) -> (r: literal<1>)
+    MyClass(1).myMethod(»(p) {
+        yield r = p;
+    }«);
+
+    // $TEST$ serialization (p: literal<1>) -> (r: literal<1>)
+    MyClass(1).myInheritedMethod(»(p) {
+        yield r = p;
+    }«);
+
+    // $TEST$ serialization (p: literal<1>) -> (r: literal<1>)
+    myFunction(1, »(p) {
+        yield r = p;
+    }«);
+}

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/expression lambdas/that are passed as arguments/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/expression lambdas/that are passed as arguments/main.sdsdev
@@ -1,9 +1,9 @@
 package tests.typing.expressions.expressionLambdas.thatArePassedAsArguments
 
-fun higherOrderFunction1(param: (p: String) -> (r: Int))
-fun higherOrderFunction2(param: () -> ())
-fun normalFunction(param: Int)
-fun parameterlessFunction()
+@Pure fun higherOrderFunction1(param: (p: String) -> (r: Int))
+@Pure fun higherOrderFunction2(param: () -> ())
+@Pure fun normalFunction(param: Int)
+@Pure fun parameterlessFunction()
 
 segment mySegment() {
     // $TEST$ serialization (p: String) -> (result: literal<1>)

--- a/packages/safe-ds-lang/tests/resources/typing/expressions/expression lambdas/that are passed as arguments/with type parameters.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/typing/expressions/expression lambdas/that are passed as arguments/with type parameters.sdsdev
@@ -1,0 +1,22 @@
+package tests.typing.expressions.expressionLambdas.thatArePassedAsArguments.withTypeParameters
+
+class MySuperclass<T> {
+    @Pure fun myInheritedMethod(callback: (p: T) -> ())
+}
+
+class MyClass<T>(param: T) sub MySuperclass<T> {
+    @Pure fun myMethod(callback: (p: T) -> ())
+}
+
+@Pure fun myFunction<T>(p: T, id: (p: T) -> (r: T))
+
+segment mySegment() {
+    // $TEST$ serialization (p: literal<1>) -> (result: literal<1>)
+    MyClass(1).myMethod(»(p) -> p«);
+
+    // $TEST$ serialization (p: literal<1>) -> (result: literal<1>)
+    MyClass(1).myInheritedMethod(»(p) -> p«);
+
+    // $TEST$ serialization (p: literal<1>) -> (result: literal<1>)
+    myFunction(1, »(p) -> p«);
+}


### PR DESCRIPTION
Closes #1047

### Summary of Changes

Type of lambda parameters can be inferred from the context. Previously, however, type parameter types that were contained in the inferred type were not substituted. Now, they also get inferred from the context.