### PR TITLE
feat: collapse class/literal types in inlay hints

### DIFF
--- a/packages/safe-ds-lang/src/language/workspace/safe-ds-settings-provider.ts
+++ b/packages/safe-ds-lang/src/language/workspace/safe-ds-settings-provider.ts
@@ -98,7 +98,7 @@ export interface Settings {
     validation: ValidationSettings;
 }
 
-interface InlayHintsSettings {
+export interface InlayHintsSettings {
     assigneeTypes: {
         enabled: boolean;
     };
@@ -112,11 +112,11 @@ interface InlayHintsSettings {
     };
 }
 
-interface RunnerSettings {
+export interface RunnerSettings {
     command: string;
 }
 
-interface ValidationSettings {
+export interface ValidationSettings {
     codeStyle: {
         enabled: boolean;
     };

--- a/packages/safe-ds-lang/src/language/workspace/safe-ds-settings-provider.ts
+++ b/packages/safe-ds-lang/src/language/workspace/safe-ds-settings-provider.ts
@@ -29,6 +29,14 @@ export class SafeDsSettingsProvider {
         return this.cachedSettings.inlayHints?.lambdaParameterTypes?.enabled ?? true;
     }
 
+    shouldCollapseClassTypesInInlayHints(): boolean {
+        return this.cachedSettings.inlayHints?.collapseClassTypes ?? true;
+    }
+
+    shouldCollapseLiteralTypesInInlayHints(): boolean {
+        return this.cachedSettings.inlayHints?.collapseLiteralTypes ?? true;
+    }
+
     shouldShowParameterNameInlayHints(): InlayHintsSettings['parameterNames']['enabled'] {
         return this.cachedSettings.inlayHints?.parameterNames?.enabled ?? 'onlyLiterals';
     }
@@ -97,6 +105,8 @@ interface InlayHintsSettings {
     lambdaParameterTypes: {
         enabled: boolean;
     };
+    collapseClassTypes: boolean;
+    collapseLiteralTypes: boolean;
     parameterNames: {
         enabled: 'none' | 'onlyLiterals' | 'exceptReferences' | 'all';
     };

--- a/packages/safe-ds-lang/tests/language/typing/model.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/model.test.ts
@@ -8,6 +8,7 @@ import {
     EnumType,
     EnumVariantType,
     NamedTupleEntry,
+    ToStringOptions,
     Type,
     TypeParameterSubstitutions,
     TypeVariable,
@@ -151,7 +152,7 @@ describe('type model', async () => {
         }
     });
 
-    const toStringTests: ToStringTest<Type>[] = [
+    const toStringTests: TypeToStringTest[] = [
         {
             value: factory.createCallableType(
                 callable1,
@@ -175,6 +176,11 @@ describe('type model', async () => {
             expectedString: 'literal<true>',
         },
         {
+            value: factory.createLiteralType(new BooleanConstant(true)),
+            options: { collapseLiteralTypes: true },
+            expectedString: 'literal<…>',
+        },
+        {
             value: factory.createNamedTupleType(new NamedTupleEntry(parameter1, 'p1', UnknownType)),
             expectedString: '(p1: unknown)',
         },
@@ -189,6 +195,11 @@ describe('type model', async () => {
         {
             value: new ClassType(class2, new Map([[typeParameter1, factory.createUnionType()]]), true),
             expectedString: 'C2<union<>>?',
+        },
+        {
+            value: new ClassType(class2, new Map([[typeParameter1, factory.createUnionType()]]), true),
+            options: { collapseClassTypes: true },
+            expectedString: 'C2<…>?',
         },
         {
             value: new EnumType(enum1, false),
@@ -227,9 +238,9 @@ describe('type model', async () => {
             expectedString: 'unknown',
         },
     ];
-    describe.each(toStringTests)('toString', ({ value, expectedString }) => {
+    describe.each(toStringTests)('toString', ({ value, options, expectedString }) => {
         it(`should return the expected string representation (${value.constructor.name} -- ${value})`, () => {
-            expect(value.toString()).toStrictEqual(expectedString);
+            expect(value.toString(options)).toStrictEqual(expectedString);
         });
     });
 
@@ -586,6 +597,16 @@ describe('type model', async () => {
         });
     });
 });
+
+/**
+ * Tests for {@link Type.toString}.
+ */
+interface TypeToStringTest extends ToStringTest<Type> {
+    /**
+     * Options to pass to the `toString` method.
+     */
+    options?: ToStringOptions;
+}
 
 /**
  * Tests for {@link Type.substituteTypeParameters}.

--- a/packages/safe-ds-vscode/package.json
+++ b/packages/safe-ds-vscode/package.json
@@ -144,6 +144,16 @@
                     "default": true,
                     "description": "Show inferred types for lambda parameters without manifest types."
                 },
+                "safe-ds.inlayHints.collapseClassTypes": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Collapse the type arguments of class types."
+                },
+                "safe-ds.inlayHints.collapseLiteralTypes": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Collapse the literals of literal types."
+                },
                 "safe-ds.inlayHints.parameterNames.enabled": {
                     "type": "string",
                     "enum": [


### PR DESCRIPTION
Closes #1048

### Summary of Changes

Add settings to collapse type arguments of class types and literals of literal types in inlay hints:

* `safe-ds.inlayHints.collapseClassTypes`
* `safe-ds.inlayHints.collapseLiteralTypes`

These types can get quite long, leading to inlay hints that tear the actual program apart. The settings are enabled by default.