### PR TITLE
feat: error if name of static member equals name of inherited member

### DIFF
--- a/packages/safe-ds-lang/src/language/typing/safe-ds-class-hierarchy.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-class-hierarchy.ts
@@ -56,12 +56,30 @@ export class SafeDsClassHierarchy {
         }
     }
 
+    /**
+     * Returns a stream of all members of the superclasses of the given class. Direct ancestors are considered first,
+     * followed by their ancestors and so on. The members of the class itself are not included in the stream.
+     */
     streamSuperclassMembers(node: SdsClass | undefined): Stream<SdsClassMember> {
         if (!node) {
             return EMPTY_STREAM;
         }
 
         return this.streamProperSuperclasses(node).flatMap(getClassMembers);
+    }
+
+    /**
+     * Returns a stream of all instance members that are inherited by the given class. Direct ancestors are considered
+     * first, followed by their ancestors and so on. The members of the class itself are not included in the stream.
+     */
+    streamInheritedMembers(node: SdsClass | undefined): Stream<SdsClassMember> {
+        if (!node) {
+            return EMPTY_STREAM;
+        }
+
+        return this.streamProperSuperclasses(node)
+            .flatMap(getClassMembers)
+            .filter((it) => !isStatic(it));
     }
 
     /**

--- a/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
+++ b/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
@@ -52,6 +52,7 @@ import {
     pipelineMustContainUniqueNames,
     schemaMustContainUniqueNames,
     segmentMustContainUniqueNames,
+    staticClassMemberNamesMustNotCollideWithInheritedMembers,
 } from './names.js';
 import {
     argumentListMustNotHavePositionalArgumentsAfterNamedArguments,
@@ -254,6 +255,7 @@ export const registerValidationChecks = function (services: SafeDsServices) {
             classMustContainUniqueNames,
             classMustOnlyInheritASingleClass(services),
             classMustNotInheritItself(services),
+            staticClassMemberNamesMustNotCollideWithInheritedMembers(services),
         ],
         SdsClassBody: [classBodyShouldNotBeEmpty(services)],
         SdsClassMember: [classMemberMustMatchOverriddenMemberAndShouldBeNeeded(services)],

--- a/packages/safe-ds-lang/tests/resources/validation/names/duplicates/in class/static and inherited.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/validation/names/duplicates/in class/static and inherited.sdsdev
@@ -1,0 +1,14 @@
+package tests.validation.names.duplicates.inClass.staticAndInherited
+
+class MyClass1 {
+    attr myInstanceAttribute1: Int
+    attr myInstanceAttribute2: Int
+}
+
+class MyClass2 sub MyClass1 {
+    // $TEST$ error "An inherited member with name 'myInstanceAttribute1' exists already."
+    static attr »myInstanceAttribute1«: Int
+
+    // $TEST$ no error r"An inherited member with name '.*' exists already\."
+    attr »myInstanceAttribute2«: Int
+}


### PR DESCRIPTION
### Summary of Changes

A class can no longer have a static member with the same name as an inherited member. Otherwise, we would need more complicated `@link` tags in the documentation and more complicated qualified names.