### PR TITLE
fix: stub for `Table.transformColumn`

### DIFF
--- a/packages/safe-ds-lang/src/resources/builtins/safeds/data/tabular/containers/table.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/data/tabular/containers/table.sdsstub
@@ -745,7 +745,7 @@ class Table(
      *
      * The original table is not modified.
      *
-     * @result result1 The table with the transformed column.
+     * @result transformedTable The table with the transformed column.
      *
      * @example
      * pipeline example {
@@ -756,8 +756,8 @@ class Table(
     @PythonName("transform_column")
     fun transformColumn(
         name: String,
-        transformer: (param1: Row) -> param2: Any
-    ) -> result1: Table
+        transformer: (row: Row) -> newColumnValue: Any?
+    ) -> transformedTable: Table
 
     /**
      * Return a new `Table` with a learned transformation applied to this table.

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/data/tabular/containers/tagged_table.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/data/tabular/containers/tagged_table.sdsstub
@@ -451,7 +451,7 @@ class TaggedTable(
      *
      * The original table is not modified.
      *
-     * @result result1 The table with the transformed column.
+     * @result transformedTable The table with the transformed column.
      *
      * @example
      * pipeline example {
@@ -462,6 +462,6 @@ class TaggedTable(
     @PythonName("transform_column")
     fun transformColumn(
         name: String,
-        transformer: (param1: Row) -> param2: Any
-    ) -> result1: TaggedTable
+        transformer: (row: Row) -> newColumnValue: Any?
+    ) -> transformedTable: TaggedTable
 }

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/data/tabular/containers/time_series.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/data/tabular/containers/time_series.sdsstub
@@ -421,7 +421,7 @@ class TimeSeries(
      * @param name The name of the column to be transformed.
      * @param transformer The transformer to the given column
      *
-     * @result result1 The time series with the transformed column.
+     * @result transformedTimeSeries The table with the transformed column.
      *
      * @example
      * pipeline example {
@@ -432,8 +432,8 @@ class TimeSeries(
     @PythonName("transform_column")
     fun transformColumn(
         name: String,
-        transformer: (param1: Row) -> param2: Any
-    ) -> result1: TimeSeries
+        transformer: (row: Row) -> newColumnValue: Any?
+    ) -> transformedTimeSeries: TimeSeries
 
     /**
      * Plot a lagplot for the target column.

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/lang/coreClasses.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/lang/coreClasses.sdsstub
@@ -52,6 +52,7 @@ class Number
  * }
  */
 class Int sub Number {
+
     /**
      * Converts this integer to a floating-point number.
      *


### PR DESCRIPTION
### Summary of Changes

Allow the callback of `Table.transformColumn` to return `null`.
