### PR TITLE
fix: potential stack overflow when computing types of lambda parameters

### DIFF
--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -297,22 +297,7 @@ export class SafeDsTypeComputer {
                 return UnknownType;
             }
 
-            const parameterType = this.computeType(parameter);
-            if (parameterType.isFullySubstituted) {
-                return parameterType;
-            }
-
-            // Compute substitutions for containing call
-            const containingCall = AstUtils.getContainerOfType(containerOfLambda, isSdsCall);
-            if (!containingCall) {
-                /* c8 ignore next 2 */
-                return parameterType;
-            }
-
-            // Prevent infinite recursion when computing the type of the lambda parameter
-            const substitutions = this.computeSubstitutionsForLambdaParameter(containingCall, containingCallable);
-
-            return parameterType.substituteTypeParameters(substitutions);
+            return this.computeType(parameter);
         }
 
         // Lambda passed as default value
@@ -454,6 +439,8 @@ export class SafeDsTypeComputer {
             .map((it) => new NamedTupleEntry(it, it.name, this.computeType(it)))
             .toArray();
 
+        // TODO: substitute type parameters
+
         return this.factory.createCallableType(
             node,
             undefined,
@@ -506,6 +493,8 @@ export class SafeDsTypeComputer {
         const resultEntries = [
             new NamedTupleEntry<SdsAbstractResult>(undefined, 'result', this.computeType(node.result)),
         ];
+
+        // TODO substitute type parameters
 
         return this.factory.createCallableType(
             node,

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of block lambdas/that are passed as arguments/with type parameters.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of block lambdas/that are passed as arguments/with type parameters.sdsdev
@@ -10,6 +10,8 @@ class MyClass<T>(param: T) sub MySuperclass<T> {
 
 @Pure fun myFunction<T>(p: T, callback: (p: T) -> ())
 
+@Pure fun myFunction2<T>(callback: (p: T) -> (r: T))
+
 segment mySegment() {
     // $TEST$ serialization literal<1>
     MyClass(1).myMethod((»p«) {});
@@ -19,4 +21,7 @@ segment mySegment() {
 
     // $TEST$ serialization literal<1>
     myFunction(1, (»p«) {});
+
+    // $TEST$ serialization literal<"">
+    myFunction2((»p«) -> "");
 }

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of expression lambdas/that are passed as arguments/with type parameters.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/of expression lambdas/that are passed as arguments/with type parameters.sdsdev
@@ -10,6 +10,8 @@ class MyClass<T>(param: T) sub MySuperclass<T> {
 
 @Pure fun myFunction<T>(p: T, callback: (p: T) -> ())
 
+@Pure fun myFunction2<T>(callback: (p: T) -> (r: T))
+
 segment mySegment() {
     // $TEST$ serialization literal<1>
     MyClass(1).myMethod((»p«) -> "");
@@ -19,4 +21,7 @@ segment mySegment() {
 
     // $TEST$ serialization literal<1>
     myFunction(1, (»p«) -> "");
+
+    // $TEST$ serialization literal<"">
+    myFunction2((»p«) -> "");
 }

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/scope provider should not cause infinite recursion/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/parameters/scope provider should not cause infinite recursion/main.sdsdev
@@ -1,0 +1,30 @@
+package tests.typing.declarations.parameters.scopeProviderShouldNotCauseInfiniteRecursion
+
+/*
+ * This test is related to the first attempt to fix infinite recursion when computing the type of a lambda parameter.
+ * There, we passed a flag around as a parameter inside the type computer to indicate that we are currently computing
+ * type arguments for a call.
+ *
+ * However, this approach was not sufficient to fix the issue, since the type computer (implicitly) calls the scope
+ * provider, which in turn calls the type computer again. The flag was lost along the way, again opening the door for
+ * infinite recursion.
+ */
+
+class MyCell<out T = Any?> {
+    @Pure
+    fun ^not() -> result: MyCell<Boolean>
+}
+
+class MyColumn<out T = Any?>(values: List<T>) {
+    @Pure
+    fun transform<R>(
+        transformer: (cell: MyCell<T>) -> (transformedCell: MyCell<R>)
+    ) -> result: MyColumn<R>
+}
+
+pipeline myPipelines {
+    val column = MyColumn([1, 2, 3]);
+
+    // $TEST$ serialization MyColumn<Boolean>
+    val »transformedColumn« = column.transform((cell) -> cell.^not());
+}


### PR DESCRIPTION
### Summary of Changes

Due to the interaction between the type computer and the scope provider, the previous approach to prevent endless recursion when computing the type of lambda parameters could fail. This PR provides a more robust implementation to fix this issue.
