### PR TITLE
fix: override `fit` in `Classifier` and `Regressor`

### DIFF
--- a/docs/api/safeds/data/tabular/transformation/TableTransformer.md
+++ b/docs/api/safeds/data/tabular/transformation/TableTransformer.md
@@ -10,7 +10,6 @@ Learn a transformation for a set of columns in a `Table` and transform another `
 **Inheritors:**
 
 - [`Discretizer`][safeds.data.tabular.transformation.Discretizer]
-- `#!sds Imputer`
 - [`InvertibleTableTransformer`][safeds.data.tabular.transformation.InvertibleTableTransformer]
 - [`SimpleImputer`][safeds.data.tabular.transformation.SimpleImputer]
 

--- a/docs/api/safeds/ml/classical/classification/AdaBoostClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/AdaBoostClassifier.md
@@ -110,7 +110,7 @@ better. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="40"
+    ```sds linenums="54"
     @Pure
     fun accuracy(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
@@ -141,7 +141,7 @@ classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="58"
+    ```sds linenums="72"
     @Pure
     @PythonName("f1_score")
     fun f1Score(
@@ -281,7 +281,7 @@ better the classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="78"
+    ```sds linenums="92"
     @Pure
     fun precision(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>,
@@ -340,7 +340,7 @@ better the classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="97"
+    ```sds linenums="111"
     @Pure
     fun recall(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>,
@@ -369,7 +369,7 @@ Summarize the classifier's metrics on the given data.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="21"
+    ```sds linenums="35"
     @Pure
     @PythonName("summarize_metrics")
     fun summarizeMetrics(

--- a/docs/api/safeds/ml/classical/classification/Classifier.md
+++ b/docs/api/safeds/ml/classical/classification/Classifier.md
@@ -16,15 +16,27 @@ A model for classification tasks.
 - [`GradientBoostingClassifier`][safeds.ml.classical.classification.GradientBoostingClassifier]
 - [`KNearestNeighborsClassifier`][safeds.ml.classical.classification.KNearestNeighborsClassifier]
 - [`LogisticClassifier`][safeds.ml.classical.classification.LogisticClassifier]
-- `#!sds LogisticRegressionClassifier`
 - [`RandomForestClassifier`][safeds.ml.classical.classification.RandomForestClassifier]
 - [`SupportVectorClassifier`][safeds.ml.classical.classification.SupportVectorClassifier]
-- `#!sds SupportVectorMachineClassifier`
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
     ```sds linenums="10"
     class Classifier sub SupervisedModel {
+        /**
+         * Create a copy of this model and fit it with the given training data.
+         *
+         * **Note:** This model is not modified.
+         *
+         * @param trainingSet The training data containing the features and target.
+         *
+         * @result fittedModel The fitted model.
+         */
+        @Pure
+        fun fit(
+            @PythonName("training_set") trainingSet: TabularDataset
+        ) -> fittedModel: Classifier
+
         /**
          * Summarize the classifier's metrics on the given data.
          *
@@ -148,7 +160,7 @@ better. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="40"
+    ```sds linenums="54"
     @Pure
     fun accuracy(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
@@ -179,7 +191,7 @@ classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="58"
+    ```sds linenums="72"
     @Pure
     @PythonName("f1_score")
     fun f1Score(
@@ -204,15 +216,15 @@ Create a copy of this model and fit it with the given training data.
 
 | Name | Type | Description |
 |------|------|-------------|
-| `fittedModel` | [`SupervisedModel`][safeds.ml.classical.SupervisedModel] | The fitted model. |
+| `fittedModel` | [`Classifier`][safeds.ml.classical.classification.Classifier] | The fitted model. |
 
-??? quote "Stub code in `SupervisedModel.sdsstub`"
+??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="26"
+    ```sds linenums="20"
     @Pure
     fun fit(
         @PythonName("training_set") trainingSet: TabularDataset
-    ) -> fittedModel: SupervisedModel
+    ) -> fittedModel: Classifier
     ```
 
 ## `#!sds fun` getFeatureNames {#safeds.ml.classical.classification.Classifier.getFeatureNames data-toc-label='getFeatureNames'}
@@ -319,7 +331,7 @@ better the classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="78"
+    ```sds linenums="92"
     @Pure
     fun precision(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>,
@@ -378,7 +390,7 @@ better the classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="97"
+    ```sds linenums="111"
     @Pure
     fun recall(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>,
@@ -407,7 +419,7 @@ Summarize the classifier's metrics on the given data.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="21"
+    ```sds linenums="35"
     @Pure
     @PythonName("summarize_metrics")
     fun summarizeMetrics(

--- a/docs/api/safeds/ml/classical/classification/DecisionTreeClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/DecisionTreeClassifier.md
@@ -97,7 +97,7 @@ better. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="40"
+    ```sds linenums="54"
     @Pure
     fun accuracy(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
@@ -128,7 +128,7 @@ classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="58"
+    ```sds linenums="72"
     @Pure
     @PythonName("f1_score")
     fun f1Score(
@@ -268,7 +268,7 @@ better the classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="78"
+    ```sds linenums="92"
     @Pure
     fun precision(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>,
@@ -327,7 +327,7 @@ better the classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="97"
+    ```sds linenums="111"
     @Pure
     fun recall(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>,
@@ -356,7 +356,7 @@ Summarize the classifier's metrics on the given data.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="21"
+    ```sds linenums="35"
     @Pure
     @PythonName("summarize_metrics")
     fun summarizeMetrics(

--- a/docs/api/safeds/ml/classical/classification/GradientBoostingClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/GradientBoostingClassifier.md
@@ -98,7 +98,7 @@ better. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="40"
+    ```sds linenums="54"
     @Pure
     fun accuracy(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
@@ -129,7 +129,7 @@ classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="58"
+    ```sds linenums="72"
     @Pure
     @PythonName("f1_score")
     fun f1Score(
@@ -269,7 +269,7 @@ better the classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="78"
+    ```sds linenums="92"
     @Pure
     fun precision(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>,
@@ -328,7 +328,7 @@ better the classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="97"
+    ```sds linenums="111"
     @Pure
     fun recall(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>,
@@ -357,7 +357,7 @@ Summarize the classifier's metrics on the given data.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="21"
+    ```sds linenums="35"
     @Pure
     @PythonName("summarize_metrics")
     fun summarizeMetrics(

--- a/docs/api/safeds/ml/classical/classification/KNearestNeighborsClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/KNearestNeighborsClassifier.md
@@ -85,7 +85,7 @@ better. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="40"
+    ```sds linenums="54"
     @Pure
     fun accuracy(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
@@ -116,7 +116,7 @@ classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="58"
+    ```sds linenums="72"
     @Pure
     @PythonName("f1_score")
     fun f1Score(
@@ -256,7 +256,7 @@ better the classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="78"
+    ```sds linenums="92"
     @Pure
     fun precision(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>,
@@ -315,7 +315,7 @@ better the classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="97"
+    ```sds linenums="111"
     @Pure
     fun recall(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>,
@@ -344,7 +344,7 @@ Summarize the classifier's metrics on the given data.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="21"
+    ```sds linenums="35"
     @Pure
     @PythonName("summarize_metrics")
     fun summarizeMetrics(

--- a/docs/api/safeds/ml/classical/classification/LogisticClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/LogisticClassifier.md
@@ -64,7 +64,7 @@ better. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="40"
+    ```sds linenums="54"
     @Pure
     fun accuracy(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
@@ -95,7 +95,7 @@ classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="58"
+    ```sds linenums="72"
     @Pure
     @PythonName("f1_score")
     fun f1Score(
@@ -235,7 +235,7 @@ better the classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="78"
+    ```sds linenums="92"
     @Pure
     fun precision(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>,
@@ -294,7 +294,7 @@ better the classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="97"
+    ```sds linenums="111"
     @Pure
     fun recall(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>,
@@ -323,7 +323,7 @@ Summarize the classifier's metrics on the given data.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="21"
+    ```sds linenums="35"
     @Pure
     @PythonName("summarize_metrics")
     fun summarizeMetrics(

--- a/docs/api/safeds/ml/classical/classification/RandomForestClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/RandomForestClassifier.md
@@ -110,7 +110,7 @@ better. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="40"
+    ```sds linenums="54"
     @Pure
     fun accuracy(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
@@ -141,7 +141,7 @@ classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="58"
+    ```sds linenums="72"
     @Pure
     @PythonName("f1_score")
     fun f1Score(
@@ -281,7 +281,7 @@ better the classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="78"
+    ```sds linenums="92"
     @Pure
     fun precision(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>,
@@ -340,7 +340,7 @@ better the classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="97"
+    ```sds linenums="111"
     @Pure
     fun recall(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>,
@@ -369,7 +369,7 @@ Summarize the classifier's metrics on the given data.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="21"
+    ```sds linenums="35"
     @Pure
     @PythonName("summarize_metrics")
     fun summarizeMetrics(

--- a/docs/api/safeds/ml/classical/classification/SupportVectorClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/SupportVectorClassifier.md
@@ -132,7 +132,7 @@ better. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="40"
+    ```sds linenums="54"
     @Pure
     fun accuracy(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
@@ -163,7 +163,7 @@ classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="58"
+    ```sds linenums="72"
     @Pure
     @PythonName("f1_score")
     fun f1Score(
@@ -303,7 +303,7 @@ better the classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="78"
+    ```sds linenums="92"
     @Pure
     fun precision(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>,
@@ -362,7 +362,7 @@ better the classifier. Results range from 0.0 to 1.0.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="97"
+    ```sds linenums="111"
     @Pure
     fun recall(
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>,
@@ -391,7 +391,7 @@ Summarize the classifier's metrics on the given data.
 
 ??? quote "Stub code in `Classifier.sdsstub`"
 
-    ```sds linenums="21"
+    ```sds linenums="35"
     @Pure
     @PythonName("summarize_metrics")
     fun summarizeMetrics(

--- a/docs/api/safeds/ml/classical/regression/AdaBoostRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/AdaBoostRegressor.md
@@ -120,7 +120,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="46"
+    ```sds linenums="60"
     @Pure
     @PythonName("coefficient_of_determination")
     fun coefficientOfDetermination(
@@ -257,7 +257,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="63"
+    ```sds linenums="77"
     @Pure
     @PythonName("mean_absolute_error")
     fun meanAbsoluteError(
@@ -291,7 +291,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="84"
+    ```sds linenums="98"
     @Pure
     @PythonName("mean_directional_accuracy")
     fun meanDirectionalAccuracy(
@@ -323,7 +323,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="103"
+    ```sds linenums="117"
     @Pure
     @PythonName("mean_squared_error")
     fun meanSquaredError(
@@ -353,7 +353,7 @@ positive infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="120"
+    ```sds linenums="134"
     @Pure
     @PythonName("median_absolute_deviation")
     fun medianAbsoluteDeviation(
@@ -406,7 +406,7 @@ Summarize the regressor's metrics on the given data.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="18"
+    ```sds linenums="32"
     @Pure
     @PythonName("summarize_metrics")
     fun summarizeMetrics(

--- a/docs/api/safeds/ml/classical/regression/DecisionTreeRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/DecisionTreeRegressor.md
@@ -107,7 +107,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="46"
+    ```sds linenums="60"
     @Pure
     @PythonName("coefficient_of_determination")
     fun coefficientOfDetermination(
@@ -244,7 +244,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="63"
+    ```sds linenums="77"
     @Pure
     @PythonName("mean_absolute_error")
     fun meanAbsoluteError(
@@ -278,7 +278,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="84"
+    ```sds linenums="98"
     @Pure
     @PythonName("mean_directional_accuracy")
     fun meanDirectionalAccuracy(
@@ -310,7 +310,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="103"
+    ```sds linenums="117"
     @Pure
     @PythonName("mean_squared_error")
     fun meanSquaredError(
@@ -340,7 +340,7 @@ positive infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="120"
+    ```sds linenums="134"
     @Pure
     @PythonName("median_absolute_deviation")
     fun medianAbsoluteDeviation(
@@ -393,7 +393,7 @@ Summarize the regressor's metrics on the given data.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="18"
+    ```sds linenums="32"
     @Pure
     @PythonName("summarize_metrics")
     fun summarizeMetrics(

--- a/docs/api/safeds/ml/classical/regression/ElasticNetRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/ElasticNetRegressor.md
@@ -109,7 +109,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="46"
+    ```sds linenums="60"
     @Pure
     @PythonName("coefficient_of_determination")
     fun coefficientOfDetermination(
@@ -246,7 +246,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="63"
+    ```sds linenums="77"
     @Pure
     @PythonName("mean_absolute_error")
     fun meanAbsoluteError(
@@ -280,7 +280,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="84"
+    ```sds linenums="98"
     @Pure
     @PythonName("mean_directional_accuracy")
     fun meanDirectionalAccuracy(
@@ -312,7 +312,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="103"
+    ```sds linenums="117"
     @Pure
     @PythonName("mean_squared_error")
     fun meanSquaredError(
@@ -342,7 +342,7 @@ positive infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="120"
+    ```sds linenums="134"
     @Pure
     @PythonName("median_absolute_deviation")
     fun medianAbsoluteDeviation(
@@ -395,7 +395,7 @@ Summarize the regressor's metrics on the given data.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="18"
+    ```sds linenums="32"
     @Pure
     @PythonName("summarize_metrics")
     fun summarizeMetrics(

--- a/docs/api/safeds/ml/classical/regression/GradientBoostingRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/GradientBoostingRegressor.md
@@ -108,7 +108,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="46"
+    ```sds linenums="60"
     @Pure
     @PythonName("coefficient_of_determination")
     fun coefficientOfDetermination(
@@ -245,7 +245,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="63"
+    ```sds linenums="77"
     @Pure
     @PythonName("mean_absolute_error")
     fun meanAbsoluteError(
@@ -279,7 +279,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="84"
+    ```sds linenums="98"
     @Pure
     @PythonName("mean_directional_accuracy")
     fun meanDirectionalAccuracy(
@@ -311,7 +311,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="103"
+    ```sds linenums="117"
     @Pure
     @PythonName("mean_squared_error")
     fun meanSquaredError(
@@ -341,7 +341,7 @@ positive infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="120"
+    ```sds linenums="134"
     @Pure
     @PythonName("median_absolute_deviation")
     fun medianAbsoluteDeviation(
@@ -394,7 +394,7 @@ Summarize the regressor's metrics on the given data.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="18"
+    ```sds linenums="32"
     @Pure
     @PythonName("summarize_metrics")
     fun summarizeMetrics(

--- a/docs/api/safeds/ml/classical/regression/KNearestNeighborsRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/KNearestNeighborsRegressor.md
@@ -95,7 +95,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="46"
+    ```sds linenums="60"
     @Pure
     @PythonName("coefficient_of_determination")
     fun coefficientOfDetermination(
@@ -232,7 +232,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="63"
+    ```sds linenums="77"
     @Pure
     @PythonName("mean_absolute_error")
     fun meanAbsoluteError(
@@ -266,7 +266,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="84"
+    ```sds linenums="98"
     @Pure
     @PythonName("mean_directional_accuracy")
     fun meanDirectionalAccuracy(
@@ -298,7 +298,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="103"
+    ```sds linenums="117"
     @Pure
     @PythonName("mean_squared_error")
     fun meanSquaredError(
@@ -328,7 +328,7 @@ positive infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="120"
+    ```sds linenums="134"
     @Pure
     @PythonName("median_absolute_deviation")
     fun medianAbsoluteDeviation(
@@ -381,7 +381,7 @@ Summarize the regressor's metrics on the given data.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="18"
+    ```sds linenums="32"
     @Pure
     @PythonName("summarize_metrics")
     fun summarizeMetrics(

--- a/docs/api/safeds/ml/classical/regression/LassoRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/LassoRegressor.md
@@ -95,7 +95,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="46"
+    ```sds linenums="60"
     @Pure
     @PythonName("coefficient_of_determination")
     fun coefficientOfDetermination(
@@ -232,7 +232,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="63"
+    ```sds linenums="77"
     @Pure
     @PythonName("mean_absolute_error")
     fun meanAbsoluteError(
@@ -266,7 +266,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="84"
+    ```sds linenums="98"
     @Pure
     @PythonName("mean_directional_accuracy")
     fun meanDirectionalAccuracy(
@@ -298,7 +298,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="103"
+    ```sds linenums="117"
     @Pure
     @PythonName("mean_squared_error")
     fun meanSquaredError(
@@ -328,7 +328,7 @@ positive infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="120"
+    ```sds linenums="134"
     @Pure
     @PythonName("median_absolute_deviation")
     fun medianAbsoluteDeviation(
@@ -381,7 +381,7 @@ Summarize the regressor's metrics on the given data.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="18"
+    ```sds linenums="32"
     @Pure
     @PythonName("summarize_metrics")
     fun summarizeMetrics(

--- a/docs/api/safeds/ml/classical/regression/LinearRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/LinearRegressor.md
@@ -74,7 +74,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="46"
+    ```sds linenums="60"
     @Pure
     @PythonName("coefficient_of_determination")
     fun coefficientOfDetermination(
@@ -211,7 +211,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="63"
+    ```sds linenums="77"
     @Pure
     @PythonName("mean_absolute_error")
     fun meanAbsoluteError(
@@ -245,7 +245,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="84"
+    ```sds linenums="98"
     @Pure
     @PythonName("mean_directional_accuracy")
     fun meanDirectionalAccuracy(
@@ -277,7 +277,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="103"
+    ```sds linenums="117"
     @Pure
     @PythonName("mean_squared_error")
     fun meanSquaredError(
@@ -307,7 +307,7 @@ positive infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="120"
+    ```sds linenums="134"
     @Pure
     @PythonName("median_absolute_deviation")
     fun medianAbsoluteDeviation(
@@ -360,7 +360,7 @@ Summarize the regressor's metrics on the given data.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="18"
+    ```sds linenums="32"
     @Pure
     @PythonName("summarize_metrics")
     fun summarizeMetrics(

--- a/docs/api/safeds/ml/classical/regression/RandomForestRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/RandomForestRegressor.md
@@ -120,7 +120,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="46"
+    ```sds linenums="60"
     @Pure
     @PythonName("coefficient_of_determination")
     fun coefficientOfDetermination(
@@ -257,7 +257,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="63"
+    ```sds linenums="77"
     @Pure
     @PythonName("mean_absolute_error")
     fun meanAbsoluteError(
@@ -291,7 +291,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="84"
+    ```sds linenums="98"
     @Pure
     @PythonName("mean_directional_accuracy")
     fun meanDirectionalAccuracy(
@@ -323,7 +323,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="103"
+    ```sds linenums="117"
     @Pure
     @PythonName("mean_squared_error")
     fun meanSquaredError(
@@ -353,7 +353,7 @@ positive infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="120"
+    ```sds linenums="134"
     @Pure
     @PythonName("median_absolute_deviation")
     fun medianAbsoluteDeviation(
@@ -406,7 +406,7 @@ Summarize the regressor's metrics on the given data.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="18"
+    ```sds linenums="32"
     @Pure
     @PythonName("summarize_metrics")
     fun summarizeMetrics(

--- a/docs/api/safeds/ml/classical/regression/Regressor.md
+++ b/docs/api/safeds/ml/classical/regression/Regressor.md
@@ -17,17 +17,29 @@ A model for regression tasks.
 - [`GradientBoostingRegressor`][safeds.ml.classical.regression.GradientBoostingRegressor]
 - [`KNearestNeighborsRegressor`][safeds.ml.classical.regression.KNearestNeighborsRegressor]
 - [`LassoRegressor`][safeds.ml.classical.regression.LassoRegressor]
-- `#!sds LinearRegressionRegressor`
 - [`LinearRegressor`][safeds.ml.classical.regression.LinearRegressor]
 - [`RandomForestRegressor`][safeds.ml.classical.regression.RandomForestRegressor]
 - [`RidgeRegressor`][safeds.ml.classical.regression.RidgeRegressor]
-- `#!sds SupportVectorMachineRegressor`
 - [`SupportVectorRegressor`][safeds.ml.classical.regression.SupportVectorRegressor]
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
     ```sds linenums="10"
     class Regressor sub SupervisedModel {
+        /**
+         * Create a copy of this model and fit it with the given training data.
+         *
+         * **Note:** This model is not modified.
+         *
+         * @param trainingSet The training data containing the features and target.
+         *
+         * @result fittedModel The fitted model.
+         */
+        @Pure
+        fun fit(
+            @PythonName("training_set") trainingSet: TabularDataset
+        ) -> fittedModel: Regressor
+
         /**
          * Summarize the regressor's metrics on the given data.
          *
@@ -184,7 +196,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="46"
+    ```sds linenums="60"
     @Pure
     @PythonName("coefficient_of_determination")
     fun coefficientOfDetermination(
@@ -208,15 +220,15 @@ Create a copy of this model and fit it with the given training data.
 
 | Name | Type | Description |
 |------|------|-------------|
-| `fittedModel` | [`SupervisedModel`][safeds.ml.classical.SupervisedModel] | The fitted model. |
+| `fittedModel` | [`Regressor`][safeds.ml.classical.regression.Regressor] | The fitted model. |
 
-??? quote "Stub code in `SupervisedModel.sdsstub`"
+??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="26"
+    ```sds linenums="20"
     @Pure
     fun fit(
         @PythonName("training_set") trainingSet: TabularDataset
-    ) -> fittedModel: SupervisedModel
+    ) -> fittedModel: Regressor
     ```
 
 ## `#!sds fun` getFeatureNames {#safeds.ml.classical.regression.Regressor.getFeatureNames data-toc-label='getFeatureNames'}
@@ -321,7 +333,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="63"
+    ```sds linenums="77"
     @Pure
     @PythonName("mean_absolute_error")
     fun meanAbsoluteError(
@@ -355,7 +367,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="84"
+    ```sds linenums="98"
     @Pure
     @PythonName("mean_directional_accuracy")
     fun meanDirectionalAccuracy(
@@ -387,7 +399,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="103"
+    ```sds linenums="117"
     @Pure
     @PythonName("mean_squared_error")
     fun meanSquaredError(
@@ -417,7 +429,7 @@ positive infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="120"
+    ```sds linenums="134"
     @Pure
     @PythonName("median_absolute_deviation")
     fun medianAbsoluteDeviation(
@@ -470,7 +482,7 @@ Summarize the regressor's metrics on the given data.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="18"
+    ```sds linenums="32"
     @Pure
     @PythonName("summarize_metrics")
     fun summarizeMetrics(

--- a/docs/api/safeds/ml/classical/regression/RidgeRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/RidgeRegressor.md
@@ -95,7 +95,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="46"
+    ```sds linenums="60"
     @Pure
     @PythonName("coefficient_of_determination")
     fun coefficientOfDetermination(
@@ -232,7 +232,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="63"
+    ```sds linenums="77"
     @Pure
     @PythonName("mean_absolute_error")
     fun meanAbsoluteError(
@@ -266,7 +266,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="84"
+    ```sds linenums="98"
     @Pure
     @PythonName("mean_directional_accuracy")
     fun meanDirectionalAccuracy(
@@ -298,7 +298,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="103"
+    ```sds linenums="117"
     @Pure
     @PythonName("mean_squared_error")
     fun meanSquaredError(
@@ -328,7 +328,7 @@ positive infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="120"
+    ```sds linenums="134"
     @Pure
     @PythonName("median_absolute_deviation")
     fun medianAbsoluteDeviation(
@@ -381,7 +381,7 @@ Summarize the regressor's metrics on the given data.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="18"
+    ```sds linenums="32"
     @Pure
     @PythonName("summarize_metrics")
     fun summarizeMetrics(

--- a/docs/api/safeds/ml/classical/regression/SupportVectorRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/SupportVectorRegressor.md
@@ -142,7 +142,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="46"
+    ```sds linenums="60"
     @Pure
     @PythonName("coefficient_of_determination")
     fun coefficientOfDetermination(
@@ -279,7 +279,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="63"
+    ```sds linenums="77"
     @Pure
     @PythonName("mean_absolute_error")
     fun meanAbsoluteError(
@@ -313,7 +313,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="84"
+    ```sds linenums="98"
     @Pure
     @PythonName("mean_directional_accuracy")
     fun meanDirectionalAccuracy(
@@ -345,7 +345,7 @@ infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="103"
+    ```sds linenums="117"
     @Pure
     @PythonName("mean_squared_error")
     fun meanSquaredError(
@@ -375,7 +375,7 @@ positive infinity.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="120"
+    ```sds linenums="134"
     @Pure
     @PythonName("median_absolute_deviation")
     fun medianAbsoluteDeviation(
@@ -428,7 +428,7 @@ Summarize the regressor's metrics on the given data.
 
 ??? quote "Stub code in `Regressor.sdsstub`"
 
-    ```sds linenums="18"
+    ```sds linenums="32"
     @Pure
     @PythonName("summarize_metrics")
     fun summarizeMetrics(

--- a/docs/api/safeds/ml/nn/NeuralNetworkClassifier.md
+++ b/docs/api/safeds/ml/nn/NeuralNetworkClassifier.md
@@ -6,9 +6,9 @@ A NeuralNetworkClassifier is a neural network that is used for classification ta
 
 | Name | Type | Description | Default |
 |------|------|-------------|---------|
-| `inputConversion` | `#!sds InputConversion<FitIn, PredictIn>` | to convert the input data for the neural network | - |
+| `inputConversion` | [`InputConversion<FitIn, PredictIn>`][safeds.ml.nn.converters.InputConversion] | to convert the input data for the neural network | - |
 | `layers` | [`List<Layer>`][safeds.lang.List] | a list of layers for the neural network to learn | - |
-| `outputConversion` | `#!sds OutputConversion<PredictIn, PredictOut>` | to convert the output data of the neural network back | - |
+| `outputConversion` | [`OutputConversion<PredictIn, PredictOut>`][safeds.ml.nn.converters.OutputConversion] | to convert the output data of the neural network back | - |
 
 **Type parameters:**
 

--- a/docs/api/safeds/ml/nn/NeuralNetworkRegressor.md
+++ b/docs/api/safeds/ml/nn/NeuralNetworkRegressor.md
@@ -6,9 +6,9 @@ A NeuralNetworkRegressor is a neural network that is used for regression tasks.
 
 | Name | Type | Description | Default |
 |------|------|-------------|---------|
-| `inputConversion` | `#!sds InputConversion<FitIn, PredictIn>` | to convert the input data for the neural network | - |
+| `inputConversion` | [`InputConversion<FitIn, PredictIn>`][safeds.ml.nn.converters.InputConversion] | to convert the input data for the neural network | - |
 | `layers` | [`List<Layer>`][safeds.lang.List] | a list of layers for the neural network to learn | - |
-| `outputConversion` | `#!sds OutputConversion<PredictIn, PredictOut>` | to convert the output data of the neural network back | - |
+| `outputConversion` | [`OutputConversion<PredictIn, PredictOut>`][safeds.ml.nn.converters.OutputConversion] | to convert the output data of the neural network back | - |
 
 **Type parameters:**
 

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/classification/Classifier.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/classification/Classifier.sdsstub
@@ -9,6 +9,20 @@ from safeds.ml.classical import SupervisedModel
  */
 class Classifier sub SupervisedModel {
     /**
+     * Create a copy of this model and fit it with the given training data.
+     *
+     * **Note:** This model is not modified.
+     *
+     * @param trainingSet The training data containing the features and target.
+     *
+     * @result fittedModel The fitted model.
+     */
+    @Pure
+    fun fit(
+        @PythonName("training_set") trainingSet: TabularDataset
+    ) -> fittedModel: Classifier
+
+    /**
      * Summarize the classifier's metrics on the given data.
      *
      * **Note:** The model must be fitted.

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/Regressor.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/ml/classical/regression/Regressor.sdsstub
@@ -9,6 +9,20 @@ from safeds.ml.classical import SupervisedModel
  */
 class Regressor sub SupervisedModel {
     /**
+     * Create a copy of this model and fit it with the given training data.
+     *
+     * **Note:** This model is not modified.
+     *
+     * @param trainingSet The training data containing the features and target.
+     *
+     * @result fittedModel The fitted model.
+     */
+    @Pure
+    fun fit(
+        @PythonName("training_set") trainingSet: TabularDataset
+    ) -> fittedModel: Regressor
+
+    /**
      * Summarize the regressor's metrics on the given data.
      *
      * @param validationOrTestSet The validation or test set.


### PR DESCRIPTION
### Summary of Changes

Override `fit` in `Classifier` and `Regressor`, so metrics can be used on the fitted models.
