### PR TITLE
docs: include inherited members in documentation

### DIFF
--- a/docs/api/safeds/data/tabular/containers/TaggedTable.md
+++ b/docs/api/safeds/data/tabular/containers/TaggedTable.md
@@ -353,11 +353,37 @@ A tagged table is a table that additionally knows which columns are features and
     }
     ```
 
+## `#!sds attr` columnNames {#safeds.data.tabular.containers.TaggedTable.columnNames data-toc-label='columnNames'}
+
+Return a list of all column names in this table.
+
+Alias for self.schema.column_names -> list[str].
+
+**Type:** [`List<String>`][safeds.lang.List]
+
 ## `#!sds attr` features {#safeds.data.tabular.containers.TaggedTable.features data-toc-label='features'}
 
 Get the feature columns of the tagged table.
 
 **Type:** [`Table`][safeds.data.tabular.containers.Table]
+
+## `#!sds attr` numberOfColumns {#safeds.data.tabular.containers.TaggedTable.numberOfColumns data-toc-label='numberOfColumns'}
+
+Return the number of columns.
+
+**Type:** [`Int`][safeds.lang.Int]
+
+## `#!sds attr` numberOfRows {#safeds.data.tabular.containers.TaggedTable.numberOfRows data-toc-label='numberOfRows'}
+
+Return the number of rows.
+
+**Type:** [`Int`][safeds.lang.Int]
+
+## `#!sds attr` schema {#safeds.data.tabular.containers.TaggedTable.schema data-toc-label='schema'}
+
+Return the schema of the table.
+
+**Type:** [`Schema`][safeds.data.tabular.typing.Schema]
 
 ## `#!sds attr` target {#safeds.data.tabular.containers.TaggedTable.target data-toc-label='target'}
 
@@ -561,6 +587,176 @@ The original tagged table is not modified.
     ) -> result1: TaggedTable
     ```
 
+## `#!sds fun` getColumn {#safeds.data.tabular.containers.TaggedTable.getColumn data-toc-label='getColumn'}
+
+Return a column with the data of the specified column.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `columnName` | [`String`][safeds.lang.String] | The name of the column. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Column<Any?>`][safeds.data.tabular.containers.Column] | The column. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="134"
+    @Pure
+    @PythonName("get_column")
+    fun getColumn(
+        @PythonName("column_name") columnName: String
+    ) -> result1: Column
+    ```
+
+## `#!sds fun` getColumnType {#safeds.data.tabular.containers.TaggedTable.getColumnType data-toc-label='getColumnType'}
+
+Return the type of the given column.
+
+Alias for self.schema.get_type_of_column(column_name: str) -> ColumnType.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `columnName` | [`String`][safeds.lang.String] | The name of the column to be queried. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`ColumnType`][safeds.data.tabular.typing.ColumnType] | The type of the column. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="164"
+    @Pure
+    @PythonName("get_column_type")
+    fun getColumnType(
+        @PythonName("column_name") columnName: String
+    ) -> result1: ColumnType
+    ```
+
+## `#!sds fun` getRow {#safeds.data.tabular.containers.TaggedTable.getRow data-toc-label='getRow'}
+
+Return the row at a specified index.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `index` | [`Int`][safeds.lang.Int] | The index. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Row`][safeds.data.tabular.containers.Row] | The row of the table at the index. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="177"
+    @Pure
+    @PythonName("get_row")
+    fun getRow(
+        index: Int
+    ) -> result1: Row
+    ```
+
+## `#!sds fun` groupRowsBy {#safeds.data.tabular.containers.TaggedTable.groupRowsBy data-toc-label='groupRowsBy'}
+
+Return a dictionary with copies of the output tables as values and the keys from the key_selector.
+
+The original table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `keySelector` | `#!sds (param1: Row) -> (param2: T)` | A Callable that is applied to all rows and returns the key of the group. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Map<T, Table>`][safeds.lang.Map] | A dictionary containing the new tables as values and the selected keys as keys. |
+
+**Type parameters:**
+
+| Name | Upper Bound | Description | Default |
+|------|-------------|-------------|---------|
+| `T` | [`Any?`][safeds.lang.Any] | - | - |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="284"
+    @Pure
+    @PythonName("group_rows_by")
+    fun groupRowsBy<T>(
+        @PythonName("key_selector") keySelector: (param1: Row) -> param2: T
+    ) -> result1: Map<T, Table>
+    ```
+
+## `#!sds fun` hasColumn {#safeds.data.tabular.containers.TaggedTable.hasColumn data-toc-label='hasColumn'}
+
+Return whether the table contains a given column.
+
+Alias for self.schema.hasColumn(column_name: str) -> bool.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `columnName` | [`String`][safeds.lang.String] | The name of the column. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Boolean`][safeds.lang.Boolean] | True if the column exists. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="149"
+    @Pure
+    @PythonName("has_column")
+    fun hasColumn(
+        @PythonName("column_name") columnName: String
+    ) -> result1: Boolean
+    ```
+
+## `#!sds fun` inverseTransformTable {#safeds.data.tabular.containers.TaggedTable.inverseTransformTable data-toc-label='inverseTransformTable'}
+
+Return a new `Table` with the inverted transformation applied by the given transformer.
+
+The original table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `transformer` | [`InvertibleTableTransformer`][safeds.data.tabular.transformation.InvertibleTableTransformer] | A transformer that was fitted with columns, which are all present in the table. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The original table. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="591"
+    @Pure
+    @PythonName("inverse_transform_table")
+    fun inverseTransformTable(
+        transformer: InvertibleTableTransformer
+    ) -> result1: Table
+    ```
+
 ## `#!sds fun` keepOnlyColumns {#safeds.data.tabular.containers.TaggedTable.keepOnlyColumns data-toc-label='keepOnlyColumns'}
 
 Return a new `TaggedTable` with only the given column(s).
@@ -587,6 +783,119 @@ The original table is not modified.
     fun keepOnlyColumns(
         @PythonName("column_names") columnNames: List<String>
     ) -> result1: TaggedTable
+    ```
+
+## `#!sds fun` plotBoxplots {#safeds.data.tabular.containers.TaggedTable.plotBoxplots data-toc-label='plotBoxplots'}
+
+Plot a boxplot for every numerical column.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Image`][safeds.data.image.containers.Image] | The plot as an image. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="644"
+    @Pure
+    @PythonName("plot_boxplots")
+    fun plotBoxplots() -> result1: Image
+    ```
+
+## `#!sds fun` plotCorrelationHeatmap {#safeds.data.tabular.containers.TaggedTable.plotCorrelationHeatmap data-toc-label='plotCorrelationHeatmap'}
+
+Plot a correlation heatmap for all numerical columns of this `Table`.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Image`][safeds.data.image.containers.Image] | The plot as an image. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="602"
+    @Pure
+    @PythonName("plot_correlation_heatmap")
+    fun plotCorrelationHeatmap() -> result1: Image
+    ```
+
+## `#!sds fun` plotHistograms {#safeds.data.tabular.containers.TaggedTable.plotHistograms data-toc-label='plotHistograms'}
+
+Plot a histogram for every column.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Image`][safeds.data.image.containers.Image] | The plot as an image. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="653"
+    @Pure
+    @PythonName("plot_histograms")
+    fun plotHistograms() -> result1: Image
+    ```
+
+## `#!sds fun` plotLineplot {#safeds.data.tabular.containers.TaggedTable.plotLineplot data-toc-label='plotLineplot'}
+
+Plot two columns against each other in a lineplot.
+
+If there are multiple x-values for a y-value, the resulting plot will consist of a line representing the mean
+and the lower-transparency area around the line representing the 95% confidence interval.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `xColumnName` | [`String`][safeds.lang.String] | The column name of the column to be plotted on the x-Axis. | - |
+| `yColumnName` | [`String`][safeds.lang.String] | The column name of the column to be plotted on the y-Axis. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Image`][safeds.data.image.containers.Image] | The plot as an image. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="617"
+    @Pure
+    @PythonName("plot_lineplot")
+    fun plotLineplot(
+        @PythonName("x_column_name") xColumnName: String,
+        @PythonName("y_column_name") yColumnName: String
+    ) -> result1: Image
+    ```
+
+## `#!sds fun` plotScatterplot {#safeds.data.tabular.containers.TaggedTable.plotScatterplot data-toc-label='plotScatterplot'}
+
+Plot two columns against each other in a scatterplot.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `xColumnName` | [`String`][safeds.lang.String] | The column name of the column to be plotted on the x-Axis. | - |
+| `yColumnName` | [`String`][safeds.lang.String] | The column name of the column to be plotted on the y-Axis. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Image`][safeds.data.image.containers.Image] | The plot as an image. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="632"
+    @Pure
+    @PythonName("plot_scatterplot")
+    fun plotScatterplot(
+        @PythonName("x_column_name") xColumnName: String,
+        @PythonName("y_column_name") yColumnName: String
+    ) -> result1: Image
     ```
 
 ## `#!sds fun` removeColumns {#safeds.data.tabular.containers.TaggedTable.removeColumns data-toc-label='removeColumns'}
@@ -909,6 +1218,259 @@ The original table is not modified.
     ) -> result1: TaggedTable
     ```
 
+## `#!sds fun` splitRows {#safeds.data.tabular.containers.TaggedTable.splitRows data-toc-label='splitRows'}
+
+Split the table into two new tables.
+
+The original table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `percentageInFirst` | [`Float`][safeds.lang.Float] | The desired size of the first table in percentage to the given table; must be between 0 and 1. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | A tuple containing the two resulting tables. The first table has the specified size, the second table contains the rest of the data. |
+| `result2` | [`Table`][safeds.data.tabular.containers.Table] | A tuple containing the two resulting tables. The first table has the specified size, the second table contains the rest of the data. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="511"
+    @Pure
+    @PythonName("split_rows")
+    fun splitRows(
+        @PythonName("percentage_in_first") percentageInFirst: Float
+    ) -> (result1: Table, result2: Table)
+    ```
+
+## `#!sds fun` summarizeStatistics {#safeds.data.tabular.containers.TaggedTable.summarizeStatistics data-toc-label='summarizeStatistics'}
+
+Return a table with a number of statistical key values.
+
+The original table is not modified.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The table with statistics. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="190"
+    @Pure
+    @PythonName("summarize_statistics")
+    fun summarizeStatistics() -> result1: Table
+    ```
+
+## `#!sds fun` tagColumns {#safeds.data.tabular.containers.TaggedTable.tagColumns data-toc-label='tagColumns'}
+
+Return a new `TaggedTable` with columns marked as a target column or feature columns.
+
+The original table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `targetName` | [`String`][safeds.lang.String] | Name of the target column. | - |
+| `featureNames` | [`List<String>?`][safeds.lang.List] | Names of the feature columns. If None, all columns except the target column are used. | `#!sds null` |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A new tagged table with the given target and feature names. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="527"
+    @Pure
+    @PythonName("tag_columns")
+    fun tagColumns(
+        @PythonName("target_name") targetName: String,
+        @PythonName("feature_names") featureNames: List<String>? = null
+    ) -> result1: TaggedTable
+    ```
+
+## `#!sds fun` timeColumns {#safeds.data.tabular.containers.TaggedTable.timeColumns data-toc-label='timeColumns'}
+
+Return a new `TimeSeries` with columns marked as a target and time column or feature columns.
+
+The original table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `targetName` | [`String`][safeds.lang.String] | Name of the target column. | - |
+| `timeName` | [`String`][safeds.lang.String] | Name of the time column. | - |
+| `featureNames` | [`List<String>?`][safeds.lang.List] | Names of the feature columns. If None, all columns except the target and time columns are used. | `#!sds null` |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | A new time series with the given target, time and feature names. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="545"
+    @Pure
+    @PythonName("time_columns")
+    fun timeColumns(
+        @PythonName("target_name") targetName: String,
+        @PythonName("time_name") timeName: String,
+        @PythonName("feature_names") featureNames: List<String>? = null
+    ) -> result1: TimeSeries
+    ```
+
+## `#!sds fun` toColumns {#safeds.data.tabular.containers.TaggedTable.toColumns data-toc-label='toColumns'}
+
+Return a list of the columns.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<Column<Any?>>`][safeds.lang.List] | List of columns. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="723"
+    @Pure
+    @PythonName("to_columns")
+    fun toColumns() -> result1: List<Column>
+    ```
+
+## `#!sds fun` toCsvFile {#safeds.data.tabular.containers.TaggedTable.toCsvFile data-toc-label='toCsvFile'}
+
+Write the data from the table into a CSV file.
+
+If the file and/or the directories do not exist they will be created. If the file already exists it will be
+overwritten.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `path` | [`String`][safeds.lang.String] | The path to the output file. | - |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="665"
+    @Impure([ImpurityReason.FileWriteToParameterizedPath("path")])
+    @PythonName("to_csv_file")
+    fun toCsvFile(
+        path: String
+    )
+    ```
+
+## `#!sds fun` toDict {#safeds.data.tabular.containers.TaggedTable.toDict data-toc-label='toDict'}
+
+Return a dictionary that maps column names to column values.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Map<String, List<Any>>`][safeds.lang.Map] | Dictionary representation of the table. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="705"
+    @Pure
+    @PythonName("to_dict")
+    fun toDict() -> result1: Map<String, List<Any>>
+    ```
+
+## `#!sds fun` toExcelFile {#safeds.data.tabular.containers.TaggedTable.toExcelFile data-toc-label='toExcelFile'}
+
+Write the data from the table into an Excel file.
+
+Valid file extensions are `.xls`, '.xlsx', `.xlsm`, `.xlsb`, `.odf`, `.ods` and `.odt`.
+If the file and/or the directories do not exist, they will be created. If the file already exists, it will be
+overwritten.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `path` | [`String`][safeds.lang.String] | The path to the output file. | - |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="680"
+    @Impure([ImpurityReason.FileWriteToParameterizedPath("path")])
+    @PythonName("to_excel_file")
+    fun toExcelFile(
+        path: String
+    )
+    ```
+
+## `#!sds fun` toHtml {#safeds.data.tabular.containers.TaggedTable.toHtml data-toc-label='toHtml'}
+
+Return an HTML representation of the table.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`String`][safeds.lang.String] | The generated HTML. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="714"
+    @Pure
+    @PythonName("to_html")
+    fun toHtml() -> result1: String
+    ```
+
+## `#!sds fun` toJsonFile {#safeds.data.tabular.containers.TaggedTable.toJsonFile data-toc-label='toJsonFile'}
+
+Write the data from the table into a JSON file.
+
+If the file and/or the directories do not exist, they will be created. If the file already exists it will be
+overwritten.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `path` | [`String`][safeds.lang.String] | The path to the output file. | - |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="694"
+    @Impure([ImpurityReason.FileWriteToParameterizedPath("path")])
+    @PythonName("to_json_file")
+    fun toJsonFile(
+        path: String
+    )
+    ```
+
+## `#!sds fun` toRows {#safeds.data.tabular.containers.TaggedTable.toRows data-toc-label='toRows'}
+
+Return a list of the rows.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<Row>`][safeds.lang.List] | List of rows. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="732"
+    @Pure
+    @PythonName("to_rows")
+    fun toRows() -> result1: List<Row>
+    ```
+
 ## `#!sds fun` transformColumn {#safeds.data.tabular.containers.TaggedTable.transformColumn data-toc-label='transformColumn'}
 
 Return a new `TaggedTable` with the provided column transformed by calling the provided transformer.
@@ -937,4 +1499,32 @@ The original table is not modified.
         name: String,
         transformer: (param1: Row) -> param2: Any
     ) -> result1: TaggedTable
+    ```
+
+## `#!sds fun` transformTable {#safeds.data.tabular.containers.TaggedTable.transformTable data-toc-label='transformTable'}
+
+Return a new `Table` with a learned transformation applied to this table.
+
+The original table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `transformer` | [`TableTransformer`][safeds.data.tabular.transformation.TableTransformer] | The transformer which transforms the given table. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The transformed table. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="576"
+    @Pure
+    @PythonName("transform_table")
+    fun transformTable(
+        transformer: TableTransformer
+    ) -> result1: Table
     ```

--- a/docs/api/safeds/data/tabular/containers/TimeSeries.md
+++ b/docs/api/safeds/data/tabular/containers/TimeSeries.md
@@ -376,11 +376,37 @@
     }
     ```
 
+## `#!sds attr` columnNames {#safeds.data.tabular.containers.TimeSeries.columnNames data-toc-label='columnNames'}
+
+Return a list of all column names in this table.
+
+Alias for self.schema.column_names -> list[str].
+
+**Type:** [`List<String>`][safeds.lang.List]
+
 ## `#!sds attr` features {#safeds.data.tabular.containers.TimeSeries.features data-toc-label='features'}
 
 Get the feature columns of the tagged table.
 
 **Type:** [`Table`][safeds.data.tabular.containers.Table]
+
+## `#!sds attr` numberOfColumns {#safeds.data.tabular.containers.TimeSeries.numberOfColumns data-toc-label='numberOfColumns'}
+
+Return the number of columns.
+
+**Type:** [`Int`][safeds.lang.Int]
+
+## `#!sds attr` numberOfRows {#safeds.data.tabular.containers.TimeSeries.numberOfRows data-toc-label='numberOfRows'}
+
+Return the number of rows.
+
+**Type:** [`Int`][safeds.lang.Int]
+
+## `#!sds attr` schema {#safeds.data.tabular.containers.TimeSeries.schema data-toc-label='schema'}
+
+Return the schema of the table.
+
+**Type:** [`Schema`][safeds.data.tabular.typing.Schema]
 
 ## `#!sds attr` target {#safeds.data.tabular.containers.TimeSeries.target data-toc-label='target'}
 
@@ -590,6 +616,176 @@ The original time series is not modified.
     ) -> result1: TimeSeries
     ```
 
+## `#!sds fun` getColumn {#safeds.data.tabular.containers.TimeSeries.getColumn data-toc-label='getColumn'}
+
+Return a column with the data of the specified column.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `columnName` | [`String`][safeds.lang.String] | The name of the column. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Column<Any?>`][safeds.data.tabular.containers.Column] | The column. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="134"
+    @Pure
+    @PythonName("get_column")
+    fun getColumn(
+        @PythonName("column_name") columnName: String
+    ) -> result1: Column
+    ```
+
+## `#!sds fun` getColumnType {#safeds.data.tabular.containers.TimeSeries.getColumnType data-toc-label='getColumnType'}
+
+Return the type of the given column.
+
+Alias for self.schema.get_type_of_column(column_name: str) -> ColumnType.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `columnName` | [`String`][safeds.lang.String] | The name of the column to be queried. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`ColumnType`][safeds.data.tabular.typing.ColumnType] | The type of the column. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="164"
+    @Pure
+    @PythonName("get_column_type")
+    fun getColumnType(
+        @PythonName("column_name") columnName: String
+    ) -> result1: ColumnType
+    ```
+
+## `#!sds fun` getRow {#safeds.data.tabular.containers.TimeSeries.getRow data-toc-label='getRow'}
+
+Return the row at a specified index.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `index` | [`Int`][safeds.lang.Int] | The index. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Row`][safeds.data.tabular.containers.Row] | The row of the table at the index. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="177"
+    @Pure
+    @PythonName("get_row")
+    fun getRow(
+        index: Int
+    ) -> result1: Row
+    ```
+
+## `#!sds fun` groupRowsBy {#safeds.data.tabular.containers.TimeSeries.groupRowsBy data-toc-label='groupRowsBy'}
+
+Return a dictionary with copies of the output tables as values and the keys from the key_selector.
+
+The original table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `keySelector` | `#!sds (param1: Row) -> (param2: T)` | A Callable that is applied to all rows and returns the key of the group. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Map<T, Table>`][safeds.lang.Map] | A dictionary containing the new tables as values and the selected keys as keys. |
+
+**Type parameters:**
+
+| Name | Upper Bound | Description | Default |
+|------|-------------|-------------|---------|
+| `T` | [`Any?`][safeds.lang.Any] | - | - |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="284"
+    @Pure
+    @PythonName("group_rows_by")
+    fun groupRowsBy<T>(
+        @PythonName("key_selector") keySelector: (param1: Row) -> param2: T
+    ) -> result1: Map<T, Table>
+    ```
+
+## `#!sds fun` hasColumn {#safeds.data.tabular.containers.TimeSeries.hasColumn data-toc-label='hasColumn'}
+
+Return whether the table contains a given column.
+
+Alias for self.schema.hasColumn(column_name: str) -> bool.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `columnName` | [`String`][safeds.lang.String] | The name of the column. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Boolean`][safeds.lang.Boolean] | True if the column exists. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="149"
+    @Pure
+    @PythonName("has_column")
+    fun hasColumn(
+        @PythonName("column_name") columnName: String
+    ) -> result1: Boolean
+    ```
+
+## `#!sds fun` inverseTransformTable {#safeds.data.tabular.containers.TimeSeries.inverseTransformTable data-toc-label='inverseTransformTable'}
+
+Return a new `Table` with the inverted transformation applied by the given transformer.
+
+The original table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `transformer` | [`InvertibleTableTransformer`][safeds.data.tabular.transformation.InvertibleTableTransformer] | A transformer that was fitted with columns, which are all present in the table. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The original table. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="591"
+    @Pure
+    @PythonName("inverse_transform_table")
+    fun inverseTransformTable(
+        transformer: InvertibleTableTransformer
+    ) -> result1: Table
+    ```
+
 ## `#!sds fun` keepOnlyColumns {#safeds.data.tabular.containers.TimeSeries.keepOnlyColumns data-toc-label='keepOnlyColumns'}
 
 Return a new `TimeSeries` with only the given column(s).
@@ -616,6 +812,60 @@ The original time series is not modified.
     fun keepOnlyColumns(
         @PythonName("column_names") columnNames: List<String>
     ) -> result1: TimeSeries
+    ```
+
+## `#!sds fun` plotBoxplots {#safeds.data.tabular.containers.TimeSeries.plotBoxplots data-toc-label='plotBoxplots'}
+
+Plot a boxplot for every numerical column.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Image`][safeds.data.image.containers.Image] | The plot as an image. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="644"
+    @Pure
+    @PythonName("plot_boxplots")
+    fun plotBoxplots() -> result1: Image
+    ```
+
+## `#!sds fun` plotCorrelationHeatmap {#safeds.data.tabular.containers.TimeSeries.plotCorrelationHeatmap data-toc-label='plotCorrelationHeatmap'}
+
+Plot a correlation heatmap for all numerical columns of this `Table`.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Image`][safeds.data.image.containers.Image] | The plot as an image. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="602"
+    @Pure
+    @PythonName("plot_correlation_heatmap")
+    fun plotCorrelationHeatmap() -> result1: Image
+    ```
+
+## `#!sds fun` plotHistograms {#safeds.data.tabular.containers.TimeSeries.plotHistograms data-toc-label='plotHistograms'}
+
+Plot a histogram for every column.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Image`][safeds.data.image.containers.Image] | The plot as an image. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="653"
+    @Pure
+    @PythonName("plot_histograms")
+    fun plotHistograms() -> result1: Image
     ```
 
 ## `#!sds fun` plotLagplot {#safeds.data.tabular.containers.TimeSeries.plotLagplot data-toc-label='plotLagplot'}
@@ -902,6 +1152,26 @@ The order of columns is kept. The original time series is not modified.
     ) -> result1: TimeSeries
     ```
 
+## `#!sds fun` shuffleRows {#safeds.data.tabular.containers.TimeSeries.shuffleRows data-toc-label='shuffleRows'}
+
+Return a new `Table` with randomly shuffled rows of this `Table`.
+
+The original table is not modified.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The shuffled Table. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="430"
+    @Pure
+    @PythonName("shuffle_rows")
+    fun shuffleRows() -> result1: Table
+    ```
+
 ## `#!sds fun` sliceRows {#safeds.data.tabular.containers.TimeSeries.sliceRows data-toc-label='sliceRows'}
 
 Slice a part of the table into a new `TimeSeries`.
@@ -971,6 +1241,294 @@ The original time series is not modified.
     ) -> result1: TimeSeries
     ```
 
+## `#!sds fun` sortRows {#safeds.data.tabular.containers.TimeSeries.sortRows data-toc-label='sortRows'}
+
+Sort the rows of a `Table` with the given comparator and return a new `Table`.
+
+The comparator is a function that takes two rows `row1` and `row2` and
+returns an integer:
+
+* If `row1` should be ordered before `row2`, the function should return a negative number.
+* If `row1` should be ordered after `row2`, the function should return a positive number.
+* If the original order of `row1` and `row2` should be kept, the function should return 0.
+
+The original table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `comparator` | `#!sds (param1: Row, param2: Row) -> (param3: Int)` | The function used to compare two rows. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | A new table with sorted rows. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="493"
+    @Pure
+    @PythonName("sort_rows")
+    fun sortRows(
+        comparator: (param1: Row, param2: Row) -> param3: Int
+    ) -> result1: Table
+    ```
+
+## `#!sds fun` splitRows {#safeds.data.tabular.containers.TimeSeries.splitRows data-toc-label='splitRows'}
+
+Split the table into two new tables.
+
+The original table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `percentageInFirst` | [`Float`][safeds.lang.Float] | The desired size of the first table in percentage to the given table; must be between 0 and 1. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | A tuple containing the two resulting tables. The first table has the specified size, the second table contains the rest of the data. |
+| `result2` | [`Table`][safeds.data.tabular.containers.Table] | A tuple containing the two resulting tables. The first table has the specified size, the second table contains the rest of the data. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="511"
+    @Pure
+    @PythonName("split_rows")
+    fun splitRows(
+        @PythonName("percentage_in_first") percentageInFirst: Float
+    ) -> (result1: Table, result2: Table)
+    ```
+
+## `#!sds fun` summarizeStatistics {#safeds.data.tabular.containers.TimeSeries.summarizeStatistics data-toc-label='summarizeStatistics'}
+
+Return a table with a number of statistical key values.
+
+The original table is not modified.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The table with statistics. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="190"
+    @Pure
+    @PythonName("summarize_statistics")
+    fun summarizeStatistics() -> result1: Table
+    ```
+
+## `#!sds fun` tagColumns {#safeds.data.tabular.containers.TimeSeries.tagColumns data-toc-label='tagColumns'}
+
+Return a new `TaggedTable` with columns marked as a target column or feature columns.
+
+The original table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `targetName` | [`String`][safeds.lang.String] | Name of the target column. | - |
+| `featureNames` | [`List<String>?`][safeds.lang.List] | Names of the feature columns. If None, all columns except the target column are used. | `#!sds null` |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A new tagged table with the given target and feature names. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="527"
+    @Pure
+    @PythonName("tag_columns")
+    fun tagColumns(
+        @PythonName("target_name") targetName: String,
+        @PythonName("feature_names") featureNames: List<String>? = null
+    ) -> result1: TaggedTable
+    ```
+
+## `#!sds fun` timeColumns {#safeds.data.tabular.containers.TimeSeries.timeColumns data-toc-label='timeColumns'}
+
+Return a new `TimeSeries` with columns marked as a target and time column or feature columns.
+
+The original table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `targetName` | [`String`][safeds.lang.String] | Name of the target column. | - |
+| `timeName` | [`String`][safeds.lang.String] | Name of the time column. | - |
+| `featureNames` | [`List<String>?`][safeds.lang.List] | Names of the feature columns. If None, all columns except the target and time columns are used. | `#!sds null` |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`TimeSeries`][safeds.data.tabular.containers.TimeSeries] | A new time series with the given target, time and feature names. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="545"
+    @Pure
+    @PythonName("time_columns")
+    fun timeColumns(
+        @PythonName("target_name") targetName: String,
+        @PythonName("time_name") timeName: String,
+        @PythonName("feature_names") featureNames: List<String>? = null
+    ) -> result1: TimeSeries
+    ```
+
+## `#!sds fun` toColumns {#safeds.data.tabular.containers.TimeSeries.toColumns data-toc-label='toColumns'}
+
+Return a list of the columns.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<Column<Any?>>`][safeds.lang.List] | List of columns. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="723"
+    @Pure
+    @PythonName("to_columns")
+    fun toColumns() -> result1: List<Column>
+    ```
+
+## `#!sds fun` toCsvFile {#safeds.data.tabular.containers.TimeSeries.toCsvFile data-toc-label='toCsvFile'}
+
+Write the data from the table into a CSV file.
+
+If the file and/or the directories do not exist they will be created. If the file already exists it will be
+overwritten.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `path` | [`String`][safeds.lang.String] | The path to the output file. | - |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="665"
+    @Impure([ImpurityReason.FileWriteToParameterizedPath("path")])
+    @PythonName("to_csv_file")
+    fun toCsvFile(
+        path: String
+    )
+    ```
+
+## `#!sds fun` toDict {#safeds.data.tabular.containers.TimeSeries.toDict data-toc-label='toDict'}
+
+Return a dictionary that maps column names to column values.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Map<String, List<Any>>`][safeds.lang.Map] | Dictionary representation of the table. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="705"
+    @Pure
+    @PythonName("to_dict")
+    fun toDict() -> result1: Map<String, List<Any>>
+    ```
+
+## `#!sds fun` toExcelFile {#safeds.data.tabular.containers.TimeSeries.toExcelFile data-toc-label='toExcelFile'}
+
+Write the data from the table into an Excel file.
+
+Valid file extensions are `.xls`, '.xlsx', `.xlsm`, `.xlsb`, `.odf`, `.ods` and `.odt`.
+If the file and/or the directories do not exist, they will be created. If the file already exists, it will be
+overwritten.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `path` | [`String`][safeds.lang.String] | The path to the output file. | - |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="680"
+    @Impure([ImpurityReason.FileWriteToParameterizedPath("path")])
+    @PythonName("to_excel_file")
+    fun toExcelFile(
+        path: String
+    )
+    ```
+
+## `#!sds fun` toHtml {#safeds.data.tabular.containers.TimeSeries.toHtml data-toc-label='toHtml'}
+
+Return an HTML representation of the table.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`String`][safeds.lang.String] | The generated HTML. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="714"
+    @Pure
+    @PythonName("to_html")
+    fun toHtml() -> result1: String
+    ```
+
+## `#!sds fun` toJsonFile {#safeds.data.tabular.containers.TimeSeries.toJsonFile data-toc-label='toJsonFile'}
+
+Write the data from the table into a JSON file.
+
+If the file and/or the directories do not exist, they will be created. If the file already exists it will be
+overwritten.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `path` | [`String`][safeds.lang.String] | The path to the output file. | - |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="694"
+    @Impure([ImpurityReason.FileWriteToParameterizedPath("path")])
+    @PythonName("to_json_file")
+    fun toJsonFile(
+        path: String
+    )
+    ```
+
+## `#!sds fun` toRows {#safeds.data.tabular.containers.TimeSeries.toRows data-toc-label='toRows'}
+
+Return a list of the rows.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<Row>`][safeds.lang.List] | List of rows. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="732"
+    @Pure
+    @PythonName("to_rows")
+    fun toRows() -> result1: List<Row>
+    ```
+
 ## `#!sds fun` transformColumn {#safeds.data.tabular.containers.TimeSeries.transformColumn data-toc-label='transformColumn'}
 
 Return a new `TimeSeries` with the provided column transformed by calling the provided transformer.
@@ -999,4 +1557,32 @@ The original time series is not modified.
         name: String,
         transformer: (param1: Row) -> param2: Any
     ) -> result1: TimeSeries
+    ```
+
+## `#!sds fun` transformTable {#safeds.data.tabular.containers.TimeSeries.transformTable data-toc-label='transformTable'}
+
+Return a new `Table` with a learned transformation applied to this table.
+
+The original table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `transformer` | [`TableTransformer`][safeds.data.tabular.transformation.TableTransformer] | The transformer which transforms the given table. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The transformed table. |
+
+??? quote "Stub code in `table.sdsstub`"
+
+    ```sds linenums="576"
+    @Pure
+    @PythonName("transform_table")
+    fun transformTable(
+        transformer: TableTransformer
+    ) -> result1: Table
     ```

--- a/docs/api/safeds/data/tabular/transformation/Discretizer.md
+++ b/docs/api/safeds/data/tabular/transformation/Discretizer.md
@@ -64,3 +64,132 @@ This transformer is not modified.
         @PythonName("column_names") columnNames: List<String>?
     ) -> result1: Discretizer
     ```
+
+## `#!sds fun` fitAndTransform {#safeds.data.tabular.transformation.Discretizer.fitAndTransform data-toc-label='fitAndTransform'}
+
+Learn a transformation for a set of columns in a table and apply the learned transformation to the same table.
+
+The table is not modified. If you also need the fitted transformer, use `fit` and `transform` separately.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `table` | [`Table`][safeds.data.tabular.containers.Table] | The table used to fit the transformer. The transformer is then applied to this table. | - |
+| `columnNames` | [`List<String>?`][safeds.lang.List] | The list of columns from the table used to fit the transformer. If `None`, all columns are used. | `#!sds null` |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The transformed table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="85"
+    @Pure
+    @PythonName("fit_and_transform")
+    fun fitAndTransform(
+        table: Table,
+        @PythonName("column_names") columnNames: List<String>? = null
+    ) -> result1: Table
+    ```
+
+## `#!sds fun` getNamesOfAddedColumns {#safeds.data.tabular.transformation.Discretizer.getNamesOfAddedColumns data-toc-label='getNamesOfAddedColumns'}
+
+Get the names of all new columns that have been added by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of the added columns, ordered as they will appear in the table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="44"
+    @Pure
+    @PythonName("get_names_of_added_columns")
+    fun getNamesOfAddedColumns() -> result1: List<String>
+    ```
+
+## `#!sds fun` getNamesOfChangedColumns {#safeds.data.tabular.transformation.Discretizer.getNamesOfChangedColumns data-toc-label='getNamesOfChangedColumns'}
+
+Get the names of all columns that have been changed by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of changed columns, ordered as they appear in the table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="53"
+    @Pure
+    @PythonName("get_names_of_changed_columns")
+    fun getNamesOfChangedColumns() -> result1: List<String>
+    ```
+
+## `#!sds fun` getNamesOfRemovedColumns {#safeds.data.tabular.transformation.Discretizer.getNamesOfRemovedColumns data-toc-label='getNamesOfRemovedColumns'}
+
+Get the names of all columns that have been removed by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of the removed columns, ordered as they appear in the table the transformer was fitted on. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="62"
+    @Pure
+    @PythonName("get_names_of_removed_columns")
+    fun getNamesOfRemovedColumns() -> result1: List<String>
+    ```
+
+## `#!sds fun` isFitted {#safeds.data.tabular.transformation.Discretizer.isFitted data-toc-label='isFitted'}
+
+Check if the transformer is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Boolean`][safeds.lang.Boolean] | Whether the transformer is fitted. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="71"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> result1: Boolean
+    ```
+
+## `#!sds fun` transform {#safeds.data.tabular.transformation.Discretizer.transform data-toc-label='transform'}
+
+Apply the learned transformation to a table.
+
+The table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `table` | [`Table`][safeds.data.tabular.containers.Table] | The table to which the learned transformation is applied. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The transformed table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="34"
+    @Pure
+    fun transform(
+        table: Table
+    ) -> result1: Table
+    ```

--- a/docs/api/safeds/data/tabular/transformation/Imputer.md
+++ b/docs/api/safeds/data/tabular/transformation/Imputer.md
@@ -87,6 +87,135 @@ This transformer is not modified.
     ) -> result1: Imputer
     ```
 
+## `#!sds fun` fitAndTransform {#safeds.data.tabular.transformation.Imputer.fitAndTransform data-toc-label='fitAndTransform'}
+
+Learn a transformation for a set of columns in a table and apply the learned transformation to the same table.
+
+The table is not modified. If you also need the fitted transformer, use `fit` and `transform` separately.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `table` | [`Table`][safeds.data.tabular.containers.Table] | The table used to fit the transformer. The transformer is then applied to this table. | - |
+| `columnNames` | [`List<String>?`][safeds.lang.List] | The list of columns from the table used to fit the transformer. If `None`, all columns are used. | `#!sds null` |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The transformed table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="85"
+    @Pure
+    @PythonName("fit_and_transform")
+    fun fitAndTransform(
+        table: Table,
+        @PythonName("column_names") columnNames: List<String>? = null
+    ) -> result1: Table
+    ```
+
+## `#!sds fun` getNamesOfAddedColumns {#safeds.data.tabular.transformation.Imputer.getNamesOfAddedColumns data-toc-label='getNamesOfAddedColumns'}
+
+Get the names of all new columns that have been added by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of the added columns, ordered as they will appear in the table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="44"
+    @Pure
+    @PythonName("get_names_of_added_columns")
+    fun getNamesOfAddedColumns() -> result1: List<String>
+    ```
+
+## `#!sds fun` getNamesOfChangedColumns {#safeds.data.tabular.transformation.Imputer.getNamesOfChangedColumns data-toc-label='getNamesOfChangedColumns'}
+
+Get the names of all columns that have been changed by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of changed columns, ordered as they appear in the table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="53"
+    @Pure
+    @PythonName("get_names_of_changed_columns")
+    fun getNamesOfChangedColumns() -> result1: List<String>
+    ```
+
+## `#!sds fun` getNamesOfRemovedColumns {#safeds.data.tabular.transformation.Imputer.getNamesOfRemovedColumns data-toc-label='getNamesOfRemovedColumns'}
+
+Get the names of all columns that have been removed by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of the removed columns, ordered as they appear in the table the transformer was fitted on. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="62"
+    @Pure
+    @PythonName("get_names_of_removed_columns")
+    fun getNamesOfRemovedColumns() -> result1: List<String>
+    ```
+
+## `#!sds fun` isFitted {#safeds.data.tabular.transformation.Imputer.isFitted data-toc-label='isFitted'}
+
+Check if the transformer is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Boolean`][safeds.lang.Boolean] | Whether the transformer is fitted. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="71"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> result1: Boolean
+    ```
+
+## `#!sds fun` transform {#safeds.data.tabular.transformation.Imputer.transform data-toc-label='transform'}
+
+Apply the learned transformation to a table.
+
+The table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `table` | [`Table`][safeds.data.tabular.containers.Table] | The table to which the learned transformation is applied. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The transformed table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="34"
+    @Pure
+    fun transform(
+        table: Table
+    ) -> result1: Table
+    ```
+
 ## `#!sds enum` Strategy {#safeds.data.tabular.transformation.Imputer.Strategy data-toc-label='Strategy'}
 
 ??? quote "Stub code in `imputer.sdsstub`"

--- a/docs/api/safeds/data/tabular/transformation/InvertibleTableTransformer.md
+++ b/docs/api/safeds/data/tabular/transformation/InvertibleTableTransformer.md
@@ -66,6 +66,90 @@ Learn a transformation for a set of columns in a table.
     ) -> result1: InvertibleTableTransformer
     ```
 
+## `#!sds fun` fitAndTransform {#safeds.data.tabular.transformation.InvertibleTableTransformer.fitAndTransform data-toc-label='fitAndTransform'}
+
+Learn a transformation for a set of columns in a table and apply the learned transformation to the same table.
+
+The table is not modified. If you also need the fitted transformer, use `fit` and `transform` separately.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `table` | [`Table`][safeds.data.tabular.containers.Table] | The table used to fit the transformer. The transformer is then applied to this table. | - |
+| `columnNames` | [`List<String>?`][safeds.lang.List] | The list of columns from the table used to fit the transformer. If `None`, all columns are used. | `#!sds null` |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The transformed table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="85"
+    @Pure
+    @PythonName("fit_and_transform")
+    fun fitAndTransform(
+        table: Table,
+        @PythonName("column_names") columnNames: List<String>? = null
+    ) -> result1: Table
+    ```
+
+## `#!sds fun` getNamesOfAddedColumns {#safeds.data.tabular.transformation.InvertibleTableTransformer.getNamesOfAddedColumns data-toc-label='getNamesOfAddedColumns'}
+
+Get the names of all new columns that have been added by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of the added columns, ordered as they will appear in the table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="44"
+    @Pure
+    @PythonName("get_names_of_added_columns")
+    fun getNamesOfAddedColumns() -> result1: List<String>
+    ```
+
+## `#!sds fun` getNamesOfChangedColumns {#safeds.data.tabular.transformation.InvertibleTableTransformer.getNamesOfChangedColumns data-toc-label='getNamesOfChangedColumns'}
+
+Get the names of all columns that have been changed by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of changed columns, ordered as they appear in the table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="53"
+    @Pure
+    @PythonName("get_names_of_changed_columns")
+    fun getNamesOfChangedColumns() -> result1: List<String>
+    ```
+
+## `#!sds fun` getNamesOfRemovedColumns {#safeds.data.tabular.transformation.InvertibleTableTransformer.getNamesOfRemovedColumns data-toc-label='getNamesOfRemovedColumns'}
+
+Get the names of all columns that have been removed by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of the removed columns, ordered as they appear in the table the transformer was fitted on. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="62"
+    @Pure
+    @PythonName("get_names_of_removed_columns")
+    fun getNamesOfRemovedColumns() -> result1: List<String>
+    ```
+
 ## `#!sds fun` inverseTransform {#safeds.data.tabular.transformation.InvertibleTableTransformer.inverseTransform data-toc-label='inverseTransform'}
 
 Undo the learned transformation.
@@ -91,5 +175,50 @@ The table is not modified.
     @PythonName("inverse_transform")
     fun inverseTransform(
         @PythonName("transformed_table") transformedTable: Table
+    ) -> result1: Table
+    ```
+
+## `#!sds fun` isFitted {#safeds.data.tabular.transformation.InvertibleTableTransformer.isFitted data-toc-label='isFitted'}
+
+Check if the transformer is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Boolean`][safeds.lang.Boolean] | Whether the transformer is fitted. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="71"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> result1: Boolean
+    ```
+
+## `#!sds fun` transform {#safeds.data.tabular.transformation.InvertibleTableTransformer.transform data-toc-label='transform'}
+
+Apply the learned transformation to a table.
+
+The table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `table` | [`Table`][safeds.data.tabular.containers.Table] | The table to which the learned transformation is applied. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The transformed table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="34"
+    @Pure
+    fun transform(
+        table: Table
     ) -> result1: Table
     ```

--- a/docs/api/safeds/data/tabular/transformation/LabelEncoder.md
+++ b/docs/api/safeds/data/tabular/transformation/LabelEncoder.md
@@ -54,3 +54,160 @@ This transformer is not modified.
         @PythonName("column_names") columnNames: List<String>?
     ) -> result1: LabelEncoder
     ```
+
+## `#!sds fun` fitAndTransform {#safeds.data.tabular.transformation.LabelEncoder.fitAndTransform data-toc-label='fitAndTransform'}
+
+Learn a transformation for a set of columns in a table and apply the learned transformation to the same table.
+
+The table is not modified. If you also need the fitted transformer, use `fit` and `transform` separately.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `table` | [`Table`][safeds.data.tabular.containers.Table] | The table used to fit the transformer. The transformer is then applied to this table. | - |
+| `columnNames` | [`List<String>?`][safeds.lang.List] | The list of columns from the table used to fit the transformer. If `None`, all columns are used. | `#!sds null` |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The transformed table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="85"
+    @Pure
+    @PythonName("fit_and_transform")
+    fun fitAndTransform(
+        table: Table,
+        @PythonName("column_names") columnNames: List<String>? = null
+    ) -> result1: Table
+    ```
+
+## `#!sds fun` getNamesOfAddedColumns {#safeds.data.tabular.transformation.LabelEncoder.getNamesOfAddedColumns data-toc-label='getNamesOfAddedColumns'}
+
+Get the names of all new columns that have been added by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of the added columns, ordered as they will appear in the table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="44"
+    @Pure
+    @PythonName("get_names_of_added_columns")
+    fun getNamesOfAddedColumns() -> result1: List<String>
+    ```
+
+## `#!sds fun` getNamesOfChangedColumns {#safeds.data.tabular.transformation.LabelEncoder.getNamesOfChangedColumns data-toc-label='getNamesOfChangedColumns'}
+
+Get the names of all columns that have been changed by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of changed columns, ordered as they appear in the table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="53"
+    @Pure
+    @PythonName("get_names_of_changed_columns")
+    fun getNamesOfChangedColumns() -> result1: List<String>
+    ```
+
+## `#!sds fun` getNamesOfRemovedColumns {#safeds.data.tabular.transformation.LabelEncoder.getNamesOfRemovedColumns data-toc-label='getNamesOfRemovedColumns'}
+
+Get the names of all columns that have been removed by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of the removed columns, ordered as they appear in the table the transformer was fitted on. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="62"
+    @Pure
+    @PythonName("get_names_of_removed_columns")
+    fun getNamesOfRemovedColumns() -> result1: List<String>
+    ```
+
+## `#!sds fun` inverseTransform {#safeds.data.tabular.transformation.LabelEncoder.inverseTransform data-toc-label='inverseTransform'}
+
+Undo the learned transformation.
+
+The table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `transformedTable` | [`Table`][safeds.data.tabular.containers.Table] | The table to be transformed back to the original version. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The original table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="120"
+    @Pure
+    @PythonName("inverse_transform")
+    fun inverseTransform(
+        @PythonName("transformed_table") transformedTable: Table
+    ) -> result1: Table
+    ```
+
+## `#!sds fun` isFitted {#safeds.data.tabular.transformation.LabelEncoder.isFitted data-toc-label='isFitted'}
+
+Check if the transformer is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Boolean`][safeds.lang.Boolean] | Whether the transformer is fitted. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="71"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> result1: Boolean
+    ```
+
+## `#!sds fun` transform {#safeds.data.tabular.transformation.LabelEncoder.transform data-toc-label='transform'}
+
+Apply the learned transformation to a table.
+
+The table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `table` | [`Table`][safeds.data.tabular.containers.Table] | The table to which the learned transformation is applied. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The transformed table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="34"
+    @Pure
+    fun transform(
+        table: Table
+    ) -> result1: Table
+    ```

--- a/docs/api/safeds/data/tabular/transformation/OneHotEncoder.md
+++ b/docs/api/safeds/data/tabular/transformation/OneHotEncoder.md
@@ -77,3 +77,160 @@ This transformer is not modified.
         @PythonName("column_names") columnNames: List<String>?
     ) -> result1: OneHotEncoder
     ```
+
+## `#!sds fun` fitAndTransform {#safeds.data.tabular.transformation.OneHotEncoder.fitAndTransform data-toc-label='fitAndTransform'}
+
+Learn a transformation for a set of columns in a table and apply the learned transformation to the same table.
+
+The table is not modified. If you also need the fitted transformer, use `fit` and `transform` separately.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `table` | [`Table`][safeds.data.tabular.containers.Table] | The table used to fit the transformer. The transformer is then applied to this table. | - |
+| `columnNames` | [`List<String>?`][safeds.lang.List] | The list of columns from the table used to fit the transformer. If `None`, all columns are used. | `#!sds null` |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The transformed table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="85"
+    @Pure
+    @PythonName("fit_and_transform")
+    fun fitAndTransform(
+        table: Table,
+        @PythonName("column_names") columnNames: List<String>? = null
+    ) -> result1: Table
+    ```
+
+## `#!sds fun` getNamesOfAddedColumns {#safeds.data.tabular.transformation.OneHotEncoder.getNamesOfAddedColumns data-toc-label='getNamesOfAddedColumns'}
+
+Get the names of all new columns that have been added by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of the added columns, ordered as they will appear in the table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="44"
+    @Pure
+    @PythonName("get_names_of_added_columns")
+    fun getNamesOfAddedColumns() -> result1: List<String>
+    ```
+
+## `#!sds fun` getNamesOfChangedColumns {#safeds.data.tabular.transformation.OneHotEncoder.getNamesOfChangedColumns data-toc-label='getNamesOfChangedColumns'}
+
+Get the names of all columns that have been changed by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of changed columns, ordered as they appear in the table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="53"
+    @Pure
+    @PythonName("get_names_of_changed_columns")
+    fun getNamesOfChangedColumns() -> result1: List<String>
+    ```
+
+## `#!sds fun` getNamesOfRemovedColumns {#safeds.data.tabular.transformation.OneHotEncoder.getNamesOfRemovedColumns data-toc-label='getNamesOfRemovedColumns'}
+
+Get the names of all columns that have been removed by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of the removed columns, ordered as they appear in the table the transformer was fitted on. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="62"
+    @Pure
+    @PythonName("get_names_of_removed_columns")
+    fun getNamesOfRemovedColumns() -> result1: List<String>
+    ```
+
+## `#!sds fun` inverseTransform {#safeds.data.tabular.transformation.OneHotEncoder.inverseTransform data-toc-label='inverseTransform'}
+
+Undo the learned transformation.
+
+The table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `transformedTable` | [`Table`][safeds.data.tabular.containers.Table] | The table to be transformed back to the original version. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The original table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="120"
+    @Pure
+    @PythonName("inverse_transform")
+    fun inverseTransform(
+        @PythonName("transformed_table") transformedTable: Table
+    ) -> result1: Table
+    ```
+
+## `#!sds fun` isFitted {#safeds.data.tabular.transformation.OneHotEncoder.isFitted data-toc-label='isFitted'}
+
+Check if the transformer is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Boolean`][safeds.lang.Boolean] | Whether the transformer is fitted. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="71"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> result1: Boolean
+    ```
+
+## `#!sds fun` transform {#safeds.data.tabular.transformation.OneHotEncoder.transform data-toc-label='transform'}
+
+Apply the learned transformation to a table.
+
+The table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `table` | [`Table`][safeds.data.tabular.containers.Table] | The table to which the learned transformation is applied. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The transformed table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="34"
+    @Pure
+    fun transform(
+        table: Table
+    ) -> result1: Table
+    ```

--- a/docs/api/safeds/data/tabular/transformation/RangeScaler.md
+++ b/docs/api/safeds/data/tabular/transformation/RangeScaler.md
@@ -64,3 +64,160 @@ This transformer is not modified.
         @PythonName("column_names") columnNames: List<String>?
     ) -> result1: RangeScaler
     ```
+
+## `#!sds fun` fitAndTransform {#safeds.data.tabular.transformation.RangeScaler.fitAndTransform data-toc-label='fitAndTransform'}
+
+Learn a transformation for a set of columns in a table and apply the learned transformation to the same table.
+
+The table is not modified. If you also need the fitted transformer, use `fit` and `transform` separately.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `table` | [`Table`][safeds.data.tabular.containers.Table] | The table used to fit the transformer. The transformer is then applied to this table. | - |
+| `columnNames` | [`List<String>?`][safeds.lang.List] | The list of columns from the table used to fit the transformer. If `None`, all columns are used. | `#!sds null` |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The transformed table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="85"
+    @Pure
+    @PythonName("fit_and_transform")
+    fun fitAndTransform(
+        table: Table,
+        @PythonName("column_names") columnNames: List<String>? = null
+    ) -> result1: Table
+    ```
+
+## `#!sds fun` getNamesOfAddedColumns {#safeds.data.tabular.transformation.RangeScaler.getNamesOfAddedColumns data-toc-label='getNamesOfAddedColumns'}
+
+Get the names of all new columns that have been added by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of the added columns, ordered as they will appear in the table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="44"
+    @Pure
+    @PythonName("get_names_of_added_columns")
+    fun getNamesOfAddedColumns() -> result1: List<String>
+    ```
+
+## `#!sds fun` getNamesOfChangedColumns {#safeds.data.tabular.transformation.RangeScaler.getNamesOfChangedColumns data-toc-label='getNamesOfChangedColumns'}
+
+Get the names of all columns that have been changed by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of changed columns, ordered as they appear in the table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="53"
+    @Pure
+    @PythonName("get_names_of_changed_columns")
+    fun getNamesOfChangedColumns() -> result1: List<String>
+    ```
+
+## `#!sds fun` getNamesOfRemovedColumns {#safeds.data.tabular.transformation.RangeScaler.getNamesOfRemovedColumns data-toc-label='getNamesOfRemovedColumns'}
+
+Get the names of all columns that have been removed by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of the removed columns, ordered as they appear in the table the transformer was fitted on. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="62"
+    @Pure
+    @PythonName("get_names_of_removed_columns")
+    fun getNamesOfRemovedColumns() -> result1: List<String>
+    ```
+
+## `#!sds fun` inverseTransform {#safeds.data.tabular.transformation.RangeScaler.inverseTransform data-toc-label='inverseTransform'}
+
+Undo the learned transformation.
+
+The table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `transformedTable` | [`Table`][safeds.data.tabular.containers.Table] | The table to be transformed back to the original version. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The original table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="120"
+    @Pure
+    @PythonName("inverse_transform")
+    fun inverseTransform(
+        @PythonName("transformed_table") transformedTable: Table
+    ) -> result1: Table
+    ```
+
+## `#!sds fun` isFitted {#safeds.data.tabular.transformation.RangeScaler.isFitted data-toc-label='isFitted'}
+
+Check if the transformer is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Boolean`][safeds.lang.Boolean] | Whether the transformer is fitted. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="71"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> result1: Boolean
+    ```
+
+## `#!sds fun` transform {#safeds.data.tabular.transformation.RangeScaler.transform data-toc-label='transform'}
+
+Apply the learned transformation to a table.
+
+The table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `table` | [`Table`][safeds.data.tabular.containers.Table] | The table to which the learned transformation is applied. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The transformed table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="34"
+    @Pure
+    fun transform(
+        table: Table
+    ) -> result1: Table
+    ```

--- a/docs/api/safeds/data/tabular/transformation/StandardScaler.md
+++ b/docs/api/safeds/data/tabular/transformation/StandardScaler.md
@@ -54,3 +54,160 @@ This transformer is not modified.
         @PythonName("column_names") columnNames: List<String>?
     ) -> result1: StandardScaler
     ```
+
+## `#!sds fun` fitAndTransform {#safeds.data.tabular.transformation.StandardScaler.fitAndTransform data-toc-label='fitAndTransform'}
+
+Learn a transformation for a set of columns in a table and apply the learned transformation to the same table.
+
+The table is not modified. If you also need the fitted transformer, use `fit` and `transform` separately.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `table` | [`Table`][safeds.data.tabular.containers.Table] | The table used to fit the transformer. The transformer is then applied to this table. | - |
+| `columnNames` | [`List<String>?`][safeds.lang.List] | The list of columns from the table used to fit the transformer. If `None`, all columns are used. | `#!sds null` |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The transformed table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="85"
+    @Pure
+    @PythonName("fit_and_transform")
+    fun fitAndTransform(
+        table: Table,
+        @PythonName("column_names") columnNames: List<String>? = null
+    ) -> result1: Table
+    ```
+
+## `#!sds fun` getNamesOfAddedColumns {#safeds.data.tabular.transformation.StandardScaler.getNamesOfAddedColumns data-toc-label='getNamesOfAddedColumns'}
+
+Get the names of all new columns that have been added by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of the added columns, ordered as they will appear in the table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="44"
+    @Pure
+    @PythonName("get_names_of_added_columns")
+    fun getNamesOfAddedColumns() -> result1: List<String>
+    ```
+
+## `#!sds fun` getNamesOfChangedColumns {#safeds.data.tabular.transformation.StandardScaler.getNamesOfChangedColumns data-toc-label='getNamesOfChangedColumns'}
+
+Get the names of all columns that have been changed by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of changed columns, ordered as they appear in the table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="53"
+    @Pure
+    @PythonName("get_names_of_changed_columns")
+    fun getNamesOfChangedColumns() -> result1: List<String>
+    ```
+
+## `#!sds fun` getNamesOfRemovedColumns {#safeds.data.tabular.transformation.StandardScaler.getNamesOfRemovedColumns data-toc-label='getNamesOfRemovedColumns'}
+
+Get the names of all columns that have been removed by the transformer.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`List<String>`][safeds.lang.List] | A list of names of the removed columns, ordered as they appear in the table the transformer was fitted on. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="62"
+    @Pure
+    @PythonName("get_names_of_removed_columns")
+    fun getNamesOfRemovedColumns() -> result1: List<String>
+    ```
+
+## `#!sds fun` inverseTransform {#safeds.data.tabular.transformation.StandardScaler.inverseTransform data-toc-label='inverseTransform'}
+
+Undo the learned transformation.
+
+The table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `transformedTable` | [`Table`][safeds.data.tabular.containers.Table] | The table to be transformed back to the original version. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The original table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="120"
+    @Pure
+    @PythonName("inverse_transform")
+    fun inverseTransform(
+        @PythonName("transformed_table") transformedTable: Table
+    ) -> result1: Table
+    ```
+
+## `#!sds fun` isFitted {#safeds.data.tabular.transformation.StandardScaler.isFitted data-toc-label='isFitted'}
+
+Check if the transformer is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Boolean`][safeds.lang.Boolean] | Whether the transformer is fitted. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="71"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> result1: Boolean
+    ```
+
+## `#!sds fun` transform {#safeds.data.tabular.transformation.StandardScaler.transform data-toc-label='transform'}
+
+Apply the learned transformation to a table.
+
+The table is not modified.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `table` | [`Table`][safeds.data.tabular.containers.Table] | The table to which the learned transformation is applied. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `result1` | [`Table`][safeds.data.tabular.containers.Table] | The transformed table. |
+
+??? quote "Stub code in `table_transformer.sdsstub`"
+
+    ```sds linenums="34"
+    @Pure
+    fun transform(
+        table: Table
+    ) -> result1: Table
+    ```

--- a/docs/api/safeds/ml/classical/classification/AdaBoostClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/AdaBoostClassifier.md
@@ -70,6 +70,59 @@ Get the maximum number of learners in the ensemble.
 
 **Type:** [`Int`][safeds.lang.Int]
 
+## `#!sds fun` accuracy {#safeds.ml.classical.classification.AdaBoostClassifier.accuracy data-toc-label='accuracy'}
+
+Compute the accuracy of the classifier on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `accuracy` | [`Float`][safeds.lang.Float] | The calculated accuracy score, i.e. the percentage of equal data. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="51"
+    @Pure
+    fun accuracy(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> accuracy: Float
+    ```
+
+## `#!sds fun` f1Score {#safeds.ml.classical.classification.AdaBoostClassifier.f1Score data-toc-label='f1Score'}
+
+Compute the classifier's $F_1$-score on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `f1Score` | [`Float`][safeds.lang.Float] | The calculated $F_1$-score, i.e. the harmonic mean between precision and recall. Return 1 if there are no positive expectations and predictions. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="95"
+    @Pure
+    @PythonName("f1_score")
+    fun f1Score(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> f1Score: Float
+    ```
+
 ## `#!sds fun` fit {#safeds.ml.classical.classification.AdaBoostClassifier.fit data-toc-label='fit'}
 
 Create a copy of this classifier and fit it with the given training data.
@@ -95,4 +148,101 @@ This classifier is not modified.
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable
     ) -> fittedClassifier: AdaBoostClassifier
+    ```
+
+## `#!sds fun` isFitted {#safeds.ml.classical.classification.AdaBoostClassifier.isFitted data-toc-label='isFitted'}
+
+Check if the classifier is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `isFitted` | [`Boolean`][safeds.lang.Boolean] | Whether the classifier is fitted. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="40"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> isFitted: Boolean
+    ```
+
+## `#!sds fun` precision {#safeds.ml.classical.classification.AdaBoostClassifier.precision data-toc-label='precision'}
+
+Compute the classifier's precision on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `precision` | [`Float`][safeds.lang.Float] | The calculated precision score, i.e. the ratio of correctly predicted positives to all predicted positives. Return 1 if no positive predictions are made. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="65"
+    @Pure
+    fun precision(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> precision: Float
+    ```
+
+## `#!sds fun` predict {#safeds.ml.classical.classification.AdaBoostClassifier.predict data-toc-label='predict'}
+
+Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `dataset` | [`Table`][safeds.data.tabular.containers.Table] | The dataset containing the feature vectors. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `prediction` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A dataset containing the given feature vectors and the predicted target vector. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="30"
+    @Pure
+    fun predict(
+        dataset: Table
+    ) -> prediction: TaggedTable
+    ```
+
+## `#!sds fun` recall {#safeds.ml.classical.classification.AdaBoostClassifier.recall data-toc-label='recall'}
+
+Compute the classifier's recall on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `recall` | [`Float`][safeds.lang.Float] | The calculated recall score, i.e. the ratio of correctly predicted positives to all expected positives. Return 1 if there are no positive expectations. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="80"
+    @Pure
+    fun recall(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> recall: Float
     ```

--- a/docs/api/safeds/ml/classical/classification/DecisionTreeClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/DecisionTreeClassifier.md
@@ -24,6 +24,59 @@ Decision tree classification.
     }
     ```
 
+## `#!sds fun` accuracy {#safeds.ml.classical.classification.DecisionTreeClassifier.accuracy data-toc-label='accuracy'}
+
+Compute the accuracy of the classifier on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `accuracy` | [`Float`][safeds.lang.Float] | The calculated accuracy score, i.e. the percentage of equal data. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="51"
+    @Pure
+    fun accuracy(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> accuracy: Float
+    ```
+
+## `#!sds fun` f1Score {#safeds.ml.classical.classification.DecisionTreeClassifier.f1Score data-toc-label='f1Score'}
+
+Compute the classifier's $F_1$-score on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `f1Score` | [`Float`][safeds.lang.Float] | The calculated $F_1$-score, i.e. the harmonic mean between precision and recall. Return 1 if there are no positive expectations and predictions. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="95"
+    @Pure
+    @PythonName("f1_score")
+    fun f1Score(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> f1Score: Float
+    ```
+
 ## `#!sds fun` fit {#safeds.ml.classical.classification.DecisionTreeClassifier.fit data-toc-label='fit'}
 
 Create a copy of this classifier and fit it with the given training data.
@@ -49,4 +102,101 @@ This classifier is not modified.
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable
     ) -> fittedClassifier: DecisionTreeClassifier
+    ```
+
+## `#!sds fun` isFitted {#safeds.ml.classical.classification.DecisionTreeClassifier.isFitted data-toc-label='isFitted'}
+
+Check if the classifier is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `isFitted` | [`Boolean`][safeds.lang.Boolean] | Whether the classifier is fitted. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="40"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> isFitted: Boolean
+    ```
+
+## `#!sds fun` precision {#safeds.ml.classical.classification.DecisionTreeClassifier.precision data-toc-label='precision'}
+
+Compute the classifier's precision on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `precision` | [`Float`][safeds.lang.Float] | The calculated precision score, i.e. the ratio of correctly predicted positives to all predicted positives. Return 1 if no positive predictions are made. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="65"
+    @Pure
+    fun precision(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> precision: Float
+    ```
+
+## `#!sds fun` predict {#safeds.ml.classical.classification.DecisionTreeClassifier.predict data-toc-label='predict'}
+
+Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `dataset` | [`Table`][safeds.data.tabular.containers.Table] | The dataset containing the feature vectors. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `prediction` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A dataset containing the given feature vectors and the predicted target vector. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="30"
+    @Pure
+    fun predict(
+        dataset: Table
+    ) -> prediction: TaggedTable
+    ```
+
+## `#!sds fun` recall {#safeds.ml.classical.classification.DecisionTreeClassifier.recall data-toc-label='recall'}
+
+Compute the classifier's recall on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `recall` | [`Float`][safeds.lang.Float] | The calculated recall score, i.e. the ratio of correctly predicted positives to all expected positives. Return 1 if there are no positive expectations. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="80"
+    @Pure
+    fun recall(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> recall: Float
     ```

--- a/docs/api/safeds/ml/classical/classification/GradientBoostingClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/GradientBoostingClassifier.md
@@ -58,6 +58,59 @@ Get the number of trees (estimators) in the ensemble.
 
 **Type:** [`Int`][safeds.lang.Int]
 
+## `#!sds fun` accuracy {#safeds.ml.classical.classification.GradientBoostingClassifier.accuracy data-toc-label='accuracy'}
+
+Compute the accuracy of the classifier on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `accuracy` | [`Float`][safeds.lang.Float] | The calculated accuracy score, i.e. the percentage of equal data. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="51"
+    @Pure
+    fun accuracy(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> accuracy: Float
+    ```
+
+## `#!sds fun` f1Score {#safeds.ml.classical.classification.GradientBoostingClassifier.f1Score data-toc-label='f1Score'}
+
+Compute the classifier's $F_1$-score on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `f1Score` | [`Float`][safeds.lang.Float] | The calculated $F_1$-score, i.e. the harmonic mean between precision and recall. Return 1 if there are no positive expectations and predictions. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="95"
+    @Pure
+    @PythonName("f1_score")
+    fun f1Score(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> f1Score: Float
+    ```
+
 ## `#!sds fun` fit {#safeds.ml.classical.classification.GradientBoostingClassifier.fit data-toc-label='fit'}
 
 Create a copy of this classifier and fit it with the given training data.
@@ -83,4 +136,101 @@ This classifier is not modified.
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable
     ) -> fittedClassifier: GradientBoostingClassifier
+    ```
+
+## `#!sds fun` isFitted {#safeds.ml.classical.classification.GradientBoostingClassifier.isFitted data-toc-label='isFitted'}
+
+Check if the classifier is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `isFitted` | [`Boolean`][safeds.lang.Boolean] | Whether the classifier is fitted. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="40"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> isFitted: Boolean
+    ```
+
+## `#!sds fun` precision {#safeds.ml.classical.classification.GradientBoostingClassifier.precision data-toc-label='precision'}
+
+Compute the classifier's precision on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `precision` | [`Float`][safeds.lang.Float] | The calculated precision score, i.e. the ratio of correctly predicted positives to all predicted positives. Return 1 if no positive predictions are made. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="65"
+    @Pure
+    fun precision(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> precision: Float
+    ```
+
+## `#!sds fun` predict {#safeds.ml.classical.classification.GradientBoostingClassifier.predict data-toc-label='predict'}
+
+Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `dataset` | [`Table`][safeds.data.tabular.containers.Table] | The dataset containing the feature vectors. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `prediction` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A dataset containing the given feature vectors and the predicted target vector. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="30"
+    @Pure
+    fun predict(
+        dataset: Table
+    ) -> prediction: TaggedTable
+    ```
+
+## `#!sds fun` recall {#safeds.ml.classical.classification.GradientBoostingClassifier.recall data-toc-label='recall'}
+
+Compute the classifier's recall on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `recall` | [`Float`][safeds.lang.Float] | The calculated recall score, i.e. the ratio of correctly predicted positives to all expected positives. Return 1 if there are no positive expectations. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="80"
+    @Pure
+    fun recall(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> recall: Float
     ```

--- a/docs/api/safeds/ml/classical/classification/KNearestNeighborsClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/KNearestNeighborsClassifier.md
@@ -45,6 +45,59 @@ Get the number of neighbors used for interpolation.
 
 **Type:** [`Int`][safeds.lang.Int]
 
+## `#!sds fun` accuracy {#safeds.ml.classical.classification.KNearestNeighborsClassifier.accuracy data-toc-label='accuracy'}
+
+Compute the accuracy of the classifier on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `accuracy` | [`Float`][safeds.lang.Float] | The calculated accuracy score, i.e. the percentage of equal data. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="51"
+    @Pure
+    fun accuracy(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> accuracy: Float
+    ```
+
+## `#!sds fun` f1Score {#safeds.ml.classical.classification.KNearestNeighborsClassifier.f1Score data-toc-label='f1Score'}
+
+Compute the classifier's $F_1$-score on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `f1Score` | [`Float`][safeds.lang.Float] | The calculated $F_1$-score, i.e. the harmonic mean between precision and recall. Return 1 if there are no positive expectations and predictions. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="95"
+    @Pure
+    @PythonName("f1_score")
+    fun f1Score(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> f1Score: Float
+    ```
+
 ## `#!sds fun` fit {#safeds.ml.classical.classification.KNearestNeighborsClassifier.fit data-toc-label='fit'}
 
 Create a copy of this classifier and fit it with the given training data.
@@ -70,4 +123,101 @@ This classifier is not modified.
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable
     ) -> fittedClassifier: KNearestNeighborsClassifier
+    ```
+
+## `#!sds fun` isFitted {#safeds.ml.classical.classification.KNearestNeighborsClassifier.isFitted data-toc-label='isFitted'}
+
+Check if the classifier is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `isFitted` | [`Boolean`][safeds.lang.Boolean] | Whether the classifier is fitted. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="40"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> isFitted: Boolean
+    ```
+
+## `#!sds fun` precision {#safeds.ml.classical.classification.KNearestNeighborsClassifier.precision data-toc-label='precision'}
+
+Compute the classifier's precision on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `precision` | [`Float`][safeds.lang.Float] | The calculated precision score, i.e. the ratio of correctly predicted positives to all predicted positives. Return 1 if no positive predictions are made. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="65"
+    @Pure
+    fun precision(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> precision: Float
+    ```
+
+## `#!sds fun` predict {#safeds.ml.classical.classification.KNearestNeighborsClassifier.predict data-toc-label='predict'}
+
+Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `dataset` | [`Table`][safeds.data.tabular.containers.Table] | The dataset containing the feature vectors. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `prediction` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A dataset containing the given feature vectors and the predicted target vector. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="30"
+    @Pure
+    fun predict(
+        dataset: Table
+    ) -> prediction: TaggedTable
+    ```
+
+## `#!sds fun` recall {#safeds.ml.classical.classification.KNearestNeighborsClassifier.recall data-toc-label='recall'}
+
+Compute the classifier's recall on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `recall` | [`Float`][safeds.lang.Float] | The calculated recall score, i.e. the ratio of correctly predicted positives to all expected positives. Return 1 if there are no positive expectations. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="80"
+    @Pure
+    fun recall(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> recall: Float
     ```

--- a/docs/api/safeds/ml/classical/classification/LogisticRegressionClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/LogisticRegressionClassifier.md
@@ -24,6 +24,59 @@ Regularized logistic regression.
     }
     ```
 
+## `#!sds fun` accuracy {#safeds.ml.classical.classification.LogisticRegressionClassifier.accuracy data-toc-label='accuracy'}
+
+Compute the accuracy of the classifier on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `accuracy` | [`Float`][safeds.lang.Float] | The calculated accuracy score, i.e. the percentage of equal data. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="51"
+    @Pure
+    fun accuracy(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> accuracy: Float
+    ```
+
+## `#!sds fun` f1Score {#safeds.ml.classical.classification.LogisticRegressionClassifier.f1Score data-toc-label='f1Score'}
+
+Compute the classifier's $F_1$-score on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `f1Score` | [`Float`][safeds.lang.Float] | The calculated $F_1$-score, i.e. the harmonic mean between precision and recall. Return 1 if there are no positive expectations and predictions. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="95"
+    @Pure
+    @PythonName("f1_score")
+    fun f1Score(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> f1Score: Float
+    ```
+
 ## `#!sds fun` fit {#safeds.ml.classical.classification.LogisticRegressionClassifier.fit data-toc-label='fit'}
 
 Create a copy of this classifier and fit it with the given training data.
@@ -49,4 +102,101 @@ This classifier is not modified.
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable
     ) -> fittedClassifier: LogisticRegressionClassifier
+    ```
+
+## `#!sds fun` isFitted {#safeds.ml.classical.classification.LogisticRegressionClassifier.isFitted data-toc-label='isFitted'}
+
+Check if the classifier is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `isFitted` | [`Boolean`][safeds.lang.Boolean] | Whether the classifier is fitted. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="40"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> isFitted: Boolean
+    ```
+
+## `#!sds fun` precision {#safeds.ml.classical.classification.LogisticRegressionClassifier.precision data-toc-label='precision'}
+
+Compute the classifier's precision on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `precision` | [`Float`][safeds.lang.Float] | The calculated precision score, i.e. the ratio of correctly predicted positives to all predicted positives. Return 1 if no positive predictions are made. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="65"
+    @Pure
+    fun precision(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> precision: Float
+    ```
+
+## `#!sds fun` predict {#safeds.ml.classical.classification.LogisticRegressionClassifier.predict data-toc-label='predict'}
+
+Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `dataset` | [`Table`][safeds.data.tabular.containers.Table] | The dataset containing the feature vectors. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `prediction` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A dataset containing the given feature vectors and the predicted target vector. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="30"
+    @Pure
+    fun predict(
+        dataset: Table
+    ) -> prediction: TaggedTable
+    ```
+
+## `#!sds fun` recall {#safeds.ml.classical.classification.LogisticRegressionClassifier.recall data-toc-label='recall'}
+
+Compute the classifier's recall on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `recall` | [`Float`][safeds.lang.Float] | The calculated recall score, i.e. the ratio of correctly predicted positives to all expected positives. Return 1 if there are no positive expectations. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="80"
+    @Pure
+    fun recall(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> recall: Float
     ```

--- a/docs/api/safeds/ml/classical/classification/RandomForestClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/RandomForestClassifier.md
@@ -45,6 +45,59 @@ Get the number of trees used in the random forest.
 
 **Type:** [`Int`][safeds.lang.Int]
 
+## `#!sds fun` accuracy {#safeds.ml.classical.classification.RandomForestClassifier.accuracy data-toc-label='accuracy'}
+
+Compute the accuracy of the classifier on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `accuracy` | [`Float`][safeds.lang.Float] | The calculated accuracy score, i.e. the percentage of equal data. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="51"
+    @Pure
+    fun accuracy(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> accuracy: Float
+    ```
+
+## `#!sds fun` f1Score {#safeds.ml.classical.classification.RandomForestClassifier.f1Score data-toc-label='f1Score'}
+
+Compute the classifier's $F_1$-score on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `f1Score` | [`Float`][safeds.lang.Float] | The calculated $F_1$-score, i.e. the harmonic mean between precision and recall. Return 1 if there are no positive expectations and predictions. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="95"
+    @Pure
+    @PythonName("f1_score")
+    fun f1Score(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> f1Score: Float
+    ```
+
 ## `#!sds fun` fit {#safeds.ml.classical.classification.RandomForestClassifier.fit data-toc-label='fit'}
 
 Create a copy of this classifier and fit it with the given training data.
@@ -70,4 +123,101 @@ This classifier is not modified.
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable
     ) -> fittedClassifier: RandomForestClassifier
+    ```
+
+## `#!sds fun` isFitted {#safeds.ml.classical.classification.RandomForestClassifier.isFitted data-toc-label='isFitted'}
+
+Check if the classifier is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `isFitted` | [`Boolean`][safeds.lang.Boolean] | Whether the classifier is fitted. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="40"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> isFitted: Boolean
+    ```
+
+## `#!sds fun` precision {#safeds.ml.classical.classification.RandomForestClassifier.precision data-toc-label='precision'}
+
+Compute the classifier's precision on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `precision` | [`Float`][safeds.lang.Float] | The calculated precision score, i.e. the ratio of correctly predicted positives to all predicted positives. Return 1 if no positive predictions are made. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="65"
+    @Pure
+    fun precision(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> precision: Float
+    ```
+
+## `#!sds fun` predict {#safeds.ml.classical.classification.RandomForestClassifier.predict data-toc-label='predict'}
+
+Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `dataset` | [`Table`][safeds.data.tabular.containers.Table] | The dataset containing the feature vectors. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `prediction` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A dataset containing the given feature vectors and the predicted target vector. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="30"
+    @Pure
+    fun predict(
+        dataset: Table
+    ) -> prediction: TaggedTable
+    ```
+
+## `#!sds fun` recall {#safeds.ml.classical.classification.RandomForestClassifier.recall data-toc-label='recall'}
+
+Compute the classifier's recall on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `recall` | [`Float`][safeds.lang.Float] | The calculated recall score, i.e. the ratio of correctly predicted positives to all expected positives. Return 1 if there are no positive expectations. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="80"
+    @Pure
+    fun recall(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> recall: Float
     ```

--- a/docs/api/safeds/ml/classical/classification/SupportVectorMachineClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/SupportVectorMachineClassifier.md
@@ -84,6 +84,59 @@ Get the type of kernel used.
 
 **Type:** [`Kernel`][safeds.ml.classical.classification.SupportVectorMachineClassifier.Kernel]
 
+## `#!sds fun` accuracy {#safeds.ml.classical.classification.SupportVectorMachineClassifier.accuracy data-toc-label='accuracy'}
+
+Compute the accuracy of the classifier on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `accuracy` | [`Float`][safeds.lang.Float] | The calculated accuracy score, i.e. the percentage of equal data. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="51"
+    @Pure
+    fun accuracy(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> accuracy: Float
+    ```
+
+## `#!sds fun` f1Score {#safeds.ml.classical.classification.SupportVectorMachineClassifier.f1Score data-toc-label='f1Score'}
+
+Compute the classifier's $F_1$-score on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `f1Score` | [`Float`][safeds.lang.Float] | The calculated $F_1$-score, i.e. the harmonic mean between precision and recall. Return 1 if there are no positive expectations and predictions. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="95"
+    @Pure
+    @PythonName("f1_score")
+    fun f1Score(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> f1Score: Float
+    ```
+
 ## `#!sds fun` fit {#safeds.ml.classical.classification.SupportVectorMachineClassifier.fit data-toc-label='fit'}
 
 Create a copy of this classifier and fit it with the given training data.
@@ -109,6 +162,103 @@ This classifier is not modified.
     fun fit(
         @PythonName("training_set") trainingSet: TaggedTable
     ) -> fittedClassifier: SupportVectorMachineClassifier
+    ```
+
+## `#!sds fun` isFitted {#safeds.ml.classical.classification.SupportVectorMachineClassifier.isFitted data-toc-label='isFitted'}
+
+Check if the classifier is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `isFitted` | [`Boolean`][safeds.lang.Boolean] | Whether the classifier is fitted. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="40"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> isFitted: Boolean
+    ```
+
+## `#!sds fun` precision {#safeds.ml.classical.classification.SupportVectorMachineClassifier.precision data-toc-label='precision'}
+
+Compute the classifier's precision on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `precision` | [`Float`][safeds.lang.Float] | The calculated precision score, i.e. the ratio of correctly predicted positives to all predicted positives. Return 1 if no positive predictions are made. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="65"
+    @Pure
+    fun precision(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> precision: Float
+    ```
+
+## `#!sds fun` predict {#safeds.ml.classical.classification.SupportVectorMachineClassifier.predict data-toc-label='predict'}
+
+Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `dataset` | [`Table`][safeds.data.tabular.containers.Table] | The dataset containing the feature vectors. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `prediction` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A dataset containing the given feature vectors and the predicted target vector. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="30"
+    @Pure
+    fun predict(
+        dataset: Table
+    ) -> prediction: TaggedTable
+    ```
+
+## `#!sds fun` recall {#safeds.ml.classical.classification.SupportVectorMachineClassifier.recall data-toc-label='recall'}
+
+Compute the classifier's recall on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+| `positiveClass` | [`Any`][safeds.lang.Any] | The class to be considered positive. All other classes are considered negative. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `recall` | [`Float`][safeds.lang.Float] | The calculated recall score, i.e. the ratio of correctly predicted positives to all expected positives. Return 1 if there are no positive expectations. |
+
+??? quote "Stub code in `classifier.sdsstub`"
+
+    ```sds linenums="80"
+    @Pure
+    fun recall(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable,
+        @PythonName("positive_class") positiveClass: Any
+    ) -> recall: Float
     ```
 
 ## `#!sds enum` Kernel {#safeds.ml.classical.classification.SupportVectorMachineClassifier.Kernel data-toc-label='Kernel'}

--- a/docs/api/safeds/ml/classical/regression/AdaBoostRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/AdaBoostRegressor.md
@@ -96,3 +96,98 @@ This regressor is not modified.
         @PythonName("training_set") trainingSet: TaggedTable
     ) -> fittedRegressor: AdaBoostRegressor
     ```
+
+## `#!sds fun` isFitted {#safeds.ml.classical.regression.AdaBoostRegressor.isFitted data-toc-label='isFitted'}
+
+Check if the classifier is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `isFitted` | [`Boolean`][safeds.lang.Boolean] | Whether the regressor is fitted. |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="40"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> isFitted: Boolean
+    ```
+
+## `#!sds fun` meanAbsoluteError {#safeds.ml.classical.regression.AdaBoostRegressor.meanAbsoluteError data-toc-label='meanAbsoluteError'}
+
+Compute the mean absolute error (MAE) of the regressor on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `meanAbsoluteError` | [`Float`][safeds.lang.Float] | The calculated mean absolute error (the average of the distance of each individual row). |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="64"
+    @Pure
+    @PythonName("mean_absolute_error")
+    fun meanAbsoluteError(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> meanAbsoluteError: Float
+    ```
+
+## `#!sds fun` meanSquaredError {#safeds.ml.classical.regression.AdaBoostRegressor.meanSquaredError data-toc-label='meanSquaredError'}
+
+Compute the mean squared error (MSE) on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `meanSquaredError` | [`Float`][safeds.lang.Float] | The calculated mean squared error (the average of the distance of each individual row squared). |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="51"
+    @Pure
+    @PythonName("mean_squared_error")
+    fun meanSquaredError(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> meanSquaredError: Float
+    ```
+
+## `#!sds fun` predict {#safeds.ml.classical.regression.AdaBoostRegressor.predict data-toc-label='predict'}
+
+Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `dataset` | [`Table`][safeds.data.tabular.containers.Table] | The dataset containing the feature vectors. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `prediction` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A dataset containing the given feature vectors and the predicted target vector. |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="30"
+    @Pure
+    fun predict(
+        dataset: Table
+    ) -> prediction: TaggedTable
+    ```

--- a/docs/api/safeds/ml/classical/regression/DecisionTreeRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/DecisionTreeRegressor.md
@@ -50,3 +50,98 @@ This regressor is not modified.
         @PythonName("training_set") trainingSet: TaggedTable
     ) -> fittedRegressor: DecisionTreeRegressor
     ```
+
+## `#!sds fun` isFitted {#safeds.ml.classical.regression.DecisionTreeRegressor.isFitted data-toc-label='isFitted'}
+
+Check if the classifier is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `isFitted` | [`Boolean`][safeds.lang.Boolean] | Whether the regressor is fitted. |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="40"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> isFitted: Boolean
+    ```
+
+## `#!sds fun` meanAbsoluteError {#safeds.ml.classical.regression.DecisionTreeRegressor.meanAbsoluteError data-toc-label='meanAbsoluteError'}
+
+Compute the mean absolute error (MAE) of the regressor on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `meanAbsoluteError` | [`Float`][safeds.lang.Float] | The calculated mean absolute error (the average of the distance of each individual row). |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="64"
+    @Pure
+    @PythonName("mean_absolute_error")
+    fun meanAbsoluteError(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> meanAbsoluteError: Float
+    ```
+
+## `#!sds fun` meanSquaredError {#safeds.ml.classical.regression.DecisionTreeRegressor.meanSquaredError data-toc-label='meanSquaredError'}
+
+Compute the mean squared error (MSE) on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `meanSquaredError` | [`Float`][safeds.lang.Float] | The calculated mean squared error (the average of the distance of each individual row squared). |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="51"
+    @Pure
+    @PythonName("mean_squared_error")
+    fun meanSquaredError(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> meanSquaredError: Float
+    ```
+
+## `#!sds fun` predict {#safeds.ml.classical.regression.DecisionTreeRegressor.predict data-toc-label='predict'}
+
+Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `dataset` | [`Table`][safeds.data.tabular.containers.Table] | The dataset containing the feature vectors. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `prediction` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A dataset containing the given feature vectors and the predicted target vector. |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="30"
+    @Pure
+    fun predict(
+        dataset: Table
+    ) -> prediction: TaggedTable
+    ```

--- a/docs/api/safeds/ml/classical/regression/ElasticNetRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/ElasticNetRegressor.md
@@ -85,3 +85,98 @@ This regressor is not modified.
         @PythonName("training_set") trainingSet: TaggedTable
     ) -> fittedRegressor: ElasticNetRegressor
     ```
+
+## `#!sds fun` isFitted {#safeds.ml.classical.regression.ElasticNetRegressor.isFitted data-toc-label='isFitted'}
+
+Check if the classifier is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `isFitted` | [`Boolean`][safeds.lang.Boolean] | Whether the regressor is fitted. |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="40"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> isFitted: Boolean
+    ```
+
+## `#!sds fun` meanAbsoluteError {#safeds.ml.classical.regression.ElasticNetRegressor.meanAbsoluteError data-toc-label='meanAbsoluteError'}
+
+Compute the mean absolute error (MAE) of the regressor on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `meanAbsoluteError` | [`Float`][safeds.lang.Float] | The calculated mean absolute error (the average of the distance of each individual row). |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="64"
+    @Pure
+    @PythonName("mean_absolute_error")
+    fun meanAbsoluteError(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> meanAbsoluteError: Float
+    ```
+
+## `#!sds fun` meanSquaredError {#safeds.ml.classical.regression.ElasticNetRegressor.meanSquaredError data-toc-label='meanSquaredError'}
+
+Compute the mean squared error (MSE) on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `meanSquaredError` | [`Float`][safeds.lang.Float] | The calculated mean squared error (the average of the distance of each individual row squared). |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="51"
+    @Pure
+    @PythonName("mean_squared_error")
+    fun meanSquaredError(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> meanSquaredError: Float
+    ```
+
+## `#!sds fun` predict {#safeds.ml.classical.regression.ElasticNetRegressor.predict data-toc-label='predict'}
+
+Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `dataset` | [`Table`][safeds.data.tabular.containers.Table] | The dataset containing the feature vectors. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `prediction` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A dataset containing the given feature vectors and the predicted target vector. |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="30"
+    @Pure
+    fun predict(
+        dataset: Table
+    ) -> prediction: TaggedTable
+    ```

--- a/docs/api/safeds/ml/classical/regression/GradientBoostingRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/GradientBoostingRegressor.md
@@ -84,3 +84,98 @@ This regressor is not modified.
         @PythonName("training_set") trainingSet: TaggedTable
     ) -> fittedRegressor: GradientBoostingRegressor
     ```
+
+## `#!sds fun` isFitted {#safeds.ml.classical.regression.GradientBoostingRegressor.isFitted data-toc-label='isFitted'}
+
+Check if the classifier is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `isFitted` | [`Boolean`][safeds.lang.Boolean] | Whether the regressor is fitted. |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="40"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> isFitted: Boolean
+    ```
+
+## `#!sds fun` meanAbsoluteError {#safeds.ml.classical.regression.GradientBoostingRegressor.meanAbsoluteError data-toc-label='meanAbsoluteError'}
+
+Compute the mean absolute error (MAE) of the regressor on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `meanAbsoluteError` | [`Float`][safeds.lang.Float] | The calculated mean absolute error (the average of the distance of each individual row). |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="64"
+    @Pure
+    @PythonName("mean_absolute_error")
+    fun meanAbsoluteError(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> meanAbsoluteError: Float
+    ```
+
+## `#!sds fun` meanSquaredError {#safeds.ml.classical.regression.GradientBoostingRegressor.meanSquaredError data-toc-label='meanSquaredError'}
+
+Compute the mean squared error (MSE) on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `meanSquaredError` | [`Float`][safeds.lang.Float] | The calculated mean squared error (the average of the distance of each individual row squared). |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="51"
+    @Pure
+    @PythonName("mean_squared_error")
+    fun meanSquaredError(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> meanSquaredError: Float
+    ```
+
+## `#!sds fun` predict {#safeds.ml.classical.regression.GradientBoostingRegressor.predict data-toc-label='predict'}
+
+Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `dataset` | [`Table`][safeds.data.tabular.containers.Table] | The dataset containing the feature vectors. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `prediction` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A dataset containing the given feature vectors and the predicted target vector. |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="30"
+    @Pure
+    fun predict(
+        dataset: Table
+    ) -> prediction: TaggedTable
+    ```

--- a/docs/api/safeds/ml/classical/regression/KNearestNeighborsRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/KNearestNeighborsRegressor.md
@@ -71,3 +71,98 @@ This regressor is not modified.
         @PythonName("training_set") trainingSet: TaggedTable
     ) -> fittedRegressor: KNearestNeighborsRegressor
     ```
+
+## `#!sds fun` isFitted {#safeds.ml.classical.regression.KNearestNeighborsRegressor.isFitted data-toc-label='isFitted'}
+
+Check if the classifier is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `isFitted` | [`Boolean`][safeds.lang.Boolean] | Whether the regressor is fitted. |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="40"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> isFitted: Boolean
+    ```
+
+## `#!sds fun` meanAbsoluteError {#safeds.ml.classical.regression.KNearestNeighborsRegressor.meanAbsoluteError data-toc-label='meanAbsoluteError'}
+
+Compute the mean absolute error (MAE) of the regressor on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `meanAbsoluteError` | [`Float`][safeds.lang.Float] | The calculated mean absolute error (the average of the distance of each individual row). |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="64"
+    @Pure
+    @PythonName("mean_absolute_error")
+    fun meanAbsoluteError(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> meanAbsoluteError: Float
+    ```
+
+## `#!sds fun` meanSquaredError {#safeds.ml.classical.regression.KNearestNeighborsRegressor.meanSquaredError data-toc-label='meanSquaredError'}
+
+Compute the mean squared error (MSE) on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `meanSquaredError` | [`Float`][safeds.lang.Float] | The calculated mean squared error (the average of the distance of each individual row squared). |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="51"
+    @Pure
+    @PythonName("mean_squared_error")
+    fun meanSquaredError(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> meanSquaredError: Float
+    ```
+
+## `#!sds fun` predict {#safeds.ml.classical.regression.KNearestNeighborsRegressor.predict data-toc-label='predict'}
+
+Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `dataset` | [`Table`][safeds.data.tabular.containers.Table] | The dataset containing the feature vectors. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `prediction` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A dataset containing the given feature vectors and the predicted target vector. |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="30"
+    @Pure
+    fun predict(
+        dataset: Table
+    ) -> prediction: TaggedTable
+    ```

--- a/docs/api/safeds/ml/classical/regression/LassoRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/LassoRegressor.md
@@ -71,3 +71,98 @@ This regressor is not modified.
         @PythonName("training_set") trainingSet: TaggedTable
     ) -> fittedRegressor: LassoRegressor
     ```
+
+## `#!sds fun` isFitted {#safeds.ml.classical.regression.LassoRegressor.isFitted data-toc-label='isFitted'}
+
+Check if the classifier is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `isFitted` | [`Boolean`][safeds.lang.Boolean] | Whether the regressor is fitted. |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="40"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> isFitted: Boolean
+    ```
+
+## `#!sds fun` meanAbsoluteError {#safeds.ml.classical.regression.LassoRegressor.meanAbsoluteError data-toc-label='meanAbsoluteError'}
+
+Compute the mean absolute error (MAE) of the regressor on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `meanAbsoluteError` | [`Float`][safeds.lang.Float] | The calculated mean absolute error (the average of the distance of each individual row). |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="64"
+    @Pure
+    @PythonName("mean_absolute_error")
+    fun meanAbsoluteError(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> meanAbsoluteError: Float
+    ```
+
+## `#!sds fun` meanSquaredError {#safeds.ml.classical.regression.LassoRegressor.meanSquaredError data-toc-label='meanSquaredError'}
+
+Compute the mean squared error (MSE) on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `meanSquaredError` | [`Float`][safeds.lang.Float] | The calculated mean squared error (the average of the distance of each individual row squared). |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="51"
+    @Pure
+    @PythonName("mean_squared_error")
+    fun meanSquaredError(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> meanSquaredError: Float
+    ```
+
+## `#!sds fun` predict {#safeds.ml.classical.regression.LassoRegressor.predict data-toc-label='predict'}
+
+Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `dataset` | [`Table`][safeds.data.tabular.containers.Table] | The dataset containing the feature vectors. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `prediction` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A dataset containing the given feature vectors and the predicted target vector. |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="30"
+    @Pure
+    fun predict(
+        dataset: Table
+    ) -> prediction: TaggedTable
+    ```

--- a/docs/api/safeds/ml/classical/regression/LinearRegressionRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/LinearRegressionRegressor.md
@@ -50,3 +50,98 @@ This regressor is not modified.
         @PythonName("training_set") trainingSet: TaggedTable
     ) -> fittedRegressor: LinearRegressionRegressor
     ```
+
+## `#!sds fun` isFitted {#safeds.ml.classical.regression.LinearRegressionRegressor.isFitted data-toc-label='isFitted'}
+
+Check if the classifier is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `isFitted` | [`Boolean`][safeds.lang.Boolean] | Whether the regressor is fitted. |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="40"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> isFitted: Boolean
+    ```
+
+## `#!sds fun` meanAbsoluteError {#safeds.ml.classical.regression.LinearRegressionRegressor.meanAbsoluteError data-toc-label='meanAbsoluteError'}
+
+Compute the mean absolute error (MAE) of the regressor on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `meanAbsoluteError` | [`Float`][safeds.lang.Float] | The calculated mean absolute error (the average of the distance of each individual row). |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="64"
+    @Pure
+    @PythonName("mean_absolute_error")
+    fun meanAbsoluteError(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> meanAbsoluteError: Float
+    ```
+
+## `#!sds fun` meanSquaredError {#safeds.ml.classical.regression.LinearRegressionRegressor.meanSquaredError data-toc-label='meanSquaredError'}
+
+Compute the mean squared error (MSE) on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `meanSquaredError` | [`Float`][safeds.lang.Float] | The calculated mean squared error (the average of the distance of each individual row squared). |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="51"
+    @Pure
+    @PythonName("mean_squared_error")
+    fun meanSquaredError(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> meanSquaredError: Float
+    ```
+
+## `#!sds fun` predict {#safeds.ml.classical.regression.LinearRegressionRegressor.predict data-toc-label='predict'}
+
+Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `dataset` | [`Table`][safeds.data.tabular.containers.Table] | The dataset containing the feature vectors. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `prediction` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A dataset containing the given feature vectors and the predicted target vector. |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="30"
+    @Pure
+    fun predict(
+        dataset: Table
+    ) -> prediction: TaggedTable
+    ```

--- a/docs/api/safeds/ml/classical/regression/RandomForestRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/RandomForestRegressor.md
@@ -71,3 +71,98 @@ This regressor is not modified.
         @PythonName("training_set") trainingSet: TaggedTable
     ) -> fittedRegressor: RandomForestRegressor
     ```
+
+## `#!sds fun` isFitted {#safeds.ml.classical.regression.RandomForestRegressor.isFitted data-toc-label='isFitted'}
+
+Check if the classifier is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `isFitted` | [`Boolean`][safeds.lang.Boolean] | Whether the regressor is fitted. |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="40"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> isFitted: Boolean
+    ```
+
+## `#!sds fun` meanAbsoluteError {#safeds.ml.classical.regression.RandomForestRegressor.meanAbsoluteError data-toc-label='meanAbsoluteError'}
+
+Compute the mean absolute error (MAE) of the regressor on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `meanAbsoluteError` | [`Float`][safeds.lang.Float] | The calculated mean absolute error (the average of the distance of each individual row). |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="64"
+    @Pure
+    @PythonName("mean_absolute_error")
+    fun meanAbsoluteError(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> meanAbsoluteError: Float
+    ```
+
+## `#!sds fun` meanSquaredError {#safeds.ml.classical.regression.RandomForestRegressor.meanSquaredError data-toc-label='meanSquaredError'}
+
+Compute the mean squared error (MSE) on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `meanSquaredError` | [`Float`][safeds.lang.Float] | The calculated mean squared error (the average of the distance of each individual row squared). |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="51"
+    @Pure
+    @PythonName("mean_squared_error")
+    fun meanSquaredError(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> meanSquaredError: Float
+    ```
+
+## `#!sds fun` predict {#safeds.ml.classical.regression.RandomForestRegressor.predict data-toc-label='predict'}
+
+Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `dataset` | [`Table`][safeds.data.tabular.containers.Table] | The dataset containing the feature vectors. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `prediction` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A dataset containing the given feature vectors and the predicted target vector. |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="30"
+    @Pure
+    fun predict(
+        dataset: Table
+    ) -> prediction: TaggedTable
+    ```

--- a/docs/api/safeds/ml/classical/regression/RidgeRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/RidgeRegressor.md
@@ -71,3 +71,98 @@ This regressor is not modified.
         @PythonName("training_set") trainingSet: TaggedTable
     ) -> fittedRegressor: RidgeRegressor
     ```
+
+## `#!sds fun` isFitted {#safeds.ml.classical.regression.RidgeRegressor.isFitted data-toc-label='isFitted'}
+
+Check if the classifier is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `isFitted` | [`Boolean`][safeds.lang.Boolean] | Whether the regressor is fitted. |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="40"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> isFitted: Boolean
+    ```
+
+## `#!sds fun` meanAbsoluteError {#safeds.ml.classical.regression.RidgeRegressor.meanAbsoluteError data-toc-label='meanAbsoluteError'}
+
+Compute the mean absolute error (MAE) of the regressor on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `meanAbsoluteError` | [`Float`][safeds.lang.Float] | The calculated mean absolute error (the average of the distance of each individual row). |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="64"
+    @Pure
+    @PythonName("mean_absolute_error")
+    fun meanAbsoluteError(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> meanAbsoluteError: Float
+    ```
+
+## `#!sds fun` meanSquaredError {#safeds.ml.classical.regression.RidgeRegressor.meanSquaredError data-toc-label='meanSquaredError'}
+
+Compute the mean squared error (MSE) on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `meanSquaredError` | [`Float`][safeds.lang.Float] | The calculated mean squared error (the average of the distance of each individual row squared). |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="51"
+    @Pure
+    @PythonName("mean_squared_error")
+    fun meanSquaredError(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> meanSquaredError: Float
+    ```
+
+## `#!sds fun` predict {#safeds.ml.classical.regression.RidgeRegressor.predict data-toc-label='predict'}
+
+Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `dataset` | [`Table`][safeds.data.tabular.containers.Table] | The dataset containing the feature vectors. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `prediction` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A dataset containing the given feature vectors and the predicted target vector. |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="30"
+    @Pure
+    fun predict(
+        dataset: Table
+    ) -> prediction: TaggedTable
+    ```

--- a/docs/api/safeds/ml/classical/regression/SupportVectorMachineRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/SupportVectorMachineRegressor.md
@@ -111,6 +111,101 @@ This regressor is not modified.
     ) -> fittedRegressor: SupportVectorMachineRegressor
     ```
 
+## `#!sds fun` isFitted {#safeds.ml.classical.regression.SupportVectorMachineRegressor.isFitted data-toc-label='isFitted'}
+
+Check if the classifier is fitted.
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `isFitted` | [`Boolean`][safeds.lang.Boolean] | Whether the regressor is fitted. |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="40"
+    @Pure
+    @PythonName("is_fitted")
+    fun isFitted() -> isFitted: Boolean
+    ```
+
+## `#!sds fun` meanAbsoluteError {#safeds.ml.classical.regression.SupportVectorMachineRegressor.meanAbsoluteError data-toc-label='meanAbsoluteError'}
+
+Compute the mean absolute error (MAE) of the regressor on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `meanAbsoluteError` | [`Float`][safeds.lang.Float] | The calculated mean absolute error (the average of the distance of each individual row). |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="64"
+    @Pure
+    @PythonName("mean_absolute_error")
+    fun meanAbsoluteError(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> meanAbsoluteError: Float
+    ```
+
+## `#!sds fun` meanSquaredError {#safeds.ml.classical.regression.SupportVectorMachineRegressor.meanSquaredError data-toc-label='meanSquaredError'}
+
+Compute the mean squared error (MSE) on the given data.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `validationOrTestSet` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | The validation or test set. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `meanSquaredError` | [`Float`][safeds.lang.Float] | The calculated mean squared error (the average of the distance of each individual row squared). |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="51"
+    @Pure
+    @PythonName("mean_squared_error")
+    fun meanSquaredError(
+        @PythonName("validation_or_test_set") validationOrTestSet: TaggedTable
+    ) -> meanSquaredError: Float
+    ```
+
+## `#!sds fun` predict {#safeds.ml.classical.regression.SupportVectorMachineRegressor.predict data-toc-label='predict'}
+
+Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
+
+**Parameters:**
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `dataset` | [`Table`][safeds.data.tabular.containers.Table] | The dataset containing the feature vectors. | - |
+
+**Results:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `prediction` | [`TaggedTable`][safeds.data.tabular.containers.TaggedTable] | A dataset containing the given feature vectors and the predicted target vector. |
+
+??? quote "Stub code in `regressor.sdsstub`"
+
+    ```sds linenums="30"
+    @Pure
+    fun predict(
+        dataset: Table
+    ) -> prediction: TaggedTable
+    ```
+
 ## `#!sds enum` Kernel {#safeds.ml.classical.regression.SupportVectorMachineRegressor.Kernel data-toc-label='Kernel'}
 
 The kernel functions that can be used in the support vector machine.

--- a/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
+++ b/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
@@ -120,23 +120,23 @@ export class SafeDsMarkdownGenerator {
             return undefined;
         }
 
-        const level = 1;
+        const state = { level: 1, knownPaths };
 
         if (isSdsAnnotation(node)) {
-            return this.describeAnnotation(node, level, knownPaths);
+            return this.describeAnnotation(node, state);
         } else if (isSdsClass(node)) {
-            return this.describeClass(node, level, knownPaths);
+            return this.describeClass(node, state);
         } else if (isSdsEnum(node)) {
-            return this.describeEnum(node, level, knownPaths);
+            return this.describeEnum(node, state);
         } else if (isSdsFunction(node)) {
-            return this.describeFunction(node, level, knownPaths);
+            return this.describeFunction(node, state);
         } else if (isSdsPipeline(node)) {
             // Pipelines cannot be called, so they are not documented
             return undefined;
         } else if (isSdsSchema(node)) {
-            return this.describeSchema(node, level, knownPaths);
+            return this.describeSchema(node, state);
         } else if (isSdsSegment(node)) {
-            return this.describeSegment(node, level, knownPaths);
+            return this.describeSegment(node, state);
         } else {
             /* c8 ignore next 2 */
             throw new Error(`Unsupported module member type: ${node.$type}`);
@@ -147,26 +147,26 @@ export class SafeDsMarkdownGenerator {
      * Returns a Markdown description for the given class member. If the member should not be documented, `undefined`
      * is returned.
      */
-    private describeClassMember(node: SdsClassMember, level: number, knownPaths: Set<string>): string | undefined {
+    private describeClassMember(node: SdsClassMember, state: DetailsState): string | undefined {
         if (isSdsAttribute(node)) {
-            return this.describeAttribute(node, level, knownPaths);
+            return this.describeAttribute(node, state);
         } else if (isSdsClass(node)) {
-            return this.describeClass(node, level, knownPaths);
+            return this.describeClass(node, state);
         } else if (isSdsEnum(node)) {
-            return this.describeEnum(node, level, knownPaths);
+            return this.describeEnum(node, state);
         } else if (isSdsFunction(node)) {
-            return this.describeFunction(node, level, knownPaths);
+            return this.describeFunction(node, state);
         } else {
             /* c8 ignore next 2 */
             throw new Error(`Unsupported class member type: ${node.$type}`);
         }
     }
 
-    private describeAnnotation(node: SdsAnnotation, level: number, knownPaths: Set<string>): string {
-        let result = this.renderPreamble(node, level, 'annotation');
+    private describeAnnotation(node: SdsAnnotation, state: DetailsState): string {
+        let result = this.renderPreamble(node, state, 'annotation');
 
         // Parameters
-        const parameters = this.renderParameters(getParameters(node), knownPaths);
+        const parameters = this.renderParameters(getParameters(node), state.knownPaths);
         if (parameters) {
             result += `\n**Parameters:**\n\n${parameters}`;
         }
@@ -200,13 +200,13 @@ export class SafeDsMarkdownGenerator {
         return result;
     }
 
-    private describeAttribute(node: SdsAttribute, level: number, knownPaths: Set<string>): string {
+    private describeAttribute(node: SdsAttribute, state: DetailsState): string {
         const keyword = isStatic(node) ? 'static attr' : 'attr';
-        let result = this.renderPreamble(node, level, 'attribute', keyword);
+        let result = this.renderPreamble(node, state, 'attribute', keyword);
 
         // Type
         const type = this.typeComputer.computeType(node.type);
-        result += `\n**Type:** ${this.renderType(type, knownPaths)}\n`;
+        result += `\n**Type:** ${this.renderType(type, state.knownPaths)}\n`;
 
         // Examples
         const examples = this.renderExamples(node);
@@ -217,25 +217,25 @@ export class SafeDsMarkdownGenerator {
         return result;
     }
 
-    private describeClass(node: SdsClass, level: number, knownPaths: Set<string>): string {
+    private describeClass(node: SdsClass, state: DetailsState): string {
         const keyword = node.parameterList ? 'class' : 'abstract class';
-        let result = this.renderPreamble(node, level, 'class', keyword);
+        let result = this.renderPreamble(node, state, 'class', keyword);
 
         // Parent type
         const parentTypes = getParentTypes(node);
         if (!isEmpty(parentTypes)) {
-            const firstParentType = this.renderType(this.typeComputer.computeType(parentTypes[0]), knownPaths);
+            const firstParentType = this.renderType(this.typeComputer.computeType(parentTypes[0]), state.knownPaths);
             result += `\n**Parent type:** ${firstParentType}\n`;
         }
 
         // Parameters
-        const parameters = this.renderParameters(getParameters(node), knownPaths);
+        const parameters = this.renderParameters(getParameters(node), state.knownPaths);
         if (parameters) {
             result += `\n**Parameters:**\n\n${parameters}`;
         }
 
         // Type parameters
-        const typeParameters = this.renderTypeParameters(getTypeParameters(node), knownPaths);
+        const typeParameters = this.renderTypeParameters(getTypeParameters(node), state.knownPaths);
         if (typeParameters) {
             result += `\n**Type parameters:**\n\n${typeParameters}`;
         }
@@ -276,14 +276,20 @@ export class SafeDsMarkdownGenerator {
             ...staticMembers.filter((it) => isSdsClass(it)),
             ...staticMembers.filter((it) => isSdsEnum(it)),
         ].forEach((member) => {
-            result += `\n${this.describeClassMember(member, level + 1, knownPaths)}`;
+            const newState = {
+                ...state,
+                level: state.level + 1,
+                contextClass: node,
+            };
+
+            result += `\n${this.describeClassMember(member, newState)}`;
         });
 
         return result;
     }
 
-    private describeEnum(node: SdsEnum, level: number, knownPaths: Set<string>): string {
-        let result = this.renderPreamble(node, level, 'enum');
+    private describeEnum(node: SdsEnum, state: DetailsState): string {
+        let result = this.renderPreamble(node, state, 'enum');
 
         // Examples
         const examples = this.renderExamples(node);
@@ -301,17 +307,22 @@ export class SafeDsMarkdownGenerator {
         getEnumVariants(node)
             .sort((a, b) => a.name.localeCompare(b.name))
             .forEach((variant) => {
-                result += `\n${this.describeEnumVariant(variant, level + 1, knownPaths)}`;
+                const newState = {
+                    ...state,
+                    level: state.level + 1,
+                };
+
+                result += `\n${this.describeEnumVariant(variant, newState)}`;
             });
 
         return result;
     }
 
-    private describeEnumVariant(node: SdsEnumVariant, level: number, knownPaths: Set<string>): string {
-        let result = this.renderPreamble(node, level, 'enum variant', '');
+    private describeEnumVariant(node: SdsEnumVariant, state: DetailsState): string {
+        let result = this.renderPreamble(node, state, 'enum variant', '');
 
         // Parameters
-        const parameters = this.renderParameters(getParameters(node), knownPaths);
+        const parameters = this.renderParameters(getParameters(node), state.knownPaths);
         if (parameters) {
             result += `\n**Parameters:**\n\n${parameters}`;
         }
@@ -325,24 +336,24 @@ export class SafeDsMarkdownGenerator {
         return result;
     }
 
-    private describeFunction(node: SdsFunction, level: number, knownPaths: Set<string>): string {
+    private describeFunction(node: SdsFunction, state: DetailsState): string {
         const keyword = isStatic(node) ? 'static fun' : 'fun';
-        let result = this.renderPreamble(node, level, 'function', keyword);
+        let result = this.renderPreamble(node, state, 'function', keyword);
 
         // Parameters
-        const parameters = this.renderParameters(getParameters(node), knownPaths);
+        const parameters = this.renderParameters(getParameters(node), state.knownPaths);
         if (parameters) {
             result += `\n**Parameters:**\n\n${parameters}`;
         }
 
         // Results
-        const results = this.renderResults(getResults(node.resultList), knownPaths);
+        const results = this.renderResults(getResults(node.resultList), state.knownPaths);
         if (results) {
             result += `\n**Results:**\n\n${results}`;
         }
 
         // Type parameters
-        const typeParameters = this.renderTypeParameters(getTypeParameters(node), knownPaths);
+        const typeParameters = this.renderTypeParameters(getTypeParameters(node), state.knownPaths);
         if (typeParameters) {
             result += `\n**Type parameters:**\n\n${typeParameters}`;
         }
@@ -362,8 +373,8 @@ export class SafeDsMarkdownGenerator {
         return result;
     }
 
-    private describeSchema(node: SdsSchema, level: number, knownPaths: Set<string>): string {
-        let result = this.renderPreamble(node, level, 'schema');
+    private describeSchema(node: SdsSchema, state: DetailsState): string {
+        let result = this.renderPreamble(node, state, 'schema');
 
         // Columns
         const columns = getColumns(node);
@@ -376,7 +387,7 @@ export class SafeDsMarkdownGenerator {
                 const name = column.columnName.value;
                 const type = this.typeComputer.computeType(column.columnType);
 
-                result += `| \`${name}\` | ${this.renderType(type, knownPaths)} |\n`;
+                result += `| \`${name}\` | ${this.renderType(type, state.knownPaths)} |\n`;
             }
         }
 
@@ -395,18 +406,18 @@ export class SafeDsMarkdownGenerator {
         return result;
     }
 
-    private describeSegment(node: SdsSegment, level: number, knownPaths: Set<string>): string {
+    private describeSegment(node: SdsSegment, state: DetailsState): string {
         const keyword = isInternal(node) ? 'internal segment' : 'segment';
-        let result = this.renderPreamble(node, level, 'segment', keyword);
+        let result = this.renderPreamble(node, state, 'segment', keyword);
 
         // Parameters
-        const parameters = this.renderParameters(getParameters(node), knownPaths);
+        const parameters = this.renderParameters(getParameters(node), state.knownPaths);
         if (parameters) {
             result += `\n**Parameters:**\n\n${parameters}`;
         }
 
         // Results
-        const results = this.renderResults(getResults(node.resultList), knownPaths);
+        const results = this.renderResults(getResults(node.resultList), state.knownPaths);
         if (results) {
             result += `\n**Results:**\n\n${results}`;
         }
@@ -426,8 +437,8 @@ export class SafeDsMarkdownGenerator {
         return result;
     }
 
-    private renderPreamble(node: SdsDeclaration, level: number, kind: string, keyword: string = kind): string {
-        let result = this.renderHeading(node, level, keyword) + '\n';
+    private renderPreamble(node: SdsDeclaration, state: DetailsState, kind: string, keyword: string = kind): string {
+        let result = this.renderHeading(node, state, keyword) + '\n';
 
         const deprecationWarning = this.renderDeprecationWarning(node, kind);
         if (deprecationWarning) {
@@ -441,8 +452,8 @@ export class SafeDsMarkdownGenerator {
         return result;
     }
 
-    private renderHeading(node: SdsDeclaration, level: number, keyword: string): string {
-        let result = '#'.repeat(Math.min(level, 6));
+    private renderHeading(node: SdsDeclaration, state: DetailsState, keyword: string): string {
+        let result = '#'.repeat(Math.min(state.level, 6));
         result += this.renderMaturity(node);
 
         if (keyword) {
@@ -450,8 +461,16 @@ export class SafeDsMarkdownGenerator {
         }
 
         result += ` ${node.name}`;
-        result += ` {#${getQualifiedName(node)} data-toc-label='${node.name}'}`;
+        result += ` {#${this.getId(node, state)} data-toc-label='${node.name}'}`;
         return result;
+    }
+
+    private getId(node: SdsDeclaration, state: DetailsState): string {
+        if (state.contextClass) {
+            return `${getQualifiedName(state.contextClass)}.${node.name}`;
+        } else {
+            return getQualifiedName(node);
+        }
     }
 
     private renderMaturity(node: SdsDeclaration): string {
@@ -708,6 +727,27 @@ export class SafeDsMarkdownGenerator {
 
 export interface GenerateOptions {
     destination: URI;
+}
+
+/**
+ * The state of the details generation process.
+ */
+interface DetailsState {
+    /**
+     * The current nesting level.
+     */
+    level: number;
+
+    /**
+     * The paths of the documents to generate documentation for. Used to decide whether to create links to other
+     * documents.
+     */
+    knownPaths: Set<string>;
+
+    /**
+     * The class for which the documentation is generated. Used to derive section IDs for inherited members.
+     */
+    contextClass?: SdsClass;
 }
 
 interface Summary {

--- a/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
+++ b/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
@@ -311,8 +311,8 @@ export class SafeDsMarkdownGenerator {
             .sort((a, b) => a.name.localeCompare(b.name))
             .forEach((variant) => {
                 const newState = {
-                    ...state,
                     level: state.level + 1,
+                    knownPaths: state.knownPaths,
                 };
 
                 result += `\n${this.describeEnumVariant(variant, newState)}`;

--- a/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
+++ b/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
@@ -253,7 +253,10 @@ export class SafeDsMarkdownGenerator {
         }
 
         // Class members
-        const staticMembers = getClassMembers(node).filter((it) => isStatic(it));
+        const staticMembers = getClassMembers(node)
+            .filter((it) => isStatic(it))
+            .sort((a, b) => a.name.localeCompare(b.name));
+
         const ownInstanceMembers = getClassMembers(node).filter((it) => !isStatic(it));
         const inheritedInstanceMembers = this.classHierarchy
             .streamProperSuperclasses(node)

--- a/packages/safe-ds-lang/src/language/helpers/nodeProperties.ts
+++ b/packages/safe-ds-lang/src/language/helpers/nodeProperties.ts
@@ -339,7 +339,7 @@ export const getParentTypes = (node: SdsClass | undefined): SdsType[] => {
     return node?.parentTypeList?.parentTypes ?? [];
 };
 
-export const getQualifiedName = (node: SdsDeclaration | undefined): string | undefined => {
+export const getQualifiedName = (node: SdsDeclaration | undefined): string => {
     const segments = [];
 
     let current: SdsDeclaration | undefined = node;

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/SUMMARY.md
@@ -15,3 +15,4 @@ search:
                     - [MyClass5](tests/generation/markdown/classes/documented/MyClass5.md)
                     - [MyClass6](tests/generation/markdown/classes/documented/MyClass6.md)
                     - [MyClass7](tests/generation/markdown/classes/documented/MyClass7.md)
+                    - [MyClass8](tests/generation/markdown/classes/documented/MyClass8.md)

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass6.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass6.md
@@ -25,7 +25,12 @@ Description of MyClass6.
         /**
          * Description of MyEnum1.
          */
-        enum MyEnum1
+        enum MyEnum1 {
+            /**
+             * Description of MyVariant1.
+             */
+            MyVariant1
+        }
     
         /**
          * Description of myFunction1.
@@ -59,7 +64,7 @@ Description of myFunction1.
 
 ??? quote "Stub code in `main.sdsstub`"
 
-    ```sds linenums="63"
+    ```sds linenums="68"
     @Pure fun myFunction1()
     ```
 
@@ -75,7 +80,7 @@ Description of myFunction2.
 
 ??? quote "Stub code in `main.sdsstub`"
 
-    ```sds linenums="67"
+    ```sds linenums="72"
     @Pure static fun myFunction2()
     ```
 
@@ -125,5 +130,14 @@ Description of MyEnum1.
 ??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="58"
-    enum MyEnum1
+    enum MyEnum1 {
+        /**
+         * Description of MyVariant1.
+         */
+        MyVariant1
+    }
     ```
+
+### MyVariant1 {#tests.generation.markdown.classes.documented.MyClass6.MyEnum1.MyVariant1 data-toc-label='MyVariant1'}
+
+Description of MyVariant1.

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass7.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass7.md
@@ -10,6 +10,6 @@ Description of MyClass7.
 
 ??? quote "Stub code in `main.sdsstub`"
 
-    ```sds linenums="84"
+    ```sds linenums="89"
     class MyClass7
     ```

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass8.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass8.md
@@ -1,0 +1,32 @@
+# `#!sds abstract class` MyClass8 {#tests.generation.markdown.classes.documented.MyClass8 data-toc-label='MyClass8'}
+
+Description of MyClass8.
+
+**Parent type:** [`MyClass6`][tests.generation.markdown.classes.documented.MyClass6]
+
+??? quote "Stub code in `main.sdsstub`"
+
+    ```sds linenums="89"
+    class MyClass8 sub MyClass6 {
+        /**
+         * Description of myAttribute1.
+         */
+        attr myAttribute1: MyClass1
+    }
+    ```
+
+## `#!sds attr` myAttribute1 {#tests.generation.markdown.classes.documented.MyClass8.myAttribute1 data-toc-label='myAttribute1'}
+
+Description of myAttribute1.
+
+**Type:** [`MyClass1`][tests.generation.markdown.classes.documented.MyClass1]
+
+## `#!sds fun` myFunction1 {#tests.generation.markdown.classes.documented.MyClass8.myFunction1 data-toc-label='myFunction1'}
+
+Description of myFunction1.
+
+??? quote "Stub code in `main.sdsstub`"
+
+    ```sds linenums="63"
+    @Pure fun myFunction1()
+    ```

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass8.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass8.md
@@ -6,7 +6,7 @@ Description of MyClass8.
 
 ??? quote "Stub code in `main.sdsstub`"
 
-    ```sds linenums="89"
+    ```sds linenums="94"
     class MyClass8 sub MyClass6 {
         /**
          * Description of myAttribute1.
@@ -27,6 +27,6 @@ Description of myFunction1.
 
 ??? quote "Stub code in `main.sdsstub`"
 
-    ```sds linenums="63"
+    ```sds linenums="68"
     @Pure fun myFunction1()
     ```

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/main.sdsstub
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/main.sdsstub
@@ -55,7 +55,12 @@ class MyClass6 {
     /**
      * Description of MyEnum1.
      */
-    enum MyEnum1
+    enum MyEnum1 {
+        /**
+         * Description of MyVariant1.
+         */
+        MyVariant1
+    }
 
     /**
      * Description of myFunction1.

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/main.sdsstub
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/main.sdsstub
@@ -82,3 +82,13 @@ class MyClass6 {
  * @example // Example of MyClass7.
  */
 class MyClass7
+
+/**
+ * Description of MyClass8.
+ */
+class MyClass8 sub MyClass6 {
+    /**
+     * Description of myAttribute1.
+     */
+    attr myAttribute1: MyClass1
+}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/SUMMARY.md
@@ -14,3 +14,4 @@ search:
                     - [MyClass4](tests/generation/markdown/classes/undocumented/MyClass4.md)
                     - [MyClass5](tests/generation/markdown/classes/undocumented/MyClass5.md)
                     - [MyClass6](tests/generation/markdown/classes/undocumented/MyClass6.md)
+                    - [MyClass7](tests/generation/markdown/classes/undocumented/MyClass7.md)

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass6.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass6.md
@@ -11,7 +11,9 @@
         @Pure static fun myFunction2()
     
         class MyClass7
-        enum MyEnum1
+        enum MyEnum1 {
+            MyVariant1
+        }
     }
     ```
 
@@ -52,5 +54,9 @@
 ??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="21"
-    enum MyEnum1
+    enum MyEnum1 {
+        MyVariant1
+    }
     ```
+
+### MyVariant1 {#tests.generation.markdown.classes.undocumented.MyClass6.MyEnum1.MyVariant1 data-toc-label='MyVariant1'}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass7.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass7.md
@@ -6,7 +6,7 @@ Description of MyClass7.
 
 ??? quote "Stub code in `main.sdsstub`"
 
-    ```sds linenums="27"
+    ```sds linenums="29"
     class MyClass7 sub MyClass6 {
         attr myAttribute1: Int
     }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass7.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass7.md
@@ -1,0 +1,25 @@
+# `#!sds abstract class` MyClass7 {#tests.generation.markdown.classes.undocumented.MyClass7 data-toc-label='MyClass7'}
+
+Description of MyClass7.
+
+**Parent type:** [`MyClass6`][tests.generation.markdown.classes.undocumented.MyClass6]
+
+??? quote "Stub code in `main.sdsstub`"
+
+    ```sds linenums="27"
+    class MyClass7 sub MyClass6 {
+        attr myAttribute1: Int
+    }
+    ```
+
+## `#!sds attr` myAttribute1 {#tests.generation.markdown.classes.undocumented.MyClass7.myAttribute1 data-toc-label='myAttribute1'}
+
+**Type:** `#!sds Int`
+
+## `#!sds fun` myFunction1 {#tests.generation.markdown.classes.undocumented.MyClass7.myFunction1 data-toc-label='myFunction1'}
+
+??? quote "Stub code in `main.sdsstub`"
+
+    ```sds linenums="17"
+    @Pure fun myFunction1()
+    ```

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/main.sdsstub
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/main.sdsstub
@@ -20,3 +20,10 @@ class MyClass6 {
     class MyClass7
     enum MyEnum1
 }
+
+/**
+ * Description of MyClass7.
+ */
+class MyClass7 sub MyClass6 {
+    attr myAttribute1: Int
+}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/main.sdsstub
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/main.sdsstub
@@ -18,7 +18,9 @@ class MyClass6 {
     @Pure static fun myFunction2()
 
     class MyClass7
-    enum MyEnum1
+    enum MyEnum1 {
+        MyVariant1
+    }
 }
 
 /**


### PR DESCRIPTION
Closes #1030

### Summary of Changes

Inherited members are now also shown in the documentation for subclasses. This way, users can see all operations that can be done with a class at once. Members of `Any` are excluded.
