### PR TITLE
feat: ignore parameter names for default values and yields

### DIFF
--- a/packages/safe-ds-lang/src/language/validation/types.ts
+++ b/packages/safe-ds-lang/src/language/validation/types.ts
@@ -320,7 +320,7 @@ export const parameterDefaultValueTypeMustMatchParameterType = (services: SafeDs
         const defaultValueType = typeComputer.computeType(defaultValue);
         const parameterType = typeComputer.computeType(node);
 
-        if (!typeChecker.isSubtypeOf(defaultValueType, parameterType)) {
+        if (!typeChecker.isSubtypeOf(defaultValueType, parameterType, { ignoreParameterNames: true })) {
             accept('error', `Expected type '${parameterType}' but got '${defaultValueType}'.`, {
                 node,
                 property: 'defaultValue',
@@ -425,7 +425,7 @@ export const yieldTypeMustMatchResultType = (services: SafeDsServices) => {
         const yieldType = typeComputer.computeType(node);
         const resultType = typeComputer.computeType(result);
 
-        if (!typeChecker.isSubtypeOf(yieldType, resultType)) {
+        if (!typeChecker.isSubtypeOf(yieldType, resultType, { ignoreParameterNames: true })) {
             accept('error', `Expected type '${resultType}' but got '${yieldType}'.`, {
                 node,
                 property: 'result',

--- a/packages/safe-ds-lang/tests/resources/validation/types/checking/default values/parameter names of callable types.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/validation/types/checking/default values/parameter names of callable types.sdsdev
@@ -1,0 +1,10 @@
+package tests.validation.types.checking.defaultValues.parameterNamesOfCallableTypes
+
+// $TEST$ no error r"Expected type .* but got .*\."
+@Pure fun f(callback: (p: Int) -> (r: Int) = »(q) {
+        yield s = 1;
+    }«
+)
+
+// $TEST$ no error r"Expected type .* but got .*\."
+@Pure fun g(callback: (p: Int) -> (r: Int) = »(q) -> 1«)

--- a/packages/safe-ds-lang/tests/resources/validation/types/checking/yields/parameter names of callable types.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/validation/types/checking/yields/parameter names of callable types.sdsdev
@@ -1,0 +1,14 @@
+package tests.validation.types.checking.yields.parameterNamesOfCallableTypes
+
+segment mySegment() -> (
+    r1: (p: Int) -> (r: Int),
+    r2: (p: Int) -> (r: Int),
+) {
+    // $TEST$ no error r"Expected type .* but got .*\."
+    yield »r1« = (q) {
+        yield s = 1;
+    };
+
+    // $TEST$ no error r"Expected type .* but got .*\."
+    yield »r2« = (q) -> 1;
+}


### PR DESCRIPTION
### Summary of Changes

Parameter names are no longer checked for lambdas used as defaults values and in yields.
