### PR TITLE
fix: import error when exploring tables in pipelines that call segments

### DIFF
--- a/packages/safe-ds-lang/src/language/index.ts
+++ b/packages/safe-ds-lang/src/language/index.ts
@@ -20,9 +20,14 @@ export { locationToString, positionToString, rangeToString } from '../helpers/lo
 // Messages
 export * as messages from './runtime/messages.js';
 
-// Constants
+// Commands
 export * as commands from './communication/commands.js';
+
+// RPC
 export * as rpc from './communication/rpc.js';
+
+// Generation
+export { CODEGEN_PREFIX } from './generation/safe-ds-python-generator.js';
 
 // Dependencies
 export const dependencies = {

--- a/packages/safe-ds-lang/tests/language/lsp/safe-ds-rename-provider.test.ts
+++ b/packages/safe-ds-lang/tests/language/lsp/safe-ds-rename-provider.test.ts
@@ -9,7 +9,6 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 const services = (await createSafeDsServices(NodeFileSystem)).SafeDs;
 const documentBuilder = services.shared.workspace.DocumentBuilder;
 const langiumDocuments = services.shared.workspace.LangiumDocuments;
-const langiumDocumentFactory = services.shared.workspace.LangiumDocumentFactory;
 const nameProvider = services.references.NameProvider;
 const renameProvider = services.lsp.RenameProvider!;
 
@@ -258,11 +257,9 @@ describe('SafeDsRenameProvider', async () => {
         }
 
         // Add documents to workspace
-        const documents = descriptions.map((description) => {
-            const document = langiumDocumentFactory.fromString(description.originalContent, URI.parse(description.uri));
-            langiumDocuments.addDocument(document);
-            return document;
-        });
+        const documents = descriptions.map((description) =>
+            langiumDocuments.createDocument(URI.parse(description.uri), description.originalContent),
+        );
         await documentBuilder.build(documents);
 
         // Get the element to rename


### PR DESCRIPTION
### Summary of Changes

Exploring a table in the following code

```
package bug

pipeline whoSurvived {
    val titanic = Table.fromCsvFile("titanic.csv");

    val beforeSplit = preprocessBeforeSplit(titanic);
}

segment preprocessBeforeSplit(table: Table) -> result: Table {
    yield result = table;
}
```

lead to a runtime error `cannot import name 'preprocessBeforeSplit' from 'bug.gen_titanic' (unknown location)`.

The document that was created for profiling was not properly built, so an incorrect import was created for the segment, even though it was in the same document.
