### PR TITLE
feat: show "print" code lens for some nullable types

### DIFF
--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
@@ -372,7 +372,6 @@ export class SafeDsTypeChecker {
     canBePrinted = (type: Type): boolean => {
         return (
             !type.equals(this.coreTypes.Nothing) &&
-            !type.equals(this.coreTypes.NothingOrNull) &&
             [
                 this.coreTypes.Boolean,
                 this.coreTypes.Float,
@@ -380,7 +379,7 @@ export class SafeDsTypeChecker {
                 this.coreTypes.List(UnknownType),
                 this.coreTypes.Map(UnknownType, UnknownType),
                 this.coreTypes.String,
-            ].some((it) => this.isSubtypeOf(type, it, { ignoreTypeParameters: true }))
+            ].some((it) => this.isSubtypeOf(type.withExplicitNullability(false), it, { ignoreTypeParameters: true }))
         );
     };
 

--- a/packages/safe-ds-lang/tests/language/lsp/safe-ds-code-lens-provider.test.ts
+++ b/packages/safe-ds-lang/tests/language/lsp/safe-ds-code-lens-provider.test.ts
@@ -26,7 +26,7 @@ describe('SafeDsCodeLensProvider', () => {
                 code: `pipeline myPipeline {
                     val a = null;
                 }`,
-                expectedCodeLensTitles: ['Run myPipeline'],
+                expectedCodeLensTitles: ['Run myPipeline', 'Print a'],
             },
             {
                 testName: 'pipeline with Image placeholder',


### PR DESCRIPTION
### Summary of Changes

The "print" code lens now also appears for selected nullable types like `Int?`.
