### PR TITLE
feat: remove warning that package is empty

### DIFF
--- a/packages/safe-ds-lang/src/language/validation/other/imports.ts
+++ b/packages/safe-ds-lang/src/language/validation/other/imports.ts
@@ -3,28 +3,17 @@ import { SdsImport } from '../../generated/ast.js';
 import { SafeDsServices } from '../../safe-ds-module.js';
 import { isEmpty } from '../../../helpers/collections.js';
 
-export const CODE_IMPORT_MISSING_PACKAGE = 'import/missing-package';
 export const CODE_IMPORT_EMPTY_PACKAGE = 'import/empty-package';
 
-export const importPackageMustExist =
-    (services: SafeDsServices) =>
-    (node: SdsImport, accept: ValidationAcceptor): void => {
-        if (!services.workspace.PackageManager.hasPackage(node.package)) {
-            accept('error', `The package '${node.package}' does not exist.`, {
-                node,
-                property: 'package',
-            });
-        }
-    };
-
-export const importPackageShouldNotBeEmpty =
+export const importPackageMustNotBeEmpty =
     (services: SafeDsServices) =>
     (node: SdsImport, accept: ValidationAcceptor): void => {
         const declarationsInPackage = services.workspace.PackageManager.getDeclarationsInPackage(node.package);
         if (isEmpty(declarationsInPackage)) {
-            accept('warning', `The package '${node.package}' is empty.`, {
+            accept('error', `The package '${node.package}' is empty.`, {
                 node,
                 property: 'package',
+                code: CODE_IMPORT_EMPTY_PACKAGE,
             });
         }
     };

--- a/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
+++ b/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
@@ -96,7 +96,7 @@ import {
     referenceTargetMustNotBeAnnotationPipelineOrSchema,
 } from './other/expressions/references.js';
 import { templateStringMustHaveExpressionBetweenTwoStringParts } from './other/expressions/templateStrings.js';
-import { importPackageMustExist, importPackageShouldNotBeEmpty } from './other/imports.js';
+import { importPackageMustNotBeEmpty } from './other/imports.js';
 import {
     moduleDeclarationsMustMatchFileKind,
     moduleWithDeclarationsMustStatePackage,
@@ -289,7 +289,7 @@ export const registerValidationChecks = function (services: SafeDsServices) {
             pythonNameMustNotBeSetIfPythonMacroIsSet(services),
             overridingAndOverriddenMethodsMustNotHavePythonMacro(services),
         ],
-        SdsImport: [importPackageMustExist(services), importPackageShouldNotBeEmpty(services)],
+        SdsImport: [importPackageMustNotBeEmpty(services)],
         SdsImportedDeclaration: [importedDeclarationAliasShouldDifferFromDeclarationName(services)],
         SdsIndexedAccess: [
             indexedAccessIndexMustBeValid(services),

--- a/packages/safe-ds-lang/tests/resources/validation/other/imports/main with issues.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/validation/other/imports/main with issues.sdsdev
@@ -1,15 +1,8 @@
 package tests.other.imports
 
-// $TEST$ error "The package 'tests.other.imports.missing' does not exist."
+// $TEST$ error "The package 'tests.other.imports.missing' is empty."
 from »tests.other.imports.missing« import *
-// $TEST$ error "The package 'tests.other.imports.missing' does not exist."
+// $TEST$ error "The package 'tests.other.imports.missing' is empty."
 from »tests.other.imports.missing« import C
-// $TEST$ error "The package 'tests.other.imports.missing' does not exist."
+// $TEST$ error "The package 'tests.other.imports.missing' is empty."
 from »tests.other.imports.missing« import C as D
-
-// $TEST$ warning "The package 'tests.other.imports.empty' is empty."
-from »tests.other.imports.empty« import *
-// $TEST$ warning "The package 'tests.other.imports.empty' is empty."
-from »tests.other.imports.empty« import C
-// $TEST$ warning "The package 'tests.other.imports.empty' is empty."
-from »tests.other.imports.empty« import C as D

--- a/packages/safe-ds-lang/tests/resources/validation/other/imports/main without issues.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/validation/other/imports/main without issues.sdsdev
@@ -1,7 +1,6 @@
 package tests.other.imports
 
-// $TEST$ no error r"The package '\.*' does not exist\."
-// $TEST$ no warning r"The package '\.*' is empty\."
+// $TEST$ no error r"The package '\.*' is empty\."
 
 from tests.other.imports.nonEmpty import *
 from tests.other.imports.nonEmpty import C


### PR DESCRIPTION
Closes #1153

### Summary of Changes

Remove the warning that an imported package is empty. It was always shown together with an error that a package did not exist. Now, only the error is shown.
