### PR TITLE
fix: use correct link syntax in stubs

### DIFF
--- a/docs/api/safeds/data/image/containers/Image.md
+++ b/docs/api/safeds/data/image/containers/Image.md
@@ -135,7 +135,7 @@ pipeline example {
          * Return a new `Image` that is converted to grayscale.
          *
          * The new image will have the same amount of channels as the original image. If you want to change the amount of
-         * channels used, please use the method [changeChannel][safeds.data.image.containers.Image.changeChannel].
+         * channels used, please use the method {@link Image.changeChannel}.
          *
          * The original image is not modified.
          *
@@ -696,7 +696,7 @@ pipeline example {
 Return a new `Image` that is converted to grayscale.
 
 The new image will have the same amount of channels as the original image. If you want to change the amount of
-channels used, please use the method [changeChannel][safeds.data.image.containers.Image.changeChannel].
+channels used, please use the method [Image.changeChannel][safeds.data.image.containers.Image.changeChannel].
 
 The original image is not modified.
 

--- a/docs/api/safeds/data/image/containers/ImageList.md
+++ b/docs/api/safeds/data/image/containers/ImageList.md
@@ -301,7 +301,7 @@ To create an `ImageList` call one of the following static methods:
          * Return a new `ImageList` with all images converted to grayscale.
          *
          * The new image will have the same amount of channels as the original image. If you want to change the amount of
-         * channels used, please use the method [changeChannel][safeds.data.image.containers.ImageList.changeChannel].
+         * channels used, please use the method {@link ImageList.changeChannel}.
          *
          * The original image list is not modified.
          *
@@ -792,7 +792,7 @@ The original image list is not modified.
 Return a new `ImageList` with all images converted to grayscale.
 
 The new image will have the same amount of channels as the original image. If you want to change the amount of
-channels used, please use the method [changeChannel][safeds.data.image.containers.ImageList.changeChannel].
+channels used, please use the method [ImageList.changeChannel][safeds.data.image.containers.ImageList.changeChannel].
 
 The original image list is not modified.
 

--- a/docs/api/safeds/data/tabular/containers/Table.md
+++ b/docs/api/safeds/data/tabular/containers/Table.md
@@ -6,13 +6,13 @@ A two-dimensional collection of data. It can either be seen as a list of rows or
 
 To create a `Table` call the constructor or use one of the following static methods:
 
-| Method                                                                  | Description                            |
-| ----------------------------------------------------------------------- | -------------------------------------- |
-| [fromCsvFile][safeds.data.tabular.containers.Table.fromCsvFile]         | Create a table from a CSV file.        |
-| [fromJsonFile][safeds.data.tabular.containers.Table.fromJsonFile]       | Create a table from a JSON file.       |
-| [fromParquetFile][safeds.data.tabular.containers.Table.fromParquetFile] | Create a table from a Parquet file.    |
-| [fromColumns][safeds.data.tabular.containers.Table.fromColumns]         | Create a table from a list of columns. |
-| [fromMap][safeds.data.tabular.containers.Table.fromMap]                 | Create a table from a map.      |
+| Method                        | Description                            |
+| ----------------------------- | -------------------------------------- |
+| [Table.fromCsvFile][safeds.data.tabular.containers.Table.fromCsvFile]     | Create a table from a CSV file.        |
+| [Table.fromJsonFile][safeds.data.tabular.containers.Table.fromJsonFile]    | Create a table from a JSON file.       |
+| [Table.fromParquetFile][safeds.data.tabular.containers.Table.fromParquetFile] | Create a table from a Parquet file.    |
+| [Table.fromColumns][safeds.data.tabular.containers.Table.fromColumns]     | Create a table from a list of columns. |
+| [Table.fromMap][safeds.data.tabular.containers.Table.fromMap]         | Create a table from a map.             |
 
 **Parameters:**
 

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/data/image/containers/Image.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/data/image/containers/Image.sdsstub
@@ -131,7 +131,7 @@ class Image {
      * Return a new `Image` that is converted to grayscale.
      *
      * The new image will have the same amount of channels as the original image. If you want to change the amount of
-     * channels used, please use the method [changeChannel][safeds.data.image.containers.Image.changeChannel].
+     * channels used, please use the method {@link Image.changeChannel}.
      *
      * The original image is not modified.
      *

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/data/image/containers/ImageList.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/data/image/containers/ImageList.sdsstub
@@ -301,7 +301,7 @@ class ImageList {
      * Return a new `ImageList` with all images converted to grayscale.
      *
      * The new image will have the same amount of channels as the original image. If you want to change the amount of
-     * channels used, please use the method [changeChannel][safeds.data.image.containers.ImageList.changeChannel].
+     * channels used, please use the method {@link ImageList.changeChannel}.
      *
      * The original image list is not modified.
      *

--- a/packages/safe-ds-lang/src/resources/builtins/safeds/data/tabular/containers/Table.sdsstub
+++ b/packages/safe-ds-lang/src/resources/builtins/safeds/data/tabular/containers/Table.sdsstub
@@ -14,13 +14,13 @@ from safeds.data.tabular.typing import Schema
  *
  * To create a `Table` call the constructor or use one of the following static methods:
  *
- * | Method                                                                  | Description                            |
- * | ----------------------------------------------------------------------- | -------------------------------------- |
- * | [fromCsvFile][safeds.data.tabular.containers.Table.fromCsvFile]         | Create a table from a CSV file.        |
- * | [fromJsonFile][safeds.data.tabular.containers.Table.fromJsonFile]       | Create a table from a JSON file.       |
- * | [fromParquetFile][safeds.data.tabular.containers.Table.fromParquetFile] | Create a table from a Parquet file.    |
- * | [fromColumns][safeds.data.tabular.containers.Table.fromColumns]         | Create a table from a list of columns. |
- * | [fromMap][safeds.data.tabular.containers.Table.fromMap]                 | Create a table from a map.      |
+ * | Method                        | Description                            |
+ * | ----------------------------- | -------------------------------------- |
+ * | {@link Table.fromCsvFile}     | Create a table from a CSV file.        |
+ * | {@link Table.fromJsonFile}    | Create a table from a JSON file.       |
+ * | {@link Table.fromParquetFile} | Create a table from a Parquet file.    |
+ * | {@link Table.fromColumns}     | Create a table from a list of columns. |
+ * | {@link Table.fromMap}         | Create a table from a map.             |
  *
  * @param data The data of the table. If null, an empty table is created.
  *


### PR DESCRIPTION
### Summary of Changes

Use correct syntax for links to other API elements in stubs. Previously, they did not work properly in tooltips.
