### PR TITLE
feat: check usages of `@PythonName` and `@PythonCall` on overriding methods

### DIFF
--- a/packages/safe-ds-lang/src/language/validation/inheritance.ts
+++ b/packages/safe-ds-lang/src/language/validation/inheritance.ts
@@ -63,6 +63,7 @@ export const classMemberMustMatchOverriddenMemberAndShouldBeNeeded = (services: 
         } else if (typeChecker.isSubtypeOf(substitutedOverriddenMemberType, ownMemberType)) {
             // Prevents the info from showing when editing the builtin files
             if (isInSafedsLangAnyClass(services, node)) {
+                /* c8 ignore next 2 */
                 return;
             }
 
@@ -220,6 +221,12 @@ export const overridingAndOverriddenMethodsMustNotHavePythonCall = (services: Sa
     const builtinAnnotations = services.builtins.Annotations;
 
     return (node: SdsFunction, accept: ValidationAcceptor): void => {
+        // Prevents the errors from showing when editing the builtin files
+        if (isInSafedsLangAnyClass(services, node)) {
+            /* c8 ignore next 2 */
+            return;
+        }
+
         // Check whether the function overrides something
         const overriddenMember = services.typing.ClassHierarchy.getOverriddenMember(node);
         if (!overriddenMember) {

--- a/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
+++ b/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
@@ -35,6 +35,8 @@ import {
     classMemberMustMatchOverriddenMemberAndShouldBeNeeded,
     classMustNotInheritItself,
     classMustOnlyInheritASingleClass,
+    overridingAndOverriddenMethodsMustNotHavePythonCall,
+    overridingMemberPythonNameMustMatchOverriddenMember,
 } from './inheritance.js';
 import {
     annotationMustContainUniqueNames,
@@ -260,7 +262,10 @@ export const registerValidationChecks = function (services: SafeDsServices) {
             staticClassMemberNamesMustNotCollideWithInheritedMembers(services),
         ],
         SdsClassBody: [classBodyShouldNotBeEmpty(services)],
-        SdsClassMember: [classMemberMustMatchOverriddenMemberAndShouldBeNeeded(services)],
+        SdsClassMember: [
+            classMemberMustMatchOverriddenMemberAndShouldBeNeeded(services),
+            overridingMemberPythonNameMustMatchOverriddenMember(services),
+        ],
         SdsConstraintList: [constraintListsShouldBeUsedWithCaution(services), constraintListShouldNotBeEmpty(services)],
         SdsDeclaration: [
             nameMustNotOccurOnCoreDeclaration(services),
@@ -283,6 +288,7 @@ export const registerValidationChecks = function (services: SafeDsServices) {
             impurityReasonShouldNotBeSetMultipleTimes(services),
             pythonCallMustOnlyContainValidTemplateExpressions(services),
             pythonNameMustNotBeSetIfPythonCallIsSet(services),
+            overridingAndOverriddenMethodsMustNotHavePythonCall(services),
         ],
         SdsImport: [importPackageMustExist(services), importPackageShouldNotBeEmpty(services)],
         SdsImportedDeclaration: [importedDeclarationAliasShouldDifferFromDeclarationName(services)],

--- a/packages/safe-ds-lang/tests/resources/validation/builtins/annotations/pythonCall/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/validation/builtins/annotations/pythonCall/main.sdsdev
@@ -33,7 +33,3 @@ fun myFunction3()
 // $TEST$ error "The template expressions '$param1', '$param2' cannot be interpreted."
 @»PythonCall«("myFunction4($param1, $param2)")
 fun myFunction4()
-
-// $TEST$ no error "An expert parameter must be optional."
-@»PythonCall«("$this")
-annotation MyAnnotation()

--- a/packages/safe-ds-lang/tests/resources/validation/inheritance/must not override method with python call annotation/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/validation/inheritance/must not override method with python call annotation/main.sdsdev
@@ -1,0 +1,30 @@
+package tests.validation.inheritance.mustNotOverrideMethodWithPythonCallAnnotation
+
+class MyClass1 {
+    // $TEST$ no error "Cannot override a method that calls the '@PythonCall' annotation."
+    @Pure
+    @PythonCall("some_other_function")
+    fun »withPythonCall«()
+
+    // $TEST$ no error "Cannot override a method that calls the '@PythonCall' annotation."
+    @Pure
+    fun »withoutPythonCall«()
+}
+
+class MyClass2 sub MyClass1 {
+    // $TEST$ no error "Cannot override a method that calls the '@PythonCall' annotation."
+    @Pure
+    @PythonCall("some_other_function")
+    fun »withPythonCall«()
+
+    // $TEST$ no error "Cannot override a method that calls the '@PythonCall' annotation."
+    @Pure
+    @PythonCall("some_other_function")
+    fun »withoutPythonCall«()
+}
+
+class MyClass3 sub MyClass1 {
+    // $TEST$ error "Cannot override a method that calls the '@PythonCall' annotation."
+    @Pure
+    fun »withPythonCall«()
+}

--- a/packages/safe-ds-lang/tests/resources/validation/inheritance/must not override method with python call annotation/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/validation/inheritance/must not override method with python call annotation/main.sdsdev
@@ -1,6 +1,8 @@
 package tests.validation.inheritance.mustNotOverrideMethodWithPythonCallAnnotation
 
 class MyClass1 {
+    attr myAttribute: Int
+
     // $TEST$ no error "Cannot override a method that calls the '@PythonCall' annotation."
     @Pure
     @PythonCall("some_other_function")
@@ -24,6 +26,10 @@ class MyClass2 sub MyClass1 {
 }
 
 class MyClass3 sub MyClass1 {
+    // $TEST$ no error "Cannot override a method that calls the '@PythonCall' annotation."
+    @Pure
+    fun »myAttribute«()
+
     // $TEST$ error "Cannot override a method that calls the '@PythonCall' annotation."
     @Pure
     fun »withPythonCall«()

--- a/packages/safe-ds-lang/tests/resources/validation/inheritance/overriding method must not have python call annotation/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/validation/inheritance/overriding method must not have python call annotation/main.sdsdev
@@ -1,0 +1,24 @@
+package tests.validation.inheritance.overridingMethodMustNotHavePythonCallAnnotation
+
+class MyClass1 {
+    // $TEST$ no error "An overriding method must not call the '@PythonCall' annotation."
+    @Pure
+    @PythonCall("some_other_function")
+    fun »withPythonCall«()
+
+    // $TEST$ no error "An overriding method must not call the '@PythonCall' annotation."
+    @Pure
+    fun »withoutPythonCall«()
+}
+
+class MyClass2 sub MyClass1 {
+    // $TEST$ error "An overriding method must not call the '@PythonCall' annotation."
+    @Pure
+    @PythonCall("some_other_function")
+    fun »withPythonCall«()
+
+    // $TEST$ error "An overriding method must not call the '@PythonCall' annotation."
+    @Pure
+    @PythonCall("some_other_function")
+    fun »withoutPythonCall«()
+}

--- a/packages/safe-ds-lang/tests/resources/validation/inheritance/overriding method should differ from overridden method/with python call.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/validation/inheritance/overriding method should differ from overridden method/with python call.sdsdev
@@ -1,0 +1,13 @@
+package tests.validation.inheritance.overridingMethodShouldDifferFromOverriddenMethod.withPythonCall
+
+class MyClass1 {
+    @Pure
+    fun f()
+}
+
+class MyClass2 {
+    // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
+    @Pure
+    @PythonCall("")
+    fun »f«()
+}

--- a/packages/safe-ds-lang/tests/resources/validation/inheritance/overriding method should differ from overridden method/with python name.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/validation/inheritance/overriding method should differ from overridden method/with python name.sdsdev
@@ -1,0 +1,34 @@
+package tests.validation.inheritance.overridingMethodShouldDifferFromOverriddenMethod.withPythonName
+
+class MyClass1 {
+    @Pure
+    fun myFunction1()
+
+    @Pure
+    @PythonName("my_function_2")
+    fun myFunction2()
+}
+
+class MyClass2 sub MyClass1 {
+    // $TEST$ info "Overriding member is identical to overridden member and can be removed."
+    @Pure
+    @PythonName("myFunction1")
+    fun »myFunction1«()
+
+    // $TEST$ info "Overriding member is identical to overridden member and can be removed."
+    @Pure
+    @PythonName("my_function_2")
+    fun »myFunction2«()
+}
+
+class MyClass3 sub MyClass1 {
+    // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
+    @Pure
+    @PythonName("anotherFunction1")
+    fun »myFunction1«()
+
+    // $TEST$ no info "Overriding member is identical to overridden member and can be removed."
+    @Pure
+    @PythonName("anotherFunction2")
+    fun »myFunction2«()
+}

--- a/packages/safe-ds-lang/tests/resources/validation/inheritance/python name must match overridden method/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/validation/inheritance/python name must match overridden method/main.sdsdev
@@ -1,0 +1,59 @@
+package tests.validation.inheritance.pythonNameMustMatchOverriddenMethod
+
+class MyClass1 {
+    // $TEST$ no error "The Python name must match the overridden member."
+    attr »myAttribute1«: Int
+
+    // $TEST$ no error "The Python name must match the overridden member."
+    @PythonName("my_Attribute_2")
+    attr »myAttribute2«: Int
+
+    // $TEST$ no error "The Python name must match the overridden member."
+    @Pure
+    fun »myFunction1«()
+
+    // $TEST$ no error "The Python name must match the overridden member."
+    @Pure
+    @PythonName("my_function_2")
+    fun »myFunction2«()
+}
+
+class MyClass2 sub MyClass1 {
+    // $TEST$ no error "The Python name must match the overridden member."
+    @PythonName("myAttribute1")
+    attr »myAttribute1«: Int
+
+    // $TEST$ no error "The Python name must match the overridden member."
+    @PythonName("my_Attribute_2")
+    attr »myAttribute2«: Int
+
+    // $TEST$ no error "The Python name must match the overridden member."
+    @Pure
+    @PythonName("myFunction1")
+    fun »myFunction1«()
+
+    // $TEST$ no error "The Python name must match the overridden member."
+    @Pure
+    @PythonName("my_function_2")
+    fun »myFunction2«()
+}
+
+class MyClass3 sub MyClass1 {
+    // $TEST$ error "The Python name must match the overridden member."
+    @PythonName("anotherAttribute1")
+    attr »myAttribute1«: Int
+
+    // $TEST$ error "The Python name must match the overridden member."
+    @PythonName("another_attribute_2")
+    attr »myAttribute2«: Int
+
+    // $TEST$ error "The Python name must match the overridden member."
+    @Pure
+    @PythonName("anotherFunction1")
+    fun »myFunction1«()
+
+    // $TEST$ error "The Python name must match the overridden member."
+    @Pure
+    @PythonName("anotherFunction2")
+    fun »myFunction2«()
+}


### PR DESCRIPTION
### Summary of Changes

Add some checks:
* Must not override method with `@PythonCall` annotation
* Overriding method must not have `@PythonCall` annotation
* Python name of overriding method must equal the python name of the overridden method
