### PR TITLE
feat: show default values of parameters in signature help

### DIFF
--- a/packages/safe-ds-lang/tests/language/lsp/safe-ds-signature-help-provider.test.ts
+++ b/packages/safe-ds-lang/tests/language/lsp/safe-ds-signature-help-provider.test.ts
@@ -90,7 +90,7 @@ describe('SafeDsSignatureHelpProvider', async () => {
             `,
             expectedSignature: [
                 {
-                    label: 'A(p: Int) -> ()',
+                    label: 'A(p: Int)',
                     documentation: {
                         kind: 'markdown',
                         value: 'Lorem ipsum.',
@@ -144,7 +144,7 @@ describe('SafeDsSignatureHelpProvider', async () => {
             `,
             expectedSignature: [
                 {
-                    label: 'f(p: Int) -> ()',
+                    label: 'f(p: Int)',
                     documentation: {
                         kind: 'markdown',
                         value: 'Lorem ipsum.',
@@ -166,7 +166,7 @@ describe('SafeDsSignatureHelpProvider', async () => {
             `,
             expectedSignature: [
                 {
-                    label: '(p: Int) -> ()',
+                    label: 'λ(p: Int)',
                     documentation: undefined,
                     parameters: [
                         {
@@ -188,11 +188,11 @@ describe('SafeDsSignatureHelpProvider', async () => {
             `,
             expectedSignature: [
                 {
-                    label: 'f(p?: Int) -> ()',
+                    label: 'f(p: Int = 0)',
                     documentation: undefined,
                     parameters: [
                         {
-                            label: 'p?: Int',
+                            label: 'p: Int = 0',
                         },
                     ],
                 },


### PR DESCRIPTION
Closes #1147

### Summary of Changes

Show default values of parameters in the signature help. Previously, it only showed whether a parameter was optional or not.