### PR TITLE
feat: do not check whether optional type parameters of classes can be inferred

### DIFF
--- a/packages/safe-ds-lang/src/language/validation/other/declarations/typeParameters.ts
+++ b/packages/safe-ds-lang/src/language/validation/other/declarations/typeParameters.ts
@@ -32,8 +32,12 @@ export const typeParameterMustHaveSufficientContext = (node: SdsTypeParameter, a
     }
     /* c8 ignore stop */
 
-    // Classes without constructor can only be used as named types, where type arguments are manifest
-    if (isSdsClass(containingCallable) && !containingCallable.parameterList) {
+    // Optional type parameters of classes get initialized to their default value if there is insufficient context in
+    // the constructor. Elsewhere, the class might be used as a named type, where type arguments are manifest, so having
+    // the type parameter is beneficial. This is not the case for functions, where type parameters only get inferred.
+    //
+    // Classes without constructor can only be used as named types, where type arguments are manifest.
+    if (isSdsClass(containingCallable) && (TypeParameter.isOptional(node) || !containingCallable.parameterList)) {
         return;
     }
 

--- a/packages/safe-ds-lang/tests/resources/validation/other/declarations/type parameters/insufficient context/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/validation/other/declarations/type parameters/insufficient context/main.sdsdev
@@ -22,6 +22,8 @@ class MyClass8<»T«>(param: () -> (r: (p: T) -> ()))
 class MyClass9<»T«>(param: union<T>)
 // $TEST$ error "Insufficient context to infer this type parameter."
 class MyClass10<»T«>(param: union<T, Int>)
+// $TEST$ no error "Insufficient context to infer this type parameter."
+class MyClass11<»T« = Int>()
 
 // $TEST$ error "Insufficient context to infer this type parameter."
 fun myFunction1<»T« sub Int>()
@@ -39,3 +41,5 @@ fun myFunction6<»T«>(param: () -> (r: (p: T) -> ()))
 fun myFunction7<»T«>(param: union<T>)
 // $TEST$ error "Insufficient context to infer this type parameter."
 fun myFunction8<»T«>(param: union<T, Int>)
+// $TEST$ error "Insufficient context to infer this type parameter."
+fun myFunction9<»T« = Int>()


### PR DESCRIPTION
Closes #1084

### Summary of Changes

Optional type parameters of classes are now always allowed, even if they can never be inferred from their usage in the constructor.

This is useful to initialize them to some default value upon instantiation and override this value later, e.g. in return types of functions. See #1084 for an example.
