### PR TITLE
docs: link to direct subclasses

### DIFF
--- a/docs/api/safeds/data/tabular/containers/Table.md
+++ b/docs/api/safeds/data/tabular/containers/Table.md
@@ -20,6 +20,11 @@ Note: When removing the last column of the table, the `number_of_columns` proper
 |------|------|-------------|---------|
 | `data` | [`Map<String, List<Any>>?`][safeds.lang.Map] | The data. If None, an empty table is created. | `#!sds null` |
 
+**Inheritors:**
+
+- [`TaggedTable`][safeds.data.tabular.containers.TaggedTable]
+- [`TimeSeries`][safeds.data.tabular.containers.TimeSeries]
+
 ??? quote "Stub code in `table.sdsstub`"
 
     ```sds linenums="25"

--- a/docs/api/safeds/data/tabular/transformation/InvertibleTableTransformer.md
+++ b/docs/api/safeds/data/tabular/transformation/InvertibleTableTransformer.md
@@ -9,6 +9,13 @@ A `TableTransformer` that can also undo the learned transformation after it has 
 
 **Parent type:** [`TableTransformer`][safeds.data.tabular.transformation.TableTransformer]
 
+**Inheritors:**
+
+- [`LabelEncoder`][safeds.data.tabular.transformation.LabelEncoder]
+- [`OneHotEncoder`][safeds.data.tabular.transformation.OneHotEncoder]
+- [`RangeScaler`][safeds.data.tabular.transformation.RangeScaler]
+- [`StandardScaler`][safeds.data.tabular.transformation.StandardScaler]
+
 ??? quote "Stub code in `table_transformer.sdsstub`"
 
     ```sds linenums="96"

--- a/docs/api/safeds/data/tabular/transformation/TableTransformer.md
+++ b/docs/api/safeds/data/tabular/transformation/TableTransformer.md
@@ -7,6 +7,12 @@ search:
 
 Learn a transformation for a set of columns in a `Table` and transform another `Table` with the same columns.
 
+**Inheritors:**
+
+- [`Discretizer`][safeds.data.tabular.transformation.Discretizer]
+- [`Imputer`][safeds.data.tabular.transformation.Imputer]
+- [`InvertibleTableTransformer`][safeds.data.tabular.transformation.InvertibleTableTransformer]
+
 ??? quote "Stub code in `table_transformer.sdsstub`"
 
     ```sds linenums="8"

--- a/docs/api/safeds/lang/Number.md
+++ b/docs/api/safeds/lang/Number.md
@@ -7,6 +7,11 @@ search:
 
 A number.
 
+**Inheritors:**
+
+- [`Float`][safeds.lang.Float]
+- [`Int`][safeds.lang.Int]
+
 ??? quote "Stub code in `coreClasses.sdsstub`"
 
     ```sds linenums="29"

--- a/docs/api/safeds/ml/classical/classification/Classifier.md
+++ b/docs/api/safeds/ml/classical/classification/Classifier.md
@@ -7,6 +7,16 @@ search:
 
 Abstract base class for all classifiers.
 
+**Inheritors:**
+
+- [`AdaBoostClassifier`][safeds.ml.classical.classification.AdaBoostClassifier]
+- [`DecisionTreeClassifier`][safeds.ml.classical.classification.DecisionTreeClassifier]
+- [`GradientBoostingClassifier`][safeds.ml.classical.classification.GradientBoostingClassifier]
+- [`KNearestNeighborsClassifier`][safeds.ml.classical.classification.KNearestNeighborsClassifier]
+- [`LogisticRegressionClassifier`][safeds.ml.classical.classification.LogisticRegressionClassifier]
+- [`RandomForestClassifier`][safeds.ml.classical.classification.RandomForestClassifier]
+- [`SupportVectorMachineClassifier`][safeds.ml.classical.classification.SupportVectorMachineClassifier]
+
 ??? quote "Stub code in `classifier.sdsstub`"
 
     ```sds linenums="8"

--- a/docs/api/safeds/ml/classical/regression/Regressor.md
+++ b/docs/api/safeds/ml/classical/regression/Regressor.md
@@ -7,6 +7,19 @@ search:
 
 Abstract base class for all regressors.
 
+**Inheritors:**
+
+- [`AdaBoostRegressor`][safeds.ml.classical.regression.AdaBoostRegressor]
+- [`DecisionTreeRegressor`][safeds.ml.classical.regression.DecisionTreeRegressor]
+- [`ElasticNetRegressor`][safeds.ml.classical.regression.ElasticNetRegressor]
+- [`GradientBoostingRegressor`][safeds.ml.classical.regression.GradientBoostingRegressor]
+- [`KNearestNeighborsRegressor`][safeds.ml.classical.regression.KNearestNeighborsRegressor]
+- [`LassoRegressor`][safeds.ml.classical.regression.LassoRegressor]
+- [`LinearRegressionRegressor`][safeds.ml.classical.regression.LinearRegressionRegressor]
+- [`RandomForestRegressor`][safeds.ml.classical.regression.RandomForestRegressor]
+- [`RidgeRegressor`][safeds.ml.classical.regression.RidgeRegressor]
+- [`SupportVectorMachineRegressor`][safeds.ml.classical.regression.SupportVectorMachineRegressor]
+
 ??? quote "Stub code in `regressor.sdsstub`"
 
     ```sds linenums="8"

--- a/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
+++ b/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
@@ -64,16 +64,16 @@ export class SafeDsMarkdownGenerator {
     private readonly builtinClasses: SafeDsClasses;
     private readonly classHierarchy: SafeDsClassHierarchy;
     private readonly documentationProvider: SafeDsDocumentationProvider;
+    private readonly packageManager: SafeDsPackageManager;
     private readonly typeComputer: SafeDsTypeComputer;
-    private readonly packages: SafeDsPackageManager;
 
     constructor(services: SafeDsServices) {
         this.builtinAnnotations = services.builtins.Annotations;
         this.builtinClasses = services.builtins.Classes;
         this.classHierarchy = services.typing.ClassHierarchy;
         this.documentationProvider = services.documentation.DocumentationProvider;
+        this.packageManager = services.workspace.PackageManager;
         this.typeComputer = services.typing.TypeComputer;
-        this.packages = services.workspace.PackageManager;
     }
 
     generate(documents: LangiumDocument[], options: GenerateOptions): TextDocument[] {
@@ -279,7 +279,7 @@ export class SafeDsMarkdownGenerator {
         let context = node;
         const packageName = getPackageName(context);
         if (packageName?.startsWith('safeds')) {
-            const description = this.packages
+            const description = this.packageManager
                 .getDeclarationsInPackage(packageName, { nodeType: SdsClass })
                 .find((it) => it.name === node.name);
 

--- a/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
+++ b/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
@@ -241,6 +241,20 @@ export class SafeDsMarkdownGenerator {
             result += `\n**Type parameters:**\n\n${typeParameters}`;
         }
 
+        // Direct subclasses
+        const directSubclasses = this.classHierarchy
+            .streamDirectSubclasses(node)
+            .toArray()
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((it) => this.renderType(this.typeComputer.computeType(it), state.knownPaths));
+
+        if (!isEmpty(directSubclasses)) {
+            result += '\n**Inheritors:**\n\n';
+            directSubclasses.forEach((subclass) => {
+                result += `- ${subclass}\n`;
+            });
+        }
+
         // Examples
         const examples = this.renderExamples(node);
         if (examples) {
@@ -254,6 +268,14 @@ export class SafeDsMarkdownGenerator {
         }
 
         // Class members
+        result += this.renderClassMembers(node, state);
+
+        return result;
+    }
+
+    private renderClassMembers(node: SdsClass, state: DetailsState) {
+        let result = '';
+
         const staticMembers = getClassMembers(node)
             .filter((it) => isStatic(it))
             .sort((a, b) => a.name.localeCompare(b.name));

--- a/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
+++ b/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
@@ -53,6 +53,7 @@ import { addLinePrefix, removeLinePrefix } from '../../helpers/strings.js';
 import { expandToStringLF } from 'langium/generate';
 import { SafeDsClassHierarchy } from '../typing/safe-ds-class-hierarchy.js';
 import { SafeDsClasses } from '../builtins/safe-ds-classes.js';
+import { SafeDsPackageManager } from '../workspace/safe-ds-package-manager.js';
 
 const INDENTATION = '    ';
 const LIB = path.join('packages', 'safe-ds-lang', 'lib', 'resources');
@@ -64,6 +65,7 @@ export class SafeDsMarkdownGenerator {
     private readonly classHierarchy: SafeDsClassHierarchy;
     private readonly documentationProvider: SafeDsDocumentationProvider;
     private readonly typeComputer: SafeDsTypeComputer;
+    private readonly packages: SafeDsPackageManager;
 
     constructor(services: SafeDsServices) {
         this.builtinAnnotations = services.builtins.Annotations;
@@ -71,6 +73,7 @@ export class SafeDsMarkdownGenerator {
         this.classHierarchy = services.typing.ClassHierarchy;
         this.documentationProvider = services.documentation.DocumentationProvider;
         this.typeComputer = services.typing.TypeComputer;
+        this.packages = services.workspace.PackageManager;
     }
 
     generate(documents: LangiumDocument[], options: GenerateOptions): TextDocument[] {
@@ -242,17 +245,9 @@ export class SafeDsMarkdownGenerator {
         }
 
         // Direct subclasses
-        const directSubclasses = this.classHierarchy
-            .streamDirectSubclasses(node)
-            .toArray()
-            .sort((a, b) => a.name.localeCompare(b.name))
-            .map((it) => this.renderType(this.typeComputer.computeType(it), state.knownPaths));
-
-        if (!isEmpty(directSubclasses)) {
-            result += '\n**Inheritors:**\n\n';
-            directSubclasses.forEach((subclass) => {
-                result += `- ${subclass}\n`;
-            });
+        const subclasses = this.renderSubclasses(node, state);
+        if (!isEmpty(subclasses)) {
+            result += `\n**Inheritors:**\n\n${subclasses}`;
         }
 
         // Examples
@@ -270,6 +265,41 @@ export class SafeDsMarkdownGenerator {
         // Class members
         result += this.renderClassMembers(node, state);
 
+        return result;
+    }
+
+    private renderSubclasses(node: SdsClass, state: DetailsState) {
+        let result = '';
+
+        // The actual builtins in the lib/ folder take precedence over anything else loaded in the workspace. This
+        // means, we cannot find subclasses when we generate documentation for the src/ folder. We, thus, find the
+        // corresponding builtin first and compute its subclasses. We need to de-duplicate the subclasses, as there
+        // might be copies in the lib/ and the src/ folder.
+        //
+        let context = node;
+        const packageName = getPackageName(context);
+        if (packageName?.startsWith('safeds')) {
+            const description = this.packages
+                .getDeclarationsInPackage(packageName, { nodeType: SdsClass })
+                .find((it) => it.name === node.name);
+
+            if (isSdsClass(description?.node)) {
+                context = description.node;
+            }
+        }
+
+        const directSubclasses = this.classHierarchy
+            .streamDirectSubclasses(context)
+            .distinct((it) => it.name)
+            .toArray()
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((it) => this.renderType(this.typeComputer.computeType(it), state.knownPaths));
+
+        if (!isEmpty(directSubclasses)) {
+            directSubclasses.forEach((subclass) => {
+                result += `- ${subclass}\n`;
+            });
+        }
         return result;
     }
 

--- a/packages/safe-ds-lang/src/language/lsp/safe-ds-type-hierarchy-provider.ts
+++ b/packages/safe-ds-lang/src/language/lsp/safe-ds-type-hierarchy-provider.ts
@@ -1,4 +1,4 @@
-import { type AstNode, AstUtils, CstUtils, type ReferenceDescription, stream, type Stream } from 'langium';
+import { type AstNode, AstUtils, CstUtils, stream } from 'langium';
 import { type TypeHierarchyItem } from 'vscode-languageserver';
 import {
     isSdsClass,
@@ -68,14 +68,10 @@ export class SafeDsTypeHierarchyProvider extends AbstractTypeHierarchyProvider {
     }
 
     protected override getSubtypes(node: AstNode): TypeHierarchyItem[] | undefined {
-        const references = this.references.findReferences(node, {
-            includeDeclaration: false,
-        });
-
         let items: TypeHierarchyItem[];
 
         if (isSdsClass(node)) {
-            items = this.getSubtypesOfClass(references);
+            items = this.getSubtypesOfClass(node);
         } else if (isSdsEnum(node)) {
             items = this.getSubtypesOfEnum(node);
         } else {
@@ -85,7 +81,11 @@ export class SafeDsTypeHierarchyProvider extends AbstractTypeHierarchyProvider {
         return items.length === 0 ? undefined : items;
     }
 
-    private getSubtypesOfClass(references: Stream<ReferenceDescription>): TypeHierarchyItem[] {
+    private getSubtypesOfClass(node: SdsClass): TypeHierarchyItem[] {
+        const references = this.references.findReferences(node, {
+            includeDeclaration: false,
+        });
+
         return references
             .flatMap((it) => {
                 const document = this.documents.getDocument(it.sourceUri);

--- a/packages/safe-ds-lang/src/language/typing/safe-ds-class-hierarchy.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-class-hierarchy.ts
@@ -1,14 +1,18 @@
-import { AstUtils, EMPTY_STREAM, stream, Stream } from 'langium';
+import { AstUtils, CstUtils, EMPTY_STREAM, LangiumDocuments, References, stream, Stream } from 'langium';
 import { SafeDsClasses } from '../builtins/safe-ds-classes.js';
-import { isSdsClass, isSdsNamedType, SdsClass, type SdsClassMember } from '../generated/ast.js';
+import { isSdsClass, isSdsNamedType, isSdsParentTypeList, SdsClass, type SdsClassMember } from '../generated/ast.js';
 import { getClassMembers, getParentTypes, isStatic } from '../helpers/nodeProperties.js';
 import { SafeDsServices } from '../safe-ds-module.js';
 
 export class SafeDsClassHierarchy {
     private readonly builtinClasses: SafeDsClasses;
+    private readonly langiumDocuments: LangiumDocuments;
+    private readonly references: References;
 
     constructor(services: SafeDsServices) {
         this.builtinClasses = services.builtins.Classes;
+        this.langiumDocuments = services.shared.workspace.LangiumDocuments;
+        this.references = services.references.References;
     }
 
     /**
@@ -123,5 +127,55 @@ export class SafeDsClassHierarchy {
         return this.streamSuperclassMembers(containingClass)
             .filter((it) => !isStatic(it) && it.name === node.name)
             .head();
+    }
+
+    /**
+     * Returns a stream of all direct subclasses of the given class. There is no guarantee about the order in which the
+     * subclasses are returned. The class itself is not included in the stream.
+     *
+     * Returns an empty stream for "Any".
+     */
+    streamDirectSubclasses(node: SdsClass | undefined): Stream<SdsClass> {
+        if (!node || node === this.builtinClasses.Any) {
+            return EMPTY_STREAM;
+        }
+
+        return this.references
+            .findReferences(node, {
+                includeDeclaration: false,
+            })
+            .flatMap((it) => {
+                const document = this.langiumDocuments.getDocument(it.sourceUri);
+                if (!document) {
+                    /* c8 ignore next 2 */
+                    return [];
+                }
+
+                const rootNode = document.parseResult.value;
+                if (!rootNode.$cstNode) {
+                    /* c8 ignore next 2 */
+                    return [];
+                }
+
+                const targetCstNode = CstUtils.findLeafNodeAtOffset(rootNode.$cstNode, it.segment.offset);
+                if (!targetCstNode) {
+                    /* c8 ignore next 2 */
+                    return [];
+                }
+
+                // Only consider the first parent type
+                const targetNode = targetCstNode.astNode;
+                if (!isSdsParentTypeList(targetNode.$container) || targetNode.$containerIndex !== 0) {
+                    return [];
+                }
+
+                const containingClass = AstUtils.getContainerOfType(targetNode, isSdsClass);
+                if (!containingClass) {
+                    /* c8 ignore next 2 */
+                    return [];
+                }
+
+                return [containingClass];
+            });
     }
 }

--- a/packages/safe-ds-lang/tests/language/typing/safe-ds-class-hierarchy.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/safe-ds-class-hierarchy.test.ts
@@ -515,6 +515,15 @@ describe('SafeDsClassHierarchy', async () => {
                 `,
                 expected: [],
             },
+            {
+                testName: 'should only consider parent type list',
+                code: `
+                    class C
+
+                    fun f(p: C)
+                `,
+                expected: [],
+            },
         ];
 
         it.each(testCases)('$testName', async ({ code, expected }) => {

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass1.md
@@ -7,6 +7,10 @@ search:
 
 Description of MyClass1.
 
+**Inheritors:**
+
+- [`MyClass5`][tests.generation.markdown.classes.documented.MyClass5]
+
 ??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="6"

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass6.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass6.md
@@ -2,6 +2,10 @@
 
 Description of MyClass6.
 
+**Inheritors:**
+
+- [`MyClass8`][tests.generation.markdown.classes.documented.MyClass8]
+
 ??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="38"

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/inheritors of builtins/generated/SUMMARY.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/inheritors of builtins/generated/SUMMARY.md
@@ -1,0 +1,9 @@
+---
+search:
+  exclude: true
+---
+
+- safeds
+    - lang
+        - [Int](safeds/lang/Int.md)
+        - [Number](safeds/lang/Number.md)

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/inheritors of builtins/generated/safeds/lang/Int.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/inheritors of builtins/generated/safeds/lang/Int.md
@@ -1,0 +1,14 @@
+---
+search:
+  boost: 0.5
+---
+
+# `#!sds abstract class` Int {#safeds.lang.Int data-toc-label='Int'}
+
+**Parent type:** `#!sds Number`
+
+??? quote "Stub code in `main.sdsstub`"
+
+    ```sds linenums="5"
+    class Int sub Number
+    ```

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/inheritors of builtins/generated/safeds/lang/Number.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/inheritors of builtins/generated/safeds/lang/Number.md
@@ -1,0 +1,17 @@
+---
+search:
+  boost: 0.5
+---
+
+# `#!sds abstract class` Number {#safeds.lang.Number data-toc-label='Number'}
+
+**Inheritors:**
+
+- `#!sds Float`
+- `#!sds Int`
+
+??? quote "Stub code in `main.sdsstub`"
+
+    ```sds linenums="3"
+    class Number
+    ```

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/inheritors of builtins/main.sdsstub
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/inheritors of builtins/main.sdsstub
@@ -1,0 +1,5 @@
+package safeds.lang
+
+class Number
+
+class Int sub Number

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass1.md
@@ -5,6 +5,10 @@ search:
 
 # `#!sds abstract class` MyClass1 {#tests.generation.markdown.classes.undocumented.MyClass1 data-toc-label='MyClass1'}
 
+**Inheritors:**
+
+- [`MyClass5`][tests.generation.markdown.classes.undocumented.MyClass5]
+
 ??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="3"

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass6.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass6.md
@@ -1,5 +1,9 @@
 # `#!sds abstract class` MyClass6 {#tests.generation.markdown.classes.undocumented.MyClass6 data-toc-label='MyClass6'}
 
+**Inheritors:**
+
+- [`MyClass7`][tests.generation.markdown.classes.undocumented.MyClass7]
+
 ??? quote "Stub code in `main.sdsstub`"
 
     ```sds linenums="13"


### PR DESCRIPTION
Closes #1036

### Summary of Changes

The direct subclasses of a class are now shown in the documentation with hyperlinks to the respective page.
