### PR TITLE
fix: also handle literal types when computing upper bound

### DIFF
--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -774,7 +774,9 @@ export class SafeDsTypeComputer {
         }
 
         const boundType = this.computeType(upperBound);
-        if (!(boundType instanceof NamedType)) {
+        if (boundType instanceof LiteralType) {
+            return boundType;
+        } else if (!(boundType instanceof NamedType)) {
             return UnknownType;
         } else if (options.stopAtTypeVariable || !(boundType instanceof TypeVariable)) {
             return boundType;


### PR DESCRIPTION
Related to #1081

### Summary of Changes

Also update the type computer to handle literal types as upper bounds of type parameters.
