### PR TITLE
fix: generation of extra statements for parameters of expression lambdas

### DIFF
--- a/packages/safe-ds-lang/tests/resources/generation/python/runner integration/expressions/block lambdas/generated/tests/generation/python/runnerIntegration/blockLambdas/gen_input.py
+++ b/packages/safe-ds-lang/tests/resources/generation/python/runner integration/expressions/block lambdas/generated/tests/generation/python/runnerIntegration/blockLambdas/gen_input.py
@@ -1,0 +1,26 @@
+# Imports ----------------------------------------------------------------------
+
+import safeds_runner
+from tests.generation.python.runnerIntegration.blockLambdas import f
+
+# Pipelines --------------------------------------------------------------------
+
+def myPipeline():
+    def __gen_lambda_1(p):
+        __gen_receiver_0 = p
+        __gen_block_lambda_result_r = safeds_runner.memoized_dynamic_call(
+            __gen_receiver_0,
+            "g",
+            [],
+            {},
+            []
+        )
+        return __gen_block_lambda_result_r
+    __gen_result = safeds_runner.memoized_static_call(
+        "tests.generation.python.runnerIntegration.blockLambdas.f",
+        f,
+        [__gen_lambda_1],
+        {},
+        []
+    )
+    safeds_runner.save_placeholder('result', __gen_result)

--- a/packages/safe-ds-lang/tests/resources/generation/python/runner integration/expressions/block lambdas/generated/tests/generation/python/runnerIntegration/blockLambdas/gen_input.py.map
+++ b/packages/safe-ds-lang/tests/resources/generation/python/runner integration/expressions/block lambdas/generated/tests/generation/python/runnerIntegration/blockLambdas/gen_input.py.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["input.sdsdev"],"names":["mypipeline","p","r","f"],"mappings":"AAEA;;;;;;;AAYA,IAASA,UAAU;IAEX,mBAACC,CAAC;QACYA,mBAAAA,CAAC;QAAX,0BAAMC,CAAC,GAAG;;;;;;;QADd,OACI,0BAAMA,CAAC;IAFf,eAAa;;QAAAC,CAAC;SACV;;;;IADJ","file":"gen_input.py"}

--- a/packages/safe-ds-lang/tests/resources/generation/python/runner integration/expressions/block lambdas/generated/tests/generation/python/runnerIntegration/blockLambdas/gen_input_myPipeline.py
+++ b/packages/safe-ds-lang/tests/resources/generation/python/runner integration/expressions/block lambdas/generated/tests/generation/python/runnerIntegration/blockLambdas/gen_input_myPipeline.py
@@ -1,0 +1,4 @@
+from .gen_input import myPipeline
+
+if __name__ == '__main__':
+    myPipeline()

--- a/packages/safe-ds-lang/tests/resources/generation/python/runner integration/expressions/block lambdas/input.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/generation/python/runner integration/expressions/block lambdas/input.sdsdev
@@ -1,0 +1,21 @@
+// Related to https://github.com/Safe-DS/DSL/issues/1136
+
+package tests.generation.python.runnerIntegration.blockLambdas
+
+class MyClass {
+    @Pure
+    fun g() -> r: Int
+}
+
+@Pure
+fun f(
+    callback: (p: MyClass) -> (r: Int)
+) -> result: Any
+
+pipeline myPipeline {
+    val result = f(
+        (p) {
+            yield r = p.g();
+        }
+    );
+}

--- a/packages/safe-ds-lang/tests/resources/generation/python/runner integration/expressions/expression lambdas/generated/tests/generation/python/runnerIntegration/expressionLambdas/gen_input.py
+++ b/packages/safe-ds-lang/tests/resources/generation/python/runner integration/expressions/expression lambdas/generated/tests/generation/python/runnerIntegration/expressionLambdas/gen_input.py
@@ -1,0 +1,25 @@
+# Imports ----------------------------------------------------------------------
+
+import safeds_runner
+from tests.generation.python.runnerIntegration.expressionLambdas import f
+
+# Pipelines --------------------------------------------------------------------
+
+def myPipeline():
+    def __gen_lambda_0(p):
+        __gen_receiver_1 = p
+        return safeds_runner.memoized_dynamic_call(
+            __gen_receiver_1,
+            "g",
+            [],
+            {},
+            []
+        )
+    __gen_result = safeds_runner.memoized_static_call(
+        "tests.generation.python.runnerIntegration.expressionLambdas.f",
+        f,
+        [__gen_lambda_0],
+        {},
+        []
+    )
+    safeds_runner.save_placeholder('result', __gen_result)

--- a/packages/safe-ds-lang/tests/resources/generation/python/runner integration/expressions/expression lambdas/generated/tests/generation/python/runnerIntegration/expressionLambdas/gen_input.py.map
+++ b/packages/safe-ds-lang/tests/resources/generation/python/runner integration/expressions/expression lambdas/generated/tests/generation/python/runnerIntegration/expressionLambdas/gen_input.py.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["input.sdsdev"],"names":["mypipeline","p","f"],"mappings":"AAEA;;;;;;;AAYA,IAASA,UAAU;IAEX,mBAACC,CAAC;QAAKA,mBAAAA,CAAC;eAAD;;;;;;;IADX,eAAa;;QAAAC,CAAC;SACV;;;;IADJ","file":"gen_input.py"}

--- a/packages/safe-ds-lang/tests/resources/generation/python/runner integration/expressions/expression lambdas/generated/tests/generation/python/runnerIntegration/expressionLambdas/gen_input_myPipeline.py
+++ b/packages/safe-ds-lang/tests/resources/generation/python/runner integration/expressions/expression lambdas/generated/tests/generation/python/runnerIntegration/expressionLambdas/gen_input_myPipeline.py
@@ -1,0 +1,4 @@
+from .gen_input import myPipeline
+
+if __name__ == '__main__':
+    myPipeline()

--- a/packages/safe-ds-lang/tests/resources/generation/python/runner integration/expressions/expression lambdas/input.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/generation/python/runner integration/expressions/expression lambdas/input.sdsdev
@@ -1,0 +1,19 @@
+// Related to https://github.com/Safe-DS/DSL/issues/1136
+
+package tests.generation.python.runnerIntegration.expressionLambdas
+
+class MyClass {
+    @Pure
+    fun g() -> r: Int
+}
+
+@Pure
+fun f(
+    callback: (p: MyClass) -> (r: Int)
+) -> result: Any
+
+pipeline myPipeline {
+    val result = f(
+        (p) -> p.g()
+    );
+}


### PR DESCRIPTION
Closes #1136

### Summary of Changes

Extra statements that were generated for the expression of an expression lambda were incorrectly placed outside the lambda. This broke the code generation for parameters of expression lambdas that were used as receivers of method calls (see the linked issue).