### PR TITLE
refactor: rename "type parameter type" to "type variable"

### DIFF
--- a/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
+++ b/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
@@ -46,7 +46,7 @@ import { SafeDsDocumentationProvider } from '../documentation/safe-ds-documentat
 import { SafeDsAnnotations } from '../builtins/safe-ds-annotations.js';
 import { isEmpty } from '../../helpers/collections.js';
 import { SafeDsTypeComputer } from '../typing/safe-ds-type-computer.js';
-import { NamedType, Type, TypeParameterType } from '../typing/model.js';
+import { NamedType, Type, TypeVariable } from '../typing/model.js';
 import path from 'path';
 import { addLinePrefix, removeLinePrefix } from '../../helpers/strings.js';
 import { expandToStringLF } from 'langium/generate';
@@ -544,7 +544,7 @@ export class SafeDsMarkdownGenerator {
     }
 
     private renderType(type: Type, knownPaths: Set<string>): string {
-        if (type instanceof NamedType && !(type instanceof TypeParameterType)) {
+        if (type instanceof NamedType && !(type instanceof TypeVariable)) {
             const realPath = AstUtils.getDocument(type.declaration).uri.fsPath;
             // When generating documentation for the standard library declarations in the `src` folder, references are
             // resolved to the `lib` folder. To still create links, we also check this augmented path.

--- a/packages/safe-ds-lang/src/language/scoping/safe-ds-scope-provider.ts
+++ b/packages/safe-ds-lang/src/language/scoping/safe-ds-scope-provider.ts
@@ -72,7 +72,7 @@ import {
 } from '../helpers/nodeProperties.js';
 import { SafeDsNodeMapper } from '../helpers/safe-ds-node-mapper.js';
 import { SafeDsServices } from '../safe-ds-module.js';
-import { ClassType, EnumVariantType, LiteralType, TypeParameterType } from '../typing/model.js';
+import { ClassType, EnumVariantType, LiteralType, TypeVariable } from '../typing/model.js';
 import type { SafeDsClassHierarchy } from '../typing/safe-ds-class-hierarchy.js';
 import { SafeDsTypeComputer } from '../typing/safe-ds-type-computer.js';
 import { SafeDsPackageManager } from '../workspace/safe-ds-package-manager.js';
@@ -244,7 +244,7 @@ export class SafeDsScopeProvider extends DefaultScopeProvider {
         let receiverType = this.typeComputer.computeType(node.receiver);
         if (receiverType instanceof LiteralType) {
             receiverType = this.typeComputer.computeClassTypeForLiteralType(receiverType);
-        } else if (receiverType instanceof TypeParameterType) {
+        } else if (receiverType instanceof TypeVariable) {
             receiverType = this.typeComputer.computeUpperBound(receiverType);
         }
 

--- a/packages/safe-ds-lang/src/language/typing/model.ts
+++ b/packages/safe-ds-lang/src/language/typing/model.ts
@@ -532,7 +532,7 @@ export class EnumVariantType extends NamedType<SdsEnumVariant> {
     }
 }
 
-export class TypeParameterType extends NamedType<SdsTypeParameter> {
+export class TypeVariable extends NamedType<SdsTypeParameter> {
     override readonly isFullySubstituted = false;
 
     constructor(
@@ -545,7 +545,7 @@ export class TypeParameterType extends NamedType<SdsTypeParameter> {
     override equals(other: unknown): boolean {
         if (other === this) {
             return true;
-        } else if (!(other instanceof TypeParameterType)) {
+        } else if (!(other instanceof TypeVariable)) {
             return false;
         }
 
@@ -564,12 +564,12 @@ export class TypeParameterType extends NamedType<SdsTypeParameter> {
         }
     }
 
-    override withExplicitNullability(isExplicitlyNullable: boolean): TypeParameterType {
+    override withExplicitNullability(isExplicitlyNullable: boolean): TypeVariable {
         if (this.isExplicitlyNullable === isExplicitlyNullable) {
             return this;
         }
 
-        return new TypeParameterType(this.declaration, isExplicitlyNullable);
+        return new TypeVariable(this.declaration, isExplicitlyNullable);
     }
 }
 

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-factory.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-factory.ts
@@ -11,7 +11,7 @@ import {
     StaticType,
     Type,
     TypeParameterSubstitutions,
-    TypeParameterType,
+    TypeVariable,
     UnionType,
 } from './model.js';
 import { Constant } from '../partialEvaluation/model.js';
@@ -66,8 +66,8 @@ export class SafeDsTypeFactory {
         return new StaticType(this.services, instanceType);
     }
 
-    createTypeParameterType(declaration: SdsTypeParameter, isExplicitlyNullable: boolean): TypeParameterType {
-        return new TypeParameterType(declaration, isExplicitlyNullable);
+    createTypeVariable(declaration: SdsTypeParameter, isExplicitlyNullable: boolean): TypeVariable {
+        return new TypeVariable(declaration, isExplicitlyNullable);
     }
 
     createUnionType(...types: Type[]): UnionType {

--- a/packages/safe-ds-lang/src/language/validation/types.ts
+++ b/packages/safe-ds-lang/src/language/validation/types.ts
@@ -26,7 +26,7 @@ import {
 } from '../generated/ast.js';
 import { getArguments, getTypeArguments, getTypeParameters, TypeParameter } from '../helpers/nodeProperties.js';
 import { SafeDsServices } from '../safe-ds-module.js';
-import { ClassType, NamedTupleType, TypeParameterType, UnknownType } from '../typing/model.js';
+import { ClassType, NamedTupleType, TypeVariable, UnknownType } from '../typing/model.js';
 
 export const CODE_TYPE_CALLABLE_RECEIVER = 'type/callable-receiver';
 export const CODE_TYPE_MISMATCH = 'type/mismatch';
@@ -135,7 +135,7 @@ export const indexedAccessIndexMustHaveCorrectType = (services: SafeDsServices) 
                     code: CODE_TYPE_MISMATCH,
                 });
             }
-        } else if (receiverType instanceof ClassType || receiverType instanceof TypeParameterType) {
+        } else if (receiverType instanceof ClassType || receiverType instanceof TypeVariable) {
             const mapType = typeComputer.computeMatchingSupertype(receiverType, coreClasses.Map);
             if (mapType) {
                 const keyType = mapType.getTypeParameterTypeByIndex(0);
@@ -293,7 +293,7 @@ export const namedTypeTypeArgumentsMustMatchBounds = (services: SafeDsServices) 
             }
 
             const upperBound = typeComputer
-                .computeUpperBound(typeParameter, { stopAtTypeParameterType: true })
+                .computeUpperBound(typeParameter, { stopAtTypeVariable: true })
                 .substituteTypeParameters(type.substitutions);
 
             if (!typeChecker.isSubtypeOf(typeArgumentType, upperBound)) {
@@ -400,7 +400,7 @@ export const typeParameterDefaultValueMustMatchUpperBound = (services: SafeDsSer
         }
 
         const defaultValueType = typeComputer.computeType(node.defaultValue);
-        const upperBoundType = typeComputer.computeUpperBound(node, { stopAtTypeParameterType: true });
+        const upperBoundType = typeComputer.computeUpperBound(node, { stopAtTypeVariable: true });
 
         if (!typeChecker.isSubtypeOf(defaultValueType, upperBoundType)) {
             accept('error', `Expected type '${upperBoundType}' but got '${defaultValueType}'.`, {

--- a/packages/safe-ds-lang/tests/language/typing/model.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/model.test.ts
@@ -10,7 +10,7 @@ import {
     NamedTupleEntry,
     Type,
     TypeParameterSubstitutions,
-    TypeParameterType,
+    TypeVariable,
     UnknownType,
 } from '../../../src/language/typing/model.js';
 import { getNodeOfType } from '../../helpers/nodeFinder.js';
@@ -107,8 +107,8 @@ describe('type model', async () => {
             valueOfOtherType: () => UnknownType,
         },
         {
-            value: () => new TypeParameterType(typeParameter1, true),
-            unequalValueOfSameType: () => new TypeParameterType(typeParameter2, true),
+            value: () => new TypeVariable(typeParameter1, true),
+            unequalValueOfSameType: () => new TypeVariable(typeParameter2, true),
             valueOfOtherType: () => UnknownType,
         },
         {
@@ -207,11 +207,11 @@ describe('type model', async () => {
             expectedString: 'MyEnum1.MyEnumVariant1?',
         },
         {
-            value: new TypeParameterType(typeParameter1, false),
+            value: new TypeVariable(typeParameter1, false),
             expectedString: 'K',
         },
         {
-            value: new TypeParameterType(typeParameter1, true),
+            value: new TypeVariable(typeParameter1, true),
             expectedString: 'K?',
         },
         {
@@ -240,11 +240,9 @@ describe('type model', async () => {
                 callable1,
                 undefined,
                 factory.createNamedTupleType(
-                    new NamedTupleEntry(parameter1, 'p1', new TypeParameterType(typeParameter1, false)),
+                    new NamedTupleEntry(parameter1, 'p1', new TypeVariable(typeParameter1, false)),
                 ),
-                factory.createNamedTupleType(
-                    new NamedTupleEntry(result, 'r', new TypeParameterType(typeParameter1, false)),
-                ),
+                factory.createNamedTupleType(new NamedTupleEntry(result, 'r', new TypeVariable(typeParameter1, false))),
             ),
             substitutions: substitutions1,
             expectedType: factory.createCallableType(
@@ -265,7 +263,7 @@ describe('type model', async () => {
         },
         {
             type: factory.createNamedTupleType(
-                new NamedTupleEntry(parameter1, 'p1', new TypeParameterType(typeParameter1, false)),
+                new NamedTupleEntry(parameter1, 'p1', new TypeVariable(typeParameter1, false)),
             ),
             substitutions: substitutions1,
             expectedType: factory.createNamedTupleType(
@@ -273,11 +271,7 @@ describe('type model', async () => {
             ),
         },
         {
-            type: new ClassType(
-                class1,
-                new Map([[typeParameter2, new TypeParameterType(typeParameter1, false)]]),
-                false,
-            ),
+            type: new ClassType(class1, new Map([[typeParameter2, new TypeVariable(typeParameter1, false)]]), false),
             substitutions: substitutions1,
             expectedType: new ClassType(
                 class1,
@@ -296,32 +290,32 @@ describe('type model', async () => {
             expectedType: new EnumVariantType(enumVariant1, false),
         },
         {
-            type: new TypeParameterType(typeParameter1, false),
+            type: new TypeVariable(typeParameter1, false),
             substitutions: substitutions1,
             expectedType: factory.createLiteralType(new IntConstant(1n)),
         },
         {
-            type: new TypeParameterType(typeParameter1, true),
+            type: new TypeVariable(typeParameter1, true),
             substitutions: substitutions1,
             expectedType: factory.createLiteralType(new IntConstant(1n), NullConstant),
         },
         {
-            type: new TypeParameterType(typeParameter2, false),
+            type: new TypeVariable(typeParameter2, false),
             substitutions: substitutions1,
-            expectedType: new TypeParameterType(typeParameter2, false),
+            expectedType: new TypeVariable(typeParameter2, false),
         },
         {
             type: factory.createStaticType(
-                new ClassType(class1, new Map([[typeParameter1, new TypeParameterType(typeParameter2, false)]]), false),
+                new ClassType(class1, new Map([[typeParameter1, new TypeVariable(typeParameter2, false)]]), false),
             ),
             substitutions: substitutions1,
             expectedType: factory.createStaticType(
-                new ClassType(class1, new Map([[typeParameter1, new TypeParameterType(typeParameter2, false)]]), false),
+                new ClassType(class1, new Map([[typeParameter1, new TypeVariable(typeParameter2, false)]]), false),
             ),
         },
         {
             type: factory.createUnionType(
-                new ClassType(class1, new Map([[typeParameter2, new TypeParameterType(typeParameter1, false)]]), false),
+                new ClassType(class1, new Map([[typeParameter2, new TypeVariable(typeParameter1, false)]]), false),
             ),
             substitutions: substitutions1,
             expectedType: factory.createUnionType(
@@ -461,14 +455,14 @@ describe('type model', async () => {
             expectedType: factory.createStaticType(new ClassType(class1, new Map(), false)),
         },
         {
-            type: new TypeParameterType(typeParameter1, false),
+            type: new TypeVariable(typeParameter1, false),
             isNullable: true,
-            expectedType: new TypeParameterType(typeParameter1, true),
+            expectedType: new TypeVariable(typeParameter1, true),
         },
         {
-            type: new TypeParameterType(typeParameter1, true),
+            type: new TypeVariable(typeParameter1, true),
             isNullable: false,
-            expectedType: new TypeParameterType(typeParameter1, false),
+            expectedType: new TypeVariable(typeParameter1, false),
         },
         {
             type: factory.createUnionType(),

--- a/packages/safe-ds-lang/tests/language/typing/type checker/isSubOrSupertypeOf.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/type checker/isSubOrSupertypeOf.test.ts
@@ -1028,7 +1028,7 @@ const classTypesWithTypeParameters = async (): Promise<IsSubOrSupertypeOfTest[]>
     ];
 };
 
-const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
+const typeVariables = async (): Promise<IsSubOrSupertypeOfTest[]> => {
     const code = `
         class TestClass<
             Unbounded,
@@ -1227,7 +1227,7 @@ const typeParameterTypes = async (): Promise<IsSubOrSupertypeOfTest[]> => {
 };
 
 describe('SafeDsTypeChecker', async () => {
-    const testCases = (await Promise.all([basic(), classTypesWithTypeParameters(), typeParameterTypes()])).flat();
+    const testCases = (await Promise.all([basic(), classTypesWithTypeParameters(), typeVariables()])).flat();
 
     describe.each(testCases)('isSubtypeOf', ({ type1, type2, expected }) => {
         it(`should check whether ${type1} a subtype of ${type2}`, () => {

--- a/packages/safe-ds-lang/tests/resources/typing/highest common subtype/class type and type variable/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/typing/highest common subtype/class type and type variable/main.sdsdev
@@ -1,4 +1,4 @@
-package tests.typing.highestCommonSubtype.classTypeAndTypeParameterType
+package tests.typing.highestCommonSubtype.classTypeAndTypeVariable
 
 class Contravariant<in T>
 

--- a/packages/safe-ds-lang/tests/resources/typing/highest common subtype/enum type and type variable/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/typing/highest common subtype/enum type and type variable/main.sdsdev
@@ -1,4 +1,4 @@
-package tests.typing.highestCommonSubtype.enumTypeAndTypeParameterType
+package tests.typing.highestCommonSubtype.enumTypeAndTypeVariable
 
 class Contravariant<in T>
 

--- a/packages/safe-ds-lang/tests/resources/typing/highest common subtype/enum variant type and type variable/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/typing/highest common subtype/enum variant type and type variable/main.sdsdev
@@ -1,4 +1,4 @@
-package tests.typing.highestCommonSubtype.enumVariantTypeAndTypeParameterType
+package tests.typing.highestCommonSubtype.enumVariantTypeAndTypeVariable
 
 class Contravariant<in T>
 

--- a/packages/safe-ds-lang/tests/resources/typing/highest common subtype/type variable and type variable/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/typing/highest common subtype/type variable and type variable/main.sdsdev
@@ -1,4 +1,4 @@
-package tests.typing.highestCommonSubtype.typeParameterTypeAndTypeParameterType
+package tests.typing.highestCommonSubtype.typeVariableAndTypeVariable
 
 class Contravariant<in T>
 

--- a/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/class type and type variable/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/class type and type variable/main.sdsdev
@@ -1,4 +1,4 @@
-package tests.typing.lowestCommonSupertype.classTypeAndTypeParameterType
+package tests.typing.lowestCommonSupertype.classTypeAndTypeVariable
 
 class C
 class D

--- a/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/enum type and type variable/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/enum type and type variable/main.sdsdev
@@ -1,4 +1,4 @@
-package tests.typing.lowestCommonSupertype.enumTypeAndTypeParameterType
+package tests.typing.lowestCommonSupertype.enumTypeAndTypeVariable
 
 enum E {
     V

--- a/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/enum variant type and type variable/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/enum variant type and type variable/main.sdsdev
@@ -1,4 +1,4 @@
-package tests.typing.lowestCommonSupertype.enumVariantTypeAndTypeParameterType
+package tests.typing.lowestCommonSupertype.enumVariantTypeAndTypeVariable
 
 enum E {
     V1

--- a/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/literal type and type variable/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/literal type and type variable/main.sdsdev
@@ -1,4 +1,4 @@
-package tests.typing.lowestCommonSupertype.literalTypeAndTypeParameterType
+package tests.typing.lowestCommonSupertype.literalTypeAndTypeVariable
 
 class Test<
     Unbounded,

--- a/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/type variable and type variable/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/typing/lowest common supertype/type variable and type variable/main.sdsdev
@@ -1,4 +1,4 @@
-package tests.typing.lowestCommonSupertype.typeParameterTypeAndTypeParameterType
+package tests.typing.lowestCommonSupertype.typeVariableAndTypeVariable
 
 class C
 class D sub C


### PR DESCRIPTION
### Summary of Changes

Rename the type "type parameter type" to "type variable". This is shorter, less cumbersome, and better highlights that this type can be substituted by another type.
