### PR TITLE
feat: hide classes that are only for typing from auto-completion

### DIFF
--- a/docs/api/safeds/data/tabular/transformation/InvertibleTableTransformer.md
+++ b/docs/api/safeds/data/tabular/transformation/InvertibleTableTransformer.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` InvertibleTableTransformer {#safeds.data.tabular.transformation.InvertibleTableTransformer data-toc-label='InvertibleTableTransformer'}
 
 A `TableTransformer` that can also undo the learned transformation after it has been applied.

--- a/docs/api/safeds/data/tabular/transformation/TableTransformer.md
+++ b/docs/api/safeds/data/tabular/transformation/TableTransformer.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` TableTransformer {#safeds.data.tabular.transformation.TableTransformer data-toc-label='TableTransformer'}
 
 Learn a transformation for a set of columns in a `Table` and transform another `Table` with the same columns.

--- a/docs/api/safeds/data/tabular/typing/ColumnType.md
+++ b/docs/api/safeds/data/tabular/typing/ColumnType.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` ColumnType {#safeds.data.tabular.typing.ColumnType data-toc-label='ColumnType'}
 
 Abstract base class for column types.

--- a/docs/api/safeds/data/tabular/typing/Schema.md
+++ b/docs/api/safeds/data/tabular/typing/Schema.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` Schema {#safeds.data.tabular.typing.Schema data-toc-label='Schema'}
 
 Store column names and corresponding data types for a `Table` or `Row`.

--- a/docs/api/safeds/lang/Any.md
+++ b/docs/api/safeds/lang/Any.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` Any {#safeds.lang.Any data-toc-label='Any'}
 
 The common superclass of all classes.

--- a/docs/api/safeds/lang/Boolean.md
+++ b/docs/api/safeds/lang/Boolean.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` Boolean {#safeds.lang.Boolean data-toc-label='Boolean'}
 
 A truth value.

--- a/docs/api/safeds/lang/Float.md
+++ b/docs/api/safeds/lang/Float.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` Float {#safeds.lang.Float data-toc-label='Float'}
 
 A floating-point number.

--- a/docs/api/safeds/lang/Int.md
+++ b/docs/api/safeds/lang/Int.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` Int {#safeds.lang.Int data-toc-label='Int'}
 
 An integer.

--- a/docs/api/safeds/lang/List.md
+++ b/docs/api/safeds/lang/List.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` List {#safeds.lang.List data-toc-label='List'}
 
 A list of elements.

--- a/docs/api/safeds/lang/Map.md
+++ b/docs/api/safeds/lang/Map.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` Map {#safeds.lang.Map data-toc-label='Map'}
 
 A map of keys to values.

--- a/docs/api/safeds/lang/Nothing.md
+++ b/docs/api/safeds/lang/Nothing.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` Nothing {#safeds.lang.Nothing data-toc-label='Nothing'}
 
 The common subclass of all classes.

--- a/docs/api/safeds/lang/Number.md
+++ b/docs/api/safeds/lang/Number.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` Number {#safeds.lang.Number data-toc-label='Number'}
 
 A number.

--- a/docs/api/safeds/lang/String.md
+++ b/docs/api/safeds/lang/String.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` String {#safeds.lang.String data-toc-label='String'}
 
 Some text.

--- a/docs/api/safeds/ml/classical/classification/Classifier.md
+++ b/docs/api/safeds/ml/classical/classification/Classifier.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` Classifier {#safeds.ml.classical.classification.Classifier data-toc-label='Classifier'}
 
 Abstract base class for all classifiers.

--- a/docs/api/safeds/ml/classical/regression/Regressor.md
+++ b/docs/api/safeds/ml/classical/regression/Regressor.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` Regressor {#safeds.ml.classical.regression.Regressor data-toc-label='Regressor'}
 
 Abstract base class for all regressors.

--- a/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
+++ b/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
@@ -27,6 +27,7 @@ import {
     SdsTypeParameter,
 } from '../generated/ast.js';
 import {
+    Class,
     getClassMembers,
     getColumns,
     getEnumVariants,
@@ -441,7 +442,9 @@ export class SafeDsMarkdownGenerator {
     }
 
     private renderPreamble(node: SdsDeclaration, state: DetailsState, kind: string, keyword: string = kind): string {
-        let result = this.renderHeading(node, state, keyword) + '\n';
+        let result = this.renderFrontMatter(node);
+
+        result += this.renderHeading(node, state, keyword) + '\n';
 
         const deprecationWarning = this.renderDeprecationWarning(node, kind);
         if (deprecationWarning) {
@@ -453,6 +456,14 @@ export class SafeDsMarkdownGenerator {
         }
 
         return result;
+    }
+
+    private renderFrontMatter(node: SdsDeclaration): string {
+        if (isSdsClass(node) && Class.isOnlyForTyping(node)) {
+            return `---\nsearch:\n  boost: 0.5\n---\n\n`;
+        }
+
+        return '';
     }
 
     private renderHeading(node: SdsDeclaration, state: DetailsState, keyword: string): string {

--- a/packages/safe-ds-lang/src/language/helpers/nodeProperties.ts
+++ b/packages/safe-ds-lang/src/language/helpers/nodeProperties.ts
@@ -102,6 +102,15 @@ export namespace Argument {
     };
 }
 
+export namespace Class {
+    /**
+     * Checks whether the class is only for typing, i.e. whether it has no constructor and no static members.
+     */
+    export const isOnlyForTyping = (node: SdsClass | undefined): boolean => {
+        return isSdsClass(node) && !node.parameterList && !getClassMembers(node).some((it) => isStatic(it));
+    };
+}
+
 export namespace Enum {
     export const isConstant = (node: SdsEnum | undefined): boolean => {
         return Boolean(node) && getEnumVariants(node).every((it) => EnumVariant.isConstant(it));

--- a/packages/safe-ds-lang/src/language/lsp/safe-ds-completion-provider.ts
+++ b/packages/safe-ds-lang/src/language/lsp/safe-ds-completion-provider.ts
@@ -18,7 +18,7 @@ import {
     SdsPipeline,
     SdsSchema,
 } from '../generated/ast.js';
-import { getPackageName } from '../helpers/nodeProperties.js';
+import { Class, getPackageName } from '../helpers/nodeProperties.js';
 import { isInPipelineFile, isInStubFile } from '../helpers/fileExtensions.js';
 import { classTypeParameterIsUsedInCorrectPosition } from '../validation/other/declarations/typeParameters.js';
 
@@ -63,7 +63,11 @@ export class SafeDsCompletionProvider extends DefaultCompletionProvider {
                 );
             }
         } else if (isSdsReference(refInfo.container)) {
-            return !this.illegalNodeTypesForReferences.has(description.type);
+            if (this.illegalNodeTypesForReferences.has(description.type)) {
+                return false;
+            } else if (isSdsClass(description.node) && Class.isOnlyForTyping(description.node)) {
+                return false;
+            }
         }
 
         return true;

--- a/packages/safe-ds-lang/tests/language/lsp/safe-ds.completion-provider.test.ts
+++ b/packages/safe-ds-lang/tests/language/lsp/safe-ds.completion-provider.test.ts
@@ -253,6 +253,23 @@ describe('SafeDsCompletionProvider', async () => {
                 },
             },
             {
+                testName: 'reference (class only for typing)',
+                code: `
+                    class MyClass1
+                    class MyClass2()
+                    class MyClass3 {
+                        static attr myAttribute: Int
+                    }
+
+                    pipeline myPipeline {
+                        <|>
+                `,
+                expectedLabels: {
+                    shouldContain: ['MyClass2', 'MyClass3'],
+                    shouldNotContain: ['MyClass1'],
+                },
+            },
+            {
                 testName: 'type arguments (no prefix)',
                 code: `
                     class MyClass<T>

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/deprecated/generated/tests/generation/markdown/classes/deprecated/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/deprecated/generated/tests/generation/markdown/classes/deprecated/MyClass1.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # :warning:{ title="Deprecated" } `#!sds abstract class` MyClass1 {#tests.generation.markdown.classes.deprecated.MyClass1 data-toc-label='MyClass1'}
 
 !!! warning "Deprecated"

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass1.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` MyClass1 {#tests.generation.markdown.classes.documented.MyClass1 data-toc-label='MyClass1'}
 
 Description of MyClass1.

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass3.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` MyClass3 {#tests.generation.markdown.classes.documented.MyClass3 data-toc-label='MyClass3'}
 
 Description of MyClass3.

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass5.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass5.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` MyClass5 {#tests.generation.markdown.classes.documented.MyClass5 data-toc-label='MyClass5'}
 
 Description of MyClass5.

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass6.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass6.md
@@ -84,6 +84,11 @@ Description of myFunction2.
     @Pure static fun myFunction2()
     ```
 
+---
+search:
+  boost: 0.5
+---
+
 ## `#!sds abstract class` MyClass7 {#tests.generation.markdown.classes.documented.MyClass6.MyClass7 data-toc-label='MyClass7'}
 
 Description of MyClass7.

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass7.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass7.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` MyClass7 {#tests.generation.markdown.classes.documented.MyClass7 data-toc-label='MyClass7'}
 
 Description of MyClass7.

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass8.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass8.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` MyClass8 {#tests.generation.markdown.classes.documented.MyClass8 data-toc-label='MyClass8'}
 
 Description of MyClass8.

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/experimental/generated/tests/generation/markdown/classes/experimental/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/experimental/generated/tests/generation/markdown/classes/experimental/MyClass1.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # :test_tube:{ title="Experimental" } `#!sds abstract class` MyClass1 {#tests.generation.markdown.classes.experimental.MyClass1 data-toc-label='MyClass1'}
 
 ??? quote "Stub code in `main.sdsstub`"

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass1.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` MyClass1 {#tests.generation.markdown.classes.undocumented.MyClass1 data-toc-label='MyClass1'}
 
 ??? quote "Stub code in `main.sdsstub`"

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass3.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` MyClass3 {#tests.generation.markdown.classes.undocumented.MyClass3 data-toc-label='MyClass3'}
 
 **Type parameters:**

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass5.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass5.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` MyClass5 {#tests.generation.markdown.classes.undocumented.MyClass5 data-toc-label='MyClass5'}
 
 **Parent type:** [`MyClass1`][tests.generation.markdown.classes.undocumented.MyClass1]

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass6.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass6.md
@@ -41,6 +41,11 @@
     @Pure static fun myFunction2()
     ```
 
+---
+search:
+  boost: 0.5
+---
+
 ## `#!sds abstract class` MyClass7 {#tests.generation.markdown.classes.undocumented.MyClass6.MyClass7 data-toc-label='MyClass7'}
 
 ??? quote "Stub code in `main.sdsstub`"

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass7.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass7.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` MyClass7 {#tests.generation.markdown.classes.undocumented.MyClass7 data-toc-label='MyClass7'}
 
 Description of MyClass7.

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyClass1.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` MyClass1 {#tests.generation.markdown.enums.documented.MyClass1 data-toc-label='MyClass1'}
 
 ??? quote "Stub code in `main.sdsstub`"

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/MyClass1.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` MyClass1 {#tests.generation.markdown.functions.documented.MyClass1 data-toc-label='MyClass1'}
 
 ??? quote "Stub code in `main.sdsstub`"

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/link tag/generated/tests/generation/markdown/linkTag/MyClass2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/link tag/generated/tests/generation/markdown/linkTag/MyClass2.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` MyClass2 {#tests.generation.markdown.linkTag.MyClass2 data-toc-label='MyClass2'}
 
 ??? quote "Stub code in `main.sdsstub`"

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/multiline/generated/tests/generation/markdown/multiline/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/multiline/generated/tests/generation/markdown/multiline/MyClass1.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` MyClass1 {#tests.generation.markdown.multiline.MyClass1 data-toc-label='MyClass1'}
 
 Description of MyClass1.

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/tests/generation/markdown/schemas/documented/MyClass.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/tests/generation/markdown/schemas/documented/MyClass.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` MyClass {#tests.generation.markdown.schemas.documented.MyClass data-toc-label='MyClass'}
 
 ??? quote "Stub code in `main.sdsstub`"

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/MyClass1.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` MyClass1 {#tests.generation.markdown.summary.package1.MyClass1 data-toc-label='MyClass1'}
 
 ??? quote "Stub code in `package1_module1.sdsstub`"

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/MyClass2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/MyClass2.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` MyClass2 {#tests.generation.markdown.summary.package1.MyClass2 data-toc-label='MyClass2'}
 
 ??? quote "Stub code in `package1_module1.sdsstub`"

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/MyClass3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/MyClass3.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` MyClass3 {#tests.generation.markdown.summary.package1.MyClass3 data-toc-label='MyClass3'}
 
 ??? quote "Stub code in `package1_module2.sdsstub`"

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/subpackage/MyClass5.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/subpackage/MyClass5.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` MyClass5 {#tests.generation.markdown.summary.package1.subpackage.MyClass5 data-toc-label='MyClass5'}
 
 ??? quote "Stub code in `package3.sdsstub`"

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package2/MyClass4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package2/MyClass4.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.5
+---
+
 # `#!sds abstract class` MyClass4 {#tests.generation.markdown.summary.package2.MyClass4 data-toc-label='MyClass4'}
 
 ??? quote "Stub code in `package2.sdsstub`"


### PR DESCRIPTION
Closes #1026

### Summary of Changes

Classes that are only for typing (no constructor, no static members) do not show up in auto-completion of references anymore. They also get ranked down in the search of the documentation site.
