### PR TITLE
refactor: execute `runPipeline` command in language server

### DIFF
--- a/packages/safe-ds-lang/src/language/communication/safe-ds-messaging-provider.ts
+++ b/packages/safe-ds-lang/src/language/communication/safe-ds-messaging-provider.ts
@@ -1,8 +1,6 @@
 import { SafeDsServices } from '../safe-ds-module.js';
-import { Connection, MessageActionItem } from 'vscode-languageserver';
+import { Connection, MessageActionItem, WorkDoneProgressReporter } from 'vscode-languageserver';
 import { Disposable } from 'vscode-languageserver-protocol';
-
-/* c8 ignore start */
 
 /**
  * Log or show messages in the language client or otherwise communicate with it.
@@ -25,6 +23,7 @@ export class SafeDsMessagingProvider {
         if (this.logger?.trace) {
             this.logger.trace(text, verbose);
         } else if (this.connection) {
+            /* c8 ignore next 2 */
             this.connection.tracer.log(text, verbose);
         }
     }
@@ -37,6 +36,7 @@ export class SafeDsMessagingProvider {
         if (this.logger?.debug) {
             this.logger.debug(text);
         } else if (this.connection) {
+            /* c8 ignore next 2 */
             this.connection.console.debug(text);
         }
     }
@@ -49,6 +49,7 @@ export class SafeDsMessagingProvider {
         if (this.logger?.info) {
             this.logger.info(text);
         } else if (this.connection) {
+            /* c8 ignore next 2 */
             this.connection.console.info(text);
         }
     }
@@ -61,6 +62,7 @@ export class SafeDsMessagingProvider {
         if (this.logger?.warn) {
             this.logger.warn(text);
         } else if (this.connection) {
+            /* c8 ignore next 2 */
             this.connection.console.warn(text);
         }
     }
@@ -73,6 +75,7 @@ export class SafeDsMessagingProvider {
         if (this.logger?.error) {
             this.logger.error(text);
         } else if (this.connection) {
+            /* c8 ignore next 2 */
             this.connection.console.error(text);
         }
     }
@@ -86,6 +89,9 @@ export class SafeDsMessagingProvider {
      *
      * Depending on the client this might be a modal dialog with a confirmation button or a notification in a
      * notification center.
+     *
+     * @returns
+     * A promise that resolves to the selected action.
      */
     showInformationMessage(message: string): void;
     async showInformationMessage<T extends MessageActionItem>(message: string, ...actions: T[]): Promise<T | undefined>;
@@ -95,11 +101,11 @@ export class SafeDsMessagingProvider {
     ): Promise<T | undefined> {
         if (this.userMessageProvider?.showInformationMessage) {
             return this.userMessageProvider.showInformationMessage(message, ...actions);
-        } else if (this.connection) {
+        } /* c8 ignore start */ else if (this.connection) {
             return this.connection.window.showInformationMessage(message, ...actions);
         } else {
             return undefined;
-        }
+        } /* c8 ignore stop */
     }
 
     /**
@@ -107,17 +113,20 @@ export class SafeDsMessagingProvider {
      *
      * Depending on the client this might be a modal dialog with a confirmation button or a notification in a
      * notification center.
+     *
+     * @returns
+     * A promise that resolves to the selected action.
      */
     showWarningMessage(message: string): void;
     async showWarningMessage<T extends MessageActionItem>(message: string, ...actions: T[]): Promise<T | undefined>;
     async showWarningMessage<T extends MessageActionItem>(message: string, ...actions: T[]): Promise<T | undefined> {
         if (this.userMessageProvider?.showWarningMessage) {
             return this.userMessageProvider.showWarningMessage(message, ...actions);
-        } else if (this.connection) {
+        } /* c8 ignore start */ else if (this.connection) {
             return this.connection.window.showWarningMessage(message, ...actions);
         } else {
             return undefined;
-        }
+        } /* c8 ignore stop */
     }
 
     /**
@@ -125,17 +134,52 @@ export class SafeDsMessagingProvider {
      *
      * Depending on the client this might be a modal dialog with a confirmation button or a notification in a
      * notification center.
+     *
+     * @returns
+     * A promise that resolves to the selected action.
      */
     showErrorMessage(message: string): void;
     async showErrorMessage<T extends MessageActionItem>(message: string, ...actions: T[]): Promise<T | undefined>;
     async showErrorMessage<T extends MessageActionItem>(message: string, ...actions: T[]): Promise<T | undefined> {
         if (this.userMessageProvider?.showErrorMessage) {
             return this.userMessageProvider.showErrorMessage(message, ...actions);
-        } else if (this.connection) {
+        } /* c8 ignore start */ else if (this.connection) {
             return this.connection.window.showErrorMessage(message, ...actions);
         } else {
             return undefined;
-        }
+        } /* c8 ignore stop */
+    }
+
+    /**
+     * Shows a progress indicator in the client's user interface.
+     *
+     * @param title
+     * The title of the progress indicator.
+     *
+     * @param message
+     * An optional message to indicate what is currently being done.
+     *
+     * @param cancellable
+     * Whether the progress indicator should be cancellable. Observe the `token` inside the returned reporter to check
+     * if the user has cancelled the progress indicator.
+     *
+     * @returns
+     * A promise that resolves to the progress reporter. Use this reporter to update the progress indicator.
+     */
+    async showProgress(
+        title: string,
+        message?: string,
+        cancellable: boolean = false,
+    ): Promise<WorkDoneProgressReporter> {
+        if (this.userMessageProvider?.showProgress) {
+            return this.userMessageProvider.showProgress(title, 0, message, cancellable);
+        } /* c8 ignore start */ else if (this.connection) {
+            const reporter = await this.connection.window.createWorkDoneProgress();
+            reporter?.begin(title, 0, message, cancellable);
+            return reporter;
+        } else {
+            return NOOP_PROGRESS_REPORTER;
+        } /* c8 ignore stop */
     }
 
     /**
@@ -145,14 +189,13 @@ export class SafeDsMessagingProvider {
      * @param handler The handler to install.
      */
     onNotification(method: string, handler: (...args: any[]) => void): Disposable {
-        if (this.connection) {
-            return this.connection.onNotification(method, handler);
-        } else if (this.messageBroker?.onNotification) {
+        if (this.messageBroker?.onNotification) {
             return this.messageBroker.onNotification(method, handler);
+        } else if (this.connection) {
+            /* c8 ignore next 2 */
+            return this.connection.onNotification(method, handler);
         } else {
-            return {
-                dispose() {},
-            };
+            return NOOP_DISPOSABLE;
         }
     }
 
@@ -163,10 +206,11 @@ export class SafeDsMessagingProvider {
      * @param args The notification's parameters.
      */
     async sendNotification(method: string, ...args: any): Promise<void> {
-        if (this.connection) {
-            await this.connection.sendNotification(method, args);
-        } else if (this.messageBroker?.sendNotification) {
+        if (this.messageBroker?.sendNotification) {
             await this.messageBroker.sendNotification(method, ...args);
+        } else if (this.connection) {
+            /* c8 ignore next 2 */
+            await this.connection.sendNotification(method, args);
         }
     }
 
@@ -191,8 +235,6 @@ export class SafeDsMessagingProvider {
         this.messageBroker = messageBroker;
     }
 }
-
-/* c8 ignore stop */
 
 /**
  * A logging provider.
@@ -230,18 +272,50 @@ export interface Logger {
 export interface UserMessageProvider {
     /**
      * Prominently show an information message. The message should be short and human-readable.
+     *
+     * @returns
+     * A thenable that resolves to the selected action.
      */
     showInformationMessage?: <T extends MessageActionItem>(message: string, ...actions: T[]) => Thenable<T | undefined>;
 
     /**
      * Prominently show a warning message. The message should be short and human-readable.
+     *
+     * @returns
+     * A thenable that resolves to the selected action.
      */
     showWarningMessage?: <T extends MessageActionItem>(message: string, ...actions: T[]) => Thenable<T | undefined>;
 
     /**
      * Prominently show an error message. The message should be short and human-readable.
+     *
+     * @returns
+     * A thenable that resolves to the selected action.
      */
     showErrorMessage?: <T extends MessageActionItem>(message: string, ...actions: T[]) => Thenable<T | undefined>;
+
+    /**
+     * Shows a progress indicator in the client's user interface.
+     *
+     * @param title
+     * The title of the progress indicator.
+     *
+     * @param message
+     * An optional message to indicate what is currently being done.
+     *
+     * @param cancellable
+     * Whether the progress indicator should be cancellable. Observe the `token` inside the returned reporter to check
+     * if the user has cancelled the progress indicator.
+     *
+     * @returns
+     * A thenable that resolves to the progress reporter. Use this reporter to update the progress indicator.
+     */
+    showProgress?: (
+        title: string,
+        percentage?: number,
+        message?: string,
+        cancellable?: boolean,
+    ) => Thenable<WorkDoneProgressReporter>;
 }
 
 /**
@@ -264,3 +338,13 @@ export interface MessageBroker {
      */
     sendNotification?: (method: string, ...args: any[]) => Promise<void>;
 }
+
+const NOOP_PROGRESS_REPORTER: WorkDoneProgressReporter = {
+    begin() {},
+    report() {},
+    done() {},
+};
+
+const NOOP_DISPOSABLE: Disposable = {
+    dispose() {},
+};

--- a/packages/safe-ds-lang/src/language/communication/safe-ds-messaging-provider.ts
+++ b/packages/safe-ds-lang/src/language/communication/safe-ds-messaging-provider.ts
@@ -345,6 +345,4 @@ const NOOP_PROGRESS_REPORTER: WorkDoneProgressReporter = {
     done() {},
 };
 
-const NOOP_DISPOSABLE: Disposable = {
-    dispose() {},
-};
+const NOOP_DISPOSABLE: Disposable = Disposable.create(() => {});

--- a/packages/safe-ds-lang/src/language/lsp/safe-ds-code-lens-provider.ts
+++ b/packages/safe-ds-lang/src/language/lsp/safe-ds-code-lens-provider.ts
@@ -7,6 +7,7 @@ import { isSdsModule, isSdsPipeline, SdsModuleMember, SdsPipeline, SdsPlaceholde
 import { SafeDsRunner } from '../runner/safe-ds-runner.js';
 import { getModuleMembers, streamPlaceholders } from '../helpers/nodeProperties.js';
 import { SafeDsTypeChecker } from '../typing/safe-ds-type-checker.js';
+import { COMMAND_RUN_PIPELINE } from './safe-ds-execute-command-handler.js';
 
 export class SafeDsCodeLensProvider implements CodeLensProvider {
     private readonly astNodeLocator: AstNodeLocator;
@@ -73,7 +74,7 @@ export class SafeDsCodeLensProvider implements CodeLensProvider {
             range: cstNode.range,
             command: {
                 title: `Run ${node.name}`,
-                command: 'safe-ds.runPipeline',
+                command: COMMAND_RUN_PIPELINE,
                 arguments: this.computeNodeId(node),
             },
         });

--- a/packages/safe-ds-lang/src/language/lsp/safe-ds-execute-command-handler.ts
+++ b/packages/safe-ds-lang/src/language/lsp/safe-ds-execute-command-handler.ts
@@ -1,0 +1,20 @@
+import { AbstractExecuteCommandHandler, ExecuteCommandAcceptor } from 'langium/lsp';
+import { SafeDsSharedServices } from '../safe-ds-module.js';
+import { SafeDsRunner } from '../runner/safe-ds-runner.js';
+
+export const COMMAND_RUN_PIPELINE = 'safe-ds.runPipeline';
+
+export class SafeDsExecuteCommandHandler extends AbstractExecuteCommandHandler {
+    private readonly runner: SafeDsRunner;
+
+    constructor(sharedServices: SafeDsSharedServices) {
+        super();
+
+        const services = sharedServices.ServiceRegistry.getSafeDsServices();
+        this.runner = services.runtime.Runner;
+    }
+
+    override registerCommands(acceptor: ExecuteCommandAcceptor) {
+        acceptor(COMMAND_RUN_PIPELINE, ([documentUri, nodePath]) => this.runner.runPipeline(documentUri, nodePath));
+    }
+}

--- a/packages/safe-ds-lang/src/language/lsp/safe-ds-execute-command-handler.ts
+++ b/packages/safe-ds-lang/src/language/lsp/safe-ds-execute-command-handler.ts
@@ -4,6 +4,7 @@ import { SafeDsRunner } from '../runner/safe-ds-runner.js';
 
 export const COMMAND_RUN_PIPELINE = 'safe-ds.runPipeline';
 
+/* c8 ignore start */
 export class SafeDsExecuteCommandHandler extends AbstractExecuteCommandHandler {
     private readonly runner: SafeDsRunner;
 
@@ -18,3 +19,4 @@ export class SafeDsExecuteCommandHandler extends AbstractExecuteCommandHandler {
         acceptor(COMMAND_RUN_PIPELINE, ([documentUri, nodePath]) => this.runner.runPipeline(documentUri, nodePath));
     }
 }
+/* c8 ignore stop */

--- a/packages/safe-ds-lang/src/language/runner/safe-ds-runner.ts
+++ b/packages/safe-ds-lang/src/language/runner/safe-ds-runner.ts
@@ -185,13 +185,13 @@ export class SafeDsRunner {
                     return `\tat ${frame.file} line ${frame.line}`;
                 }),
             );
-            this.logger.error(
-                `Runner-RuntimeError (${message.id}): ${
+            this.logger.debug(
+                `[${message.id}] ${
                     (<RuntimeErrorMessage>message).data.message
-                } \n${readableStacktracePython.join('\n')}`,
+                }\n${readableStacktracePython.join('\n')}`,
             );
             this.logger.error(
-                `Safe-DS Error (${message.id}): ${(<RuntimeErrorMessage>message).data.message} \n${readableStacktraceSafeDs
+                `[${message.id}] ${(<RuntimeErrorMessage>message).data.message} \n${readableStacktraceSafeDs
                     .reverse()
                     .join('\n')}`,
             );

--- a/packages/safe-ds-lang/src/language/runner/safe-ds-runner.ts
+++ b/packages/safe-ds-lang/src/language/runner/safe-ds-runner.ts
@@ -134,13 +134,6 @@ export class SafeDsRunner {
                     });
                 }
             }),
-
-            this.addMessageCallback('shutdown', () => {
-                progress.done();
-                disposables.forEach((it) => {
-                    it.dispose();
-                });
-            }),
         ];
 
         await this.executePipeline(pipelineExecutionId, document, pipeline.name);
@@ -574,13 +567,13 @@ export class SafeDsRunner {
     /* c8 ignore start */
     public sendMessageToPythonServer(message: PythonServerMessage): void {
         const messageString = JSON.stringify(message);
-        this.logger.debug(`Sending message to python server: ${messageString}`);
+        this.logger.trace(`Sending message to python server: ${messageString}`);
         this.serverConnection!.send(messageString);
     }
 
     private async getPythonServerVersion(process: child_process.ChildProcessWithoutNullStreams) {
         process.stderr.on('data', (data: Buffer) => {
-            this.logger.debug(`[Runner-Err] ${data.toString().trim()}`);
+            this.logger.debug(data.toString().trim());
         });
         return new Promise<string>((resolve, reject) => {
             process.stdout.on('data', (data: Buffer) => {

--- a/packages/safe-ds-lang/src/language/runner/safe-ds-runner.ts
+++ b/packages/safe-ds-lang/src/language/runner/safe-ds-runner.ts
@@ -299,11 +299,23 @@ export class SafeDsRunner {
     public addMessageCallback<M extends PythonServerMessage['type']>(
         callback: (message: Extract<PythonServerMessage, { type: M }>) => void,
         messageType: M,
-    ): void {
+    ): Disposable {
         if (!this.messageCallbacks.has(messageType)) {
             this.messageCallbacks.set(messageType, []);
         }
         this.messageCallbacks.get(messageType)!.push(<(message: PythonServerMessage) => void>callback);
+
+        return {
+            dispose: () => {
+                if (!this.messageCallbacks.has(messageType)) {
+                    return;
+                }
+                this.messageCallbacks.set(
+                    messageType,
+                    this.messageCallbacks.get(messageType)!.filter((storedCallback) => storedCallback !== callback),
+                );
+            },
+        };
     }
 
     /**

--- a/packages/safe-ds-lang/src/language/safe-ds-module.ts
+++ b/packages/safe-ds-lang/src/language/safe-ds-module.ts
@@ -45,10 +45,10 @@ import { SafeDsMarkdownGenerator } from './generation/safe-ds-markdown-generator
 import { SafeDsCompletionProvider } from './lsp/safe-ds-completion-provider.js';
 import { SafeDsFuzzyMatcher } from './lsp/safe-ds-fuzzy-matcher.js';
 import {
-    type Logger,
-    MessageBroker,
+    type SafeDsLogger,
+    SafeDsMessageBroker,
     SafeDsMessagingProvider,
-    type UserMessageProvider,
+    type SafeDsUserMessageProvider,
 } from './communication/safe-ds-messaging-provider.js';
 import { SafeDsConfigurationProvider } from './workspace/safe-ds-configuration-provider.js';
 import { SafeDsCodeLensProvider } from './lsp/safe-ds-code-lens-provider.js';
@@ -275,7 +275,7 @@ export interface ModuleOptions {
      * A logging provider. If the logger lacks a capability, we fall back to the logger provided by the language server
      * connection, if available.
      */
-    logger?: Logger;
+    logger?: Partial<SafeDsLogger>;
 
     /**
      * By default, builtins are loaded into the workspace. If this option is set to true, builtins are omitted.
@@ -286,7 +286,7 @@ export interface ModuleOptions {
      * A message broker for communicating with the client. If the broker lacks a capability, we fall back to the
      * language server connection, if available.
      */
-    messageBroker?: MessageBroker;
+    messageBroker?: Partial<SafeDsMessageBroker>;
 
     /**
      * Command to start the runner.
@@ -297,5 +297,5 @@ export interface ModuleOptions {
      * A service for showing messages to the user. If the provider lacks a capability, we fall back to the language
      * server connection, if available.
      */
-    userMessageProvider?: UserMessageProvider;
+    userMessageProvider?: Partial<SafeDsUserMessageProvider>;
 }

--- a/packages/safe-ds-lang/src/language/safe-ds-module.ts
+++ b/packages/safe-ds-lang/src/language/safe-ds-module.ts
@@ -248,11 +248,9 @@ export const createSafeDsServices = async function (
 
     // Apply options
     if (options?.logger) {
-        /* c8 ignore next 2 */
         SafeDs.communication.MessagingProvider.setLogger(options.logger);
     }
     if (options?.messageBroker) {
-        /* c8 ignore next 2 */
         SafeDs.communication.MessagingProvider.setMessageBroker(options.messageBroker);
     }
     if (!options?.omitBuiltins) {
@@ -263,7 +261,6 @@ export const createSafeDsServices = async function (
         await SafeDs.runtime.Runner.updateRunnerCommand(options.runnerCommand);
     }
     if (options?.userMessageProvider) {
-        /* c8 ignore next 2 */
         SafeDs.communication.MessagingProvider.setUserMessageProvider(options.userMessageProvider);
     }
 

--- a/packages/safe-ds-lang/src/language/safe-ds-module.ts
+++ b/packages/safe-ds-lang/src/language/safe-ds-module.ts
@@ -52,6 +52,8 @@ import {
 } from './communication/safe-ds-messaging-provider.js';
 import { SafeDsConfigurationProvider } from './workspace/safe-ds-configuration-provider.js';
 import { SafeDsCodeLensProvider } from './lsp/safe-ds-code-lens-provider.js';
+import { SafeDsExecuteCommandHandler } from './lsp/safe-ds-execute-command-handler.js';
+import { SafeDsServiceRegistry } from './safe-ds-service-registry.js';
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -105,6 +107,7 @@ export type SafeDsAddedServices = {
 };
 
 export type SafeDsAddedSharedServices = {
+    ServiceRegistry: SafeDsServiceRegistry;
     workspace: {
         ConfigurationProvider: SafeDsConfigurationProvider;
     };
@@ -193,13 +196,15 @@ export const SafeDsModule: Module<SafeDsServices, PartialLangiumServices & SafeD
 };
 
 export const SafeDsSharedModule: Module<SafeDsSharedServices, DeepPartial<SafeDsSharedServices>> = {
+    ServiceRegistry: () => new SafeDsServiceRegistry(),
     lsp: {
+        ExecuteCommandHandler: (sharedServices) => new SafeDsExecuteCommandHandler(sharedServices),
         FuzzyMatcher: () => new SafeDsFuzzyMatcher(),
         NodeKindProvider: () => new SafeDsNodeKindProvider(),
     },
     workspace: {
-        ConfigurationProvider: (services) => new SafeDsConfigurationProvider(services),
-        WorkspaceManager: (services) => new SafeDsWorkspaceManager(services),
+        ConfigurationProvider: (sharedServices) => new SafeDsConfigurationProvider(sharedServices),
+        WorkspaceManager: (sharedServices) => new SafeDsWorkspaceManager(sharedServices),
     },
 };
 

--- a/packages/safe-ds-lang/src/language/safe-ds-service-registry.ts
+++ b/packages/safe-ds-lang/src/language/safe-ds-service-registry.ts
@@ -1,0 +1,10 @@
+import { DefaultServiceRegistry, URI } from 'langium';
+import { SafeDsLanguageMetaData } from './generated/module.js';
+import { SafeDsServices } from './safe-ds-module.js';
+
+export class SafeDsServiceRegistry extends DefaultServiceRegistry {
+    getSafeDsServices(): SafeDsServices {
+        const extension = SafeDsLanguageMetaData.fileExtensions[0];
+        return this.getServices(URI.file(`any.${extension}`)) as SafeDsServices;
+    }
+}

--- a/packages/safe-ds-lang/src/language/safe-ds-service-registry.ts
+++ b/packages/safe-ds-lang/src/language/safe-ds-service-registry.ts
@@ -3,8 +3,10 @@ import { SafeDsLanguageMetaData } from './generated/module.js';
 import { SafeDsServices } from './safe-ds-module.js';
 
 export class SafeDsServiceRegistry extends DefaultServiceRegistry {
+    /* c8 ignore start */
     getSafeDsServices(): SafeDsServices {
         const extension = SafeDsLanguageMetaData.fileExtensions[0];
         return this.getServices(URI.file(`any.${extension}`)) as SafeDsServices;
     }
+    /* c8 ignore stop */
 }

--- a/packages/safe-ds-lang/tests/language/communication/safe-ds-messaging-provider.test.ts
+++ b/packages/safe-ds-lang/tests/language/communication/safe-ds-messaging-provider.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSafeDsServices } from '../../../src/language/index.js';
+import { NodeFileSystem } from 'langium/node';
+import { ModuleOptions } from '../../../src/language/safe-ds-module.js';
+import { EventEmitter } from 'node:events';
+
+// ReadableStream();
+// describe('with connection', async () => {
+//     const connection = createConnection(ProposedFeatures.all);
+//     createConnection(Readable.from([]), Writable, ProposedFeatures.all);
+//     const { SafeDs: services, shared } = await createSafeDsServices({ connection, ...NodeFileSystem });
+//     doStartLanguageServer(shared);
+//
+//     describe('logging', () => {
+//         it('should not be undefined', () => {
+//             // expect(services.logging).not.toBeUndefined();
+//         });
+//     });
+// });
+
+describe('without connection', async () => {
+    const eventEmitter = new EventEmitter();
+    const options: ModuleOptions = {
+        logger: {
+            trace: vi.fn(),
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+        },
+        messageBroker: {
+            onNotification(event, handler) {
+                eventEmitter.on(event, handler);
+                return {
+                    dispose() {
+                        eventEmitter.off(event, handler);
+                    },
+                };
+            },
+            sendNotification: vi.fn(),
+        },
+        userMessageProvider: {
+            showInformationMessage: vi.fn().mockReturnValue(undefined),
+            showWarningMessage: vi.fn().mockReturnValue(undefined),
+            showErrorMessage: vi.fn().mockReturnValue(undefined),
+            showProgress: vi.fn().mockReturnValue(undefined),
+        },
+    };
+    const services = (await createSafeDsServices(NodeFileSystem, options)).SafeDs;
+    const messaging = services.communication.MessagingProvider;
+
+    describe('logger', () => {
+        it('should call the trace function defined in the options', () => {
+            messaging.trace('Test', 'trace', 'verbose');
+            expect(options.logger!.trace).toHaveBeenCalledWith('[Test] trace', 'verbose');
+        });
+
+        it('should call the debug function defined in the options', () => {
+            messaging.debug('Test', 'debug');
+            expect(options.logger!.debug).toHaveBeenCalledWith('[Test] debug');
+        });
+
+        it('should call the info function defined in the options', () => {
+            messaging.info('Test', 'info');
+            expect(options.logger!.info).toHaveBeenCalledWith('[Test] info');
+        });
+
+        it('should call the warn function defined in the options', () => {
+            messaging.warn('Test', 'warn');
+            expect(options.logger!.warn).toHaveBeenCalledWith('[Test] warn');
+        });
+
+        it('should call the error function defined in the options', () => {
+            messaging.error('Test', 'error');
+            expect(options.logger!.error).toHaveBeenCalledWith('[Test] error');
+        });
+    });
+
+    describe('messageBroker', () => {
+        it('should call the onNotification function defined in the options', () => {
+            const listener = vi.fn();
+            messaging.onNotification('Test', listener);
+            eventEmitter.emit('Test', 'onNotification');
+            expect(listener).toHaveBeenCalledWith('onNotification');
+        });
+
+        it('should call the sendNotification function defined in the options', () => {
+            messaging.sendNotification('Test', 'sendNotification');
+            expect(options.messageBroker!.sendNotification).toHaveBeenCalledWith('Test', 'sendNotification');
+        });
+    });
+
+    describe('userMessageProvider', () => {
+        it('should call the showInformationMessage function defined in the options', () => {
+            messaging.showInformationMessage('Test', { title: 'showInformationMessage' });
+            expect(options.userMessageProvider!.showInformationMessage).toHaveBeenCalledWith('Test', {
+                title: 'showInformationMessage',
+            });
+        });
+
+        it('should call the showWarningMessage function defined in the options', () => {
+            messaging.showWarningMessage('Test', { title: 'showWarningMessage' });
+            expect(options.userMessageProvider!.showWarningMessage).toHaveBeenCalledWith('Test', {
+                title: 'showWarningMessage',
+            });
+        });
+
+        it('should call the showErrorMessage function defined in the options', () => {
+            messaging.showErrorMessage('Test', { title: 'showErrorMessage' });
+            expect(options.userMessageProvider!.showErrorMessage).toHaveBeenCalledWith('Test', {
+                title: 'showErrorMessage',
+            });
+        });
+
+        it('should call the showProgress function defined in the options', () => {
+            messaging.showProgress('Test', 'showProgress');
+            expect(options.userMessageProvider!.showProgress).toHaveBeenCalledWith('Test', 0, 'showProgress', false);
+        });
+    });
+});

--- a/packages/safe-ds-lang/tests/language/communication/safe-ds-messaging-provider.test.ts
+++ b/packages/safe-ds-lang/tests/language/communication/safe-ds-messaging-provider.test.ts
@@ -4,20 +4,6 @@ import { NodeFileSystem } from 'langium/node';
 import { ModuleOptions } from '../../../src/language/safe-ds-module.js';
 import { EventEmitter } from 'node:events';
 
-// ReadableStream();
-// describe('with connection', async () => {
-//     const connection = createConnection(ProposedFeatures.all);
-//     createConnection(Readable.from([]), Writable, ProposedFeatures.all);
-//     const { SafeDs: services, shared } = await createSafeDsServices({ connection, ...NodeFileSystem });
-//     doStartLanguageServer(shared);
-//
-//     describe('logging', () => {
-//         it('should not be undefined', () => {
-//             // expect(services.logging).not.toBeUndefined();
-//         });
-//     });
-// });
-
 describe('without connection', async () => {
     const eventEmitter = new EventEmitter();
     const options: ModuleOptions = {

--- a/packages/safe-ds-vscode/src/extension/eda/apis/runnerApi.ts
+++ b/packages/safe-ds-vscode/src/extension/eda/apis/runnerApi.ts
@@ -1,6 +1,6 @@
 import { Base64Image, Column, Profiling, ProfilingDetailStatistical, Table } from '@safe-ds/eda/types/state.js';
-import { SafeDsServices, ast, messages } from '@safe-ds/lang';
-import { LangiumDocument, AstNode } from 'langium';
+import { ast, messages, SafeDsServices } from '@safe-ds/lang';
+import { AstNode, LangiumDocument } from 'langium';
 import { printOutputMessage } from '../../output.ts';
 import * as vscode from 'vscode';
 import crypto from 'crypto';
@@ -63,8 +63,8 @@ export class RunnerApi {
                     return;
                 }
                 if (message.data === 'done') {
-                    this.services.runtime.Runner.removeMessageCallback(runtimeCallback, 'runtime_progress');
-                    this.services.runtime.Runner.removeMessageCallback(errorCallback, 'runtime_error');
+                    this.services.runtime.Runner.removeMessageCallback('runtime_progress', runtimeCallback);
+                    this.services.runtime.Runner.removeMessageCallback('runtime_error', errorCallback);
                     resolve();
                 }
             };
@@ -72,12 +72,12 @@ export class RunnerApi {
                 if (message.id !== pipelineExecutionId) {
                     return;
                 }
-                this.services.runtime.Runner.removeMessageCallback(runtimeCallback, 'runtime_progress');
-                this.services.runtime.Runner.removeMessageCallback(errorCallback, 'runtime_error');
+                this.services.runtime.Runner.removeMessageCallback('runtime_progress', runtimeCallback);
+                this.services.runtime.Runner.removeMessageCallback('runtime_error', errorCallback);
                 reject(message.data);
             };
-            this.services.runtime.Runner.addMessageCallback(runtimeCallback, 'runtime_progress');
-            this.services.runtime.Runner.addMessageCallback(errorCallback, 'runtime_error');
+            this.services.runtime.Runner.addMessageCallback('runtime_progress', runtimeCallback);
+            this.services.runtime.Runner.addMessageCallback('runtime_error', errorCallback);
 
             setTimeout(() => {
                 reject('Pipeline execution timed out');
@@ -139,11 +139,11 @@ export class RunnerApi {
                 if (message.id !== pipelineExecutionId || message.data.name !== placeholder) {
                     return;
                 }
-                this.services.runtime.Runner.removeMessageCallback(placeholderValueCallback, 'placeholder_value');
+                this.services.runtime.Runner.removeMessageCallback('placeholder_value', placeholderValueCallback);
                 resolve(message.data.value);
             };
 
-            this.services.runtime.Runner.addMessageCallback(placeholderValueCallback, 'placeholder_value');
+            this.services.runtime.Runner.addMessageCallback('placeholder_value', placeholderValueCallback);
             printOutputMessage('Getting placeholder from Runner ...');
             this.services.runtime.Runner.sendMessageToPythonServer(
                 messages.createPlaceholderQueryMessage(pipelineExecutionId, placeholder),

--- a/packages/safe-ds-vscode/src/extension/logging.ts
+++ b/packages/safe-ds-vscode/src/extension/logging.ts
@@ -1,0 +1,93 @@
+import vscode, { LogLevel, LogOutputChannel, ViewColumn } from 'vscode';
+
+const TRACE_PREFIX = /^\[Trace.*?\] /iu;
+const DEBUG_PREFIX = /^\[Debug.*?\] /iu;
+const INFO_PREFIX = /^\[Info.*?\] /iu;
+const WARN_PREFIX = /^\[Warn.*?\] /iu;
+const ERROR_PREFIX = /^\[Error.*?\] /iu;
+
+export class SafeDsLogOutputChannel implements LogOutputChannel {
+    private readonly delegate: LogOutputChannel;
+
+    constructor(name: string) {
+        this.delegate = vscode.window.createOutputChannel(name, { log: true });
+    }
+
+    get logLevel(): LogLevel {
+        return this.delegate.logLevel;
+    }
+
+    get name(): string {
+        return this.delegate.name;
+    }
+
+    get onDidChangeLogLevel(): vscode.Event<LogLevel> {
+        return this.delegate.onDidChangeLogLevel;
+    }
+
+    append(value: string): void {
+        this.delegate.append(value);
+    }
+
+    appendLine(value: string): void {
+        if (TRACE_PREFIX.test(value)) {
+            this.delegate.trace(value.replace(TRACE_PREFIX, ''));
+        } else if (DEBUG_PREFIX.test(value)) {
+            this.delegate.debug(value.replace(DEBUG_PREFIX, ''));
+        } else if (INFO_PREFIX.test(value)) {
+            this.delegate.info(value.replace(INFO_PREFIX, ''));
+        } else if (WARN_PREFIX.test(value)) {
+            this.delegate.warn(value.replace(WARN_PREFIX, ''));
+        } else if (ERROR_PREFIX.test(value)) {
+            this.delegate.error(value.replace(ERROR_PREFIX, ''));
+        } else {
+            this.delegate.appendLine(value);
+        }
+    }
+
+    clear(): void {
+        this.delegate.clear();
+    }
+
+    debug(message: string, ...args: any[]): void {
+        this.delegate.debug(message, args);
+    }
+
+    dispose(): void {
+        this.delegate.dispose();
+    }
+
+    error(error: string | Error, ...args: any[]): void {
+        this.delegate.error(error, args);
+    }
+
+    hide(): void {
+        this.delegate.hide();
+    }
+
+    info(message: string, ...args: any[]): void {
+        this.delegate.info(message, args);
+    }
+
+    replace(value: string): void {
+        this.delegate.replace(value);
+    }
+
+    show(preserveFocus?: boolean): void;
+    show(column?: ViewColumn, preserveFocus?: boolean): void;
+    show(columnOrPreserveFocus?: ViewColumn | boolean, preserveFocus?: boolean): void {
+        if (typeof columnOrPreserveFocus === 'boolean') {
+            this.delegate.show(columnOrPreserveFocus);
+        } else {
+            this.delegate.show(columnOrPreserveFocus, preserveFocus);
+        }
+    }
+
+    trace(message: string, ...args: any[]): void {
+        this.delegate.trace(message, args);
+    }
+
+    warn(message: string, ...args: any[]): void {
+        this.delegate.warn(message, args);
+    }
+}

--- a/packages/safe-ds-vscode/src/extension/mainClient.ts
+++ b/packages/safe-ds-vscode/src/extension/mainClient.ts
@@ -14,6 +14,7 @@ import { openDiagnosticsDumps } from './commands/openDiagnosticsDumps.js';
 import { isSdsPlaceholder } from '../../../safe-ds-lang/src/language/generated/ast.js';
 import { installRunner } from './commands/installRunner.js';
 import { updateRunner } from './commands/updateRunner.js';
+import { SafeDsLogOutputChannel } from './logging.js';
 
 let client: LanguageClient;
 let services: SafeDsServices;
@@ -92,7 +93,7 @@ const createLanguageClient = function (context: vscode.ExtensionContext): Langua
             // Notify the server about file changes to files contained in the workspace
             fileEvents: fileSystemWatcher,
         },
-        outputChannel: vscode.window.createOutputChannel('Safe-DS Language Client', 'log'),
+        outputChannel: new SafeDsLogOutputChannel('Safe-DS Language Client'),
     };
 
     // Create the language client

--- a/packages/safe-ds-vscode/src/extension/mainClient.ts
+++ b/packages/safe-ds-vscode/src/extension/mainClient.ts
@@ -259,11 +259,11 @@ const exploreTable = (context: vscode.ExtensionContext) => {
                     pipelineNode,
                     message.data.name,
                 );
-                services.runtime.Runner.removeMessageCallback(placeholderTypeCallback, 'placeholder_type');
+                services.runtime.Runner.removeMessageCallback('placeholder_type', placeholderTypeCallback);
                 cleanupLoadingIndication();
             }
         };
-        services.runtime.Runner.addMessageCallback(placeholderTypeCallback, 'placeholder_type');
+        services.runtime.Runner.addMessageCallback('placeholder_type', placeholderTypeCallback);
 
         const runtimeProgressCallback = function (message: messages.RuntimeProgressMessage) {
             printOutputMessage(`Runner-Progress (${message.id}): ${message.data}`);
@@ -274,21 +274,21 @@ const exploreTable = (context: vscode.ExtensionContext) => {
             ) {
                 lastFinishedPipelineExecutionId = pipelineExecutionId;
                 vscode.window.showErrorMessage(`Selected text is not a placeholder!`);
-                services.runtime.Runner.removeMessageCallback(runtimeProgressCallback, 'runtime_progress');
+                services.runtime.Runner.removeMessageCallback('runtime_progress', runtimeProgressCallback);
                 cleanupLoadingIndication();
             }
         };
-        services.runtime.Runner.addMessageCallback(runtimeProgressCallback, 'runtime_progress');
+        services.runtime.Runner.addMessageCallback('runtime_progress', runtimeProgressCallback);
 
         const runtimeErrorCallback = function (message: messages.RuntimeErrorMessage) {
             if (message.id === pipelineExecutionId && lastFinishedPipelineExecutionId !== pipelineExecutionId) {
                 lastFinishedPipelineExecutionId = pipelineExecutionId;
                 vscode.window.showErrorMessage(`Pipeline ran into an Error!`);
-                services.runtime.Runner.removeMessageCallback(runtimeErrorCallback, 'runtime_error');
+                services.runtime.Runner.removeMessageCallback('runtime_error', runtimeErrorCallback);
                 cleanupLoadingIndication();
             }
         };
-        services.runtime.Runner.addMessageCallback(runtimeErrorCallback, 'runtime_error');
+        services.runtime.Runner.addMessageCallback('runtime_error', runtimeErrorCallback);
 
         await doRunPipelineFile(uri, pipelineExecutionId, pipelineName, requestedPlaceholderName);
     };

--- a/packages/safe-ds-vscode/src/extension/mainClient.ts
+++ b/packages/safe-ds-vscode/src/extension/mainClient.ts
@@ -11,7 +11,7 @@ import { AstUtils, LangiumDocument } from 'langium';
 import { EDAPanel } from './eda/edaPanel.ts';
 import { dumpDiagnostics } from './commands/dumpDiagnostics.js';
 import { openDiagnosticsDumps } from './commands/openDiagnosticsDumps.js';
-import { isSdsPipeline, isSdsPlaceholder } from '../../../safe-ds-lang/src/language/generated/ast.js';
+import { isSdsPlaceholder } from '../../../safe-ds-lang/src/language/generated/ast.js';
 import { installRunner } from './commands/installRunner.js';
 import { updateRunner } from './commands/updateRunner.js';
 
@@ -120,7 +120,6 @@ const registerCommands = function (context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('safe-ds.installRunner', installRunner(context, client, services)),
         vscode.commands.registerCommand('safe-ds.openDiagnosticsDumps', openDiagnosticsDumps(context)),
         vscode.commands.registerCommand('safe-ds.refreshWebview', refreshWebview(context)),
-        vscode.commands.registerCommand('safe-ds.runPipeline', runPipeline),
         vscode.commands.registerCommand('safe-ds.updateRunner', updateRunner(context, client, services)),
     );
 };
@@ -356,28 +355,6 @@ export const getPipelineDocument = async function (
     }
 
     return mainDocument;
-};
-
-const runPipeline = async (documentUri: string, nodePath: string) => {
-    const uri = Uri.parse(documentUri);
-    const document = await getPipelineDocument(uri);
-    if (!document) {
-        vscode.window.showErrorMessage('Could not find document.');
-        return;
-    }
-
-    const root = document.parseResult.value;
-    const pipeline = services.workspace.AstNodeLocator.getAstNode(root, nodePath);
-    if (!isSdsPipeline(pipeline)) {
-        vscode.window.showErrorMessage('Selected node is not a pipeline.');
-        return;
-    }
-
-    const pipelineExecutionId = crypto.randomUUID();
-
-    printOutputMessage(`Launching Pipeline (${pipelineExecutionId}): ${documentUri} - ${pipeline.name}`);
-
-    await services.runtime.Runner.executePipeline(pipelineExecutionId, document, pipeline.name);
 };
 
 const validateDocuments = async function (


### PR DESCRIPTION
### Summary of Changes

The `runPipeline` command is now executed in the language server rather than the client. This makes it easier to write extensions for other IDEs that support LSP.
