### PR TITLE
docs: exclude stub/implementation code blocks from search

### DIFF
--- a/docs/api/safeds/data/image/containers/Image.md
+++ b/docs/api/safeds/data/image/containers/Image.md
@@ -435,6 +435,7 @@ pipeline example {
         fun findEdges() -> newImage: Image
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `channel` {#safeds.data.image.containers.Image.channel data-toc-label='[attribute] channel'}
 
@@ -498,6 +499,7 @@ pipeline example {
         standardDeviation >= 0.0
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `adjustBrightness` {#safeds.data.image.containers.Image.adjustBrightness data-toc-label='[function] adjustBrightness'}
 
@@ -537,6 +539,7 @@ pipeline example {
         factor >= 0.0
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `adjustColorBalance` {#safeds.data.image.containers.Image.adjustColorBalance data-toc-label='[function] adjustColorBalance'}
 
@@ -576,6 +579,7 @@ pipeline example {
         factor >= 0.0
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `adjustContrast` {#safeds.data.image.containers.Image.adjustContrast data-toc-label='[function] adjustContrast'}
 
@@ -615,6 +619,7 @@ pipeline example {
         factor >= 0.0
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `blur` {#safeds.data.image.containers.Image.blur data-toc-label='[function] blur'}
 
@@ -653,6 +658,7 @@ pipeline example {
         radius >= 0
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `changeChannel` {#safeds.data.image.containers.Image.changeChannel data-toc-label='[function] changeChannel'}
 
@@ -690,6 +696,7 @@ pipeline example {
         channel: Int
     ) -> newImage: Image
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `convertToGrayscale` {#safeds.data.image.containers.Image.convertToGrayscale data-toc-label='[function] convertToGrayscale'}
 
@@ -722,6 +729,7 @@ pipeline example {
     @PythonName("convert_to_grayscale")
     fun convertToGrayscale() -> newImage: Image
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `crop` {#safeds.data.image.containers.Image.crop data-toc-label='[function] crop'}
 
@@ -769,6 +777,7 @@ pipeline example {
         height >= 0
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `findEdges` {#safeds.data.image.containers.Image.findEdges data-toc-label='[function] findEdges'}
 
@@ -798,6 +807,7 @@ pipeline example {
     @PythonName("find_edges")
     fun findEdges() -> newImage: Image
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `flipHorizontally` {#safeds.data.image.containers.Image.flipHorizontally data-toc-label='[function] flipHorizontally'}
 
@@ -827,6 +837,7 @@ pipeline example {
     @PythonName("flip_horizontally")
     fun flipHorizontally() -> newImage: Image
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `flipVertically` {#safeds.data.image.containers.Image.flipVertically data-toc-label='[function] flipVertically'}
 
@@ -856,6 +867,7 @@ pipeline example {
     @PythonName("flip_vertically")
     fun flipVertically() -> newImage: Image
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `invertColors` {#safeds.data.image.containers.Image.invertColors data-toc-label='[function] invertColors'}
 
@@ -885,6 +897,7 @@ pipeline example {
     @PythonName("invert_colors")
     fun invertColors() -> newImage: Image
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `resize` {#safeds.data.image.containers.Image.resize data-toc-label='[function] resize'}
 
@@ -926,6 +939,7 @@ pipeline example {
         newHeight >= 0
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `rotateLeft` {#safeds.data.image.containers.Image.rotateLeft data-toc-label='[function] rotateLeft'}
 
@@ -955,6 +969,7 @@ pipeline example {
     @PythonName("rotate_left")
     fun rotateLeft() -> newImage: Image
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `rotateRight` {#safeds.data.image.containers.Image.rotateRight data-toc-label='[function] rotateRight'}
 
@@ -984,6 +999,7 @@ pipeline example {
     @PythonName("rotate_right")
     fun rotateRight() -> newImage: Image
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `sharpen` {#safeds.data.image.containers.Image.sharpen data-toc-label='[function] sharpen'}
 
@@ -1022,6 +1038,7 @@ pipeline example {
         factor >= 0.0
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toJpegFile` {#safeds.data.image.containers.Image.toJpegFile data-toc-label='[function] toJpegFile'}
 
@@ -1051,6 +1068,7 @@ pipeline example {
         path: String
     )
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toPngFile` {#safeds.data.image.containers.Image.toPngFile data-toc-label='[function] toPngFile'}
 
@@ -1080,6 +1098,7 @@ pipeline example {
         path: String
     )
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `fromFile` {#safeds.data.image.containers.Image.fromFile data-toc-label='[static-function] fromFile'}
 
@@ -1114,3 +1133,4 @@ pipeline example {
         path: String
     ) -> image: Image
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/image/containers/ImageList.md
+++ b/docs/api/safeds/data/image/containers/ImageList.md
@@ -517,6 +517,7 @@ To create an `ImageList` call one of the following static methods:
         fun findEdges() -> imageList: ImageList
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `channel` {#safeds.data.image.containers.ImageList.channel data-toc-label='[attribute] channel'}
 
@@ -581,6 +582,7 @@ The original image list is not modified.
         image: Image
     ) -> imageList: ImageList
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `addImages` {#safeds.data.image.containers.ImageList.addImages data-toc-label='[function] addImages'}
 
@@ -609,6 +611,7 @@ The original image list is not modified.
         images: union<ImageList, List<Image>>
     ) -> imageList: ImageList
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `addNoise` {#safeds.data.image.containers.ImageList.addNoise data-toc-label='[function] addNoise'}
 
@@ -639,6 +642,7 @@ The original image list is not modified.
         standardDeviation >= 0.0
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `adjustBrightness` {#safeds.data.image.containers.ImageList.adjustBrightness data-toc-label='[function] adjustBrightness'}
 
@@ -669,6 +673,7 @@ The original image list is not modified.
         factor >= 0.0
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `adjustColorBalance` {#safeds.data.image.containers.ImageList.adjustColorBalance data-toc-label='[function] adjustColorBalance'}
 
@@ -699,6 +704,7 @@ The original image list is not modified.
         factor >= 0.0
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `adjustContrast` {#safeds.data.image.containers.ImageList.adjustContrast data-toc-label='[function] adjustContrast'}
 
@@ -729,6 +735,7 @@ The original image list is not modified.
         factor >= 0.0
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `blur` {#safeds.data.image.containers.ImageList.blur data-toc-label='[function] blur'}
 
@@ -758,6 +765,7 @@ The original image list is not modified.
         radius >= 0
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `changeChannel` {#safeds.data.image.containers.ImageList.changeChannel data-toc-label='[function] changeChannel'}
 
@@ -786,6 +794,7 @@ The original image list is not modified.
         channel: Int
     ) -> imageList: ImageList
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `convertToGrayscale` {#safeds.data.image.containers.ImageList.convertToGrayscale data-toc-label='[function] convertToGrayscale'}
 
@@ -809,6 +818,7 @@ The original image list is not modified.
     @PythonName("convert_to_grayscale")
     fun convertToGrayscale() -> imageList: ImageList
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `crop` {#safeds.data.image.containers.ImageList.crop data-toc-label='[function] crop'}
 
@@ -847,6 +857,7 @@ The original image list is not modified.
         height >= 0
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `findEdges` {#safeds.data.image.containers.ImageList.findEdges data-toc-label='[function] findEdges'}
 
@@ -867,6 +878,7 @@ The original image list is not modified.
     @PythonName("find_edges")
     fun findEdges() -> imageList: ImageList
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `flipHorizontally` {#safeds.data.image.containers.ImageList.flipHorizontally data-toc-label='[function] flipHorizontally'}
 
@@ -887,6 +899,7 @@ The original image list is not modified.
     @PythonName("flip_horizontally")
     fun flipHorizontally() -> imageList: ImageList
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `flipVertically` {#safeds.data.image.containers.ImageList.flipVertically data-toc-label='[function] flipVertically'}
 
@@ -907,6 +920,7 @@ The original image list is not modified.
     @PythonName("flip_vertically")
     fun flipVertically() -> imageList: ImageList
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getImage` {#safeds.data.image.containers.ImageList.getImage data-toc-label='[function] getImage'}
 
@@ -933,6 +947,7 @@ Return the image at the given index.
         index: Int
     ) -> image: Image
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `hasImage` {#safeds.data.image.containers.ImageList.hasImage data-toc-label='[function] hasImage'}
 
@@ -959,6 +974,7 @@ Return whether the given image is in this image list.
         image: Image
     ) -> hasImage: Boolean
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `index` {#safeds.data.image.containers.ImageList.index data-toc-label='[function] index'}
 
@@ -986,6 +1002,7 @@ If the image has multiple occurrences, all indices will be returned
         image: Image
     ) -> indices: List<Int>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `invertColors` {#safeds.data.image.containers.ImageList.invertColors data-toc-label='[function] invertColors'}
 
@@ -1006,6 +1023,7 @@ The original image list is not modified.
     @PythonName("invert_colors")
     fun invertColors() -> imageList: ImageList
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `removeDuplicateImages` {#safeds.data.image.containers.ImageList.removeDuplicateImages data-toc-label='[function] removeDuplicateImages'}
 
@@ -1028,6 +1046,7 @@ The original image list is not modified.
     @PythonName("remove_duplicate_images")
     fun removeDuplicateImages() -> imageList: ImageList
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `removeImage` {#safeds.data.image.containers.ImageList.removeImage data-toc-label='[function] removeImage'}
 
@@ -1058,6 +1077,7 @@ The original image list is not modified.
         image: Image
     ) -> imageList: ImageList
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `removeImageByIndex` {#safeds.data.image.containers.ImageList.removeImageByIndex data-toc-label='[function] removeImageByIndex'}
 
@@ -1086,6 +1106,7 @@ The original image list is not modified.
         index: union<Int, List<Int>>
     ) -> imageList: ImageList
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `removeImages` {#safeds.data.image.containers.ImageList.removeImages data-toc-label='[function] removeImages'}
 
@@ -1116,6 +1137,7 @@ The original image list is not modified.
         images: List<Image>
     ) -> imageList: ImageList
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `removeImagesWithSize` {#safeds.data.image.containers.ImageList.removeImagesWithSize data-toc-label='[function] removeImagesWithSize'}
 
@@ -1146,6 +1168,7 @@ The original image list is not modified.
         height: Int
     ) -> imageList: ImageList
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `resize` {#safeds.data.image.containers.ImageList.resize data-toc-label='[function] resize'}
 
@@ -1178,6 +1201,7 @@ The original image list is not modified.
         newHeight >= 0
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `rotateLeft` {#safeds.data.image.containers.ImageList.rotateLeft data-toc-label='[function] rotateLeft'}
 
@@ -1198,6 +1222,7 @@ The original image list is not modified.
     @PythonName("rotate_left")
     fun rotateLeft() -> imageList: ImageList
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `rotateRight` {#safeds.data.image.containers.ImageList.rotateRight data-toc-label='[function] rotateRight'}
 
@@ -1218,6 +1243,7 @@ The original image list is not modified.
     @PythonName("rotate_right")
     fun rotateRight() -> imageList: ImageList
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `sharpen` {#safeds.data.image.containers.ImageList.sharpen data-toc-label='[function] sharpen'}
 
@@ -1247,6 +1273,7 @@ The original image list is not modified.
         factor >= 0.0
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `shuffleImages` {#safeds.data.image.containers.ImageList.shuffleImages data-toc-label='[function] shuffleImages'}
 
@@ -1267,6 +1294,7 @@ The original image list is not modified.
     @PythonName("shuffle_images")
     fun shuffleImages() -> imageList: ImageList
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toImages` {#safeds.data.image.containers.ImageList.toImages data-toc-label='[function] toImages'}
 
@@ -1293,6 +1321,7 @@ Return a list of all images in this image list.
         indices: List<Int>? = null
     ) -> images: List<Image>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toJpegFiles` {#safeds.data.image.containers.ImageList.toJpegFiles data-toc-label='[function] toJpegFiles'}
 
@@ -1313,6 +1342,7 @@ Save all images as jpeg files.
         path: union<List<String>, String>
     )
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toPngFiles` {#safeds.data.image.containers.ImageList.toPngFiles data-toc-label='[function] toPngFiles'}
 
@@ -1333,6 +1363,7 @@ Save all images as png files.
         path: union<List<String>, String>
     )
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `fromFiles` {#safeds.data.image.containers.ImageList.fromFiles data-toc-label='[static-function] fromFiles'}
 
@@ -1361,6 +1392,7 @@ If you provide a path to a directory the images will be sorted alphabetically wh
         path: union<List<String>, String>
     ) -> imageList: ImageList
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `fromImages` {#safeds.data.image.containers.ImageList.fromImages data-toc-label='[static-function] fromImages'}
 
@@ -1387,3 +1419,4 @@ Create an ImageList from a list of images.
         images: List<Image>
     ) -> imageList: ImageList
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/image/typing/ImageSize.md
+++ b/docs/api/safeds/data/image/typing/ImageSize.md
@@ -16,6 +16,7 @@ A container for image size data.
     ```sds linenums="15"
     class ImageSize sub ConstantImageSize
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `channel` {#safeds.data.image.typing.ImageSize.channel data-toc-label='[attribute] channel'}
 

--- a/docs/api/safeds/data/labeled/containers/Dataset.md
+++ b/docs/api/safeds/data/labeled/containers/Dataset.md
@@ -27,3 +27,4 @@ A dataset is used as input to machine learning models.
     ```sds linenums="9"
     class Dataset<out I, out O>
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/labeled/containers/ImageDataset.md
+++ b/docs/api/safeds/data/labeled/containers/ImageDataset.md
@@ -127,6 +127,7 @@ pipeline example {
         ) -> (firstDataset: ImageDataset<O>, secondDataset: ImageDataset<O>)
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `inputSize` {#safeds.data.labeled.containers.ImageDataset.inputSize data-toc-label='[attribute] inputSize'}
 
@@ -169,6 +170,7 @@ pipeline example {
     @PythonName("get_input")
     fun getInput() -> input: ImageList
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getOutput` {#safeds.data.labeled.containers.ImageDataset.getOutput data-toc-label='[function] getOutput'}
 
@@ -199,6 +201,7 @@ pipeline example {
     @PythonName("get_output")
     fun getOutput() -> output: O
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `shuffle` {#safeds.data.labeled.containers.ImageDataset.shuffle data-toc-label='[function] shuffle'}
 
@@ -230,6 +233,7 @@ pipeline example {
     @Pure
     fun shuffle() -> imageDataset: ImageDataset<O>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `split` {#safeds.data.labeled.containers.ImageDataset.split data-toc-label='[function] split'}
 
@@ -264,3 +268,4 @@ The original dataset is not modified.
         shuffle: Boolean = true
     ) -> (firstDataset: ImageDataset<O>, secondDataset: ImageDataset<O>)
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/labeled/containers/TabularDataset.md
+++ b/docs/api/safeds/data/labeled/containers/TabularDataset.md
@@ -85,6 +85,7 @@ pipeline example {
         fun toTable() -> table: Table
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `extras` {#safeds.data.labeled.containers.TabularDataset.extras data-toc-label='[attribute] extras'}
 
@@ -139,3 +140,4 @@ pipeline example {
     @PythonName("to_table")
     fun toTable() -> table: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/labeled/containers/TimeSeriesDataset.md
+++ b/docs/api/safeds/data/labeled/containers/TimeSeriesDataset.md
@@ -93,6 +93,7 @@ pipeline example {
         fun toTable() -> table: Table
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `continuous` {#safeds.data.labeled.containers.TimeSeriesDataset.continuous data-toc-label='[attribute] continuous'}
 
@@ -165,3 +166,4 @@ pipeline example {
     @PythonName("to_table")
     fun toTable() -> table: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/tabular/containers/Cell.md
+++ b/docs/api/safeds/data/tabular/containers/Cell.md
@@ -439,6 +439,7 @@ This class cannot be instantiated directly. It is only used for arguments of cal
         ) -> result: Cell<Boolean>
     }
     ```
+    { data-search-exclude }
 
 ## :test_tube:{ title="Experimental" } <code class="doc-symbol doc-symbol-attribute"></code> `dt` {#safeds.data.tabular.containers.Cell.dt data-toc-label='[attribute] dt'}
 
@@ -478,6 +479,7 @@ pipeline example {
     @Pure
     fun abs() -> result: Cell<Number>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `add` {#safeds.data.tabular.containers.Cell.add data-toc-label='[function] add'}
 
@@ -520,6 +522,7 @@ pipeline example {
         other: union<Number, Cell> // TODO, once cell types can be inferred: union<Number, Cell<Number>>
     ) -> result: Cell<Number>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `and` {#safeds.data.tabular.containers.Cell.and data-toc-label='[function] and'}
 
@@ -563,6 +566,7 @@ pipeline example {
         other: union<Boolean, Cell> // TODO, once cell types can be inferred: union<Boolean, Cell<Boolean>>
     ) -> result: Cell<Boolean>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `ceil` {#safeds.data.tabular.containers.Cell.ceil data-toc-label='[function] ceil'}
 
@@ -590,6 +594,7 @@ pipeline example {
     @Pure
     fun ceil() -> result: Cell<Int>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `div` {#safeds.data.tabular.containers.Cell.div data-toc-label='[function] div'}
 
@@ -632,6 +637,7 @@ pipeline example {
         other: union<Number, Cell> // TODO, once cell types can be inferred: union<Number, Cell<Number>>
     ) -> result: Cell<Number>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `eq` {#safeds.data.tabular.containers.Cell.eq data-toc-label='[function] eq'}
 
@@ -674,6 +680,7 @@ pipeline example {
         other: Any?
     ) -> result: Cell<Boolean>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `floor` {#safeds.data.tabular.containers.Cell.floor data-toc-label='[function] floor'}
 
@@ -701,6 +708,7 @@ pipeline example {
     @Pure
     fun floor() -> result: Cell<Int>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `ge` {#safeds.data.tabular.containers.Cell.ge data-toc-label='[function] ge'}
 
@@ -743,6 +751,7 @@ pipeline example {
         other: union<Number, Cell> // TODO, once cell types can be inferred: union<Number, Cell<Number>>
     ) -> result: Cell<Boolean>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `gt` {#safeds.data.tabular.containers.Cell.gt data-toc-label='[function] gt'}
 
@@ -785,6 +794,7 @@ pipeline example {
         other: union<Number, Cell> // TODO, once cell types can be inferred: union<Number, Cell<Number>>
     ) -> result: Cell<Boolean>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `le` {#safeds.data.tabular.containers.Cell.le data-toc-label='[function] le'}
 
@@ -827,6 +837,7 @@ pipeline example {
         other: union<Number, Cell> // TODO, once cell types can be inferred: union<Number, Cell<Number>>
     ) -> result: Cell<Boolean>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `lt` {#safeds.data.tabular.containers.Cell.lt data-toc-label='[function] lt'}
 
@@ -869,6 +880,7 @@ pipeline example {
         other: union<Number, Cell> // TODO, once cell types can be inferred: union<Number, Cell<Number>>
     ) -> result: Cell<Boolean>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `mod` {#safeds.data.tabular.containers.Cell.mod data-toc-label='[function] mod'}
 
@@ -911,6 +923,7 @@ pipeline example {
         other: union<Number, Cell> // TODO, once cell types can be inferred: union<Number, Cell<Number>>
     ) -> result: Cell<Number>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `mul` {#safeds.data.tabular.containers.Cell.mul data-toc-label='[function] mul'}
 
@@ -953,6 +966,7 @@ pipeline example {
         other: union<Number, Cell> // TODO, once cell types can be inferred: union<Number, Cell<Number>>
     ) -> result: Cell<Number>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `neg` {#safeds.data.tabular.containers.Cell.neg data-toc-label='[function] neg'}
 
@@ -987,6 +1001,7 @@ pipeline example {
     @Pure
     fun neg() -> result: Cell<Number>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `neq` {#safeds.data.tabular.containers.Cell.neq data-toc-label='[function] neq'}
 
@@ -1029,6 +1044,7 @@ pipeline example {
         other: Any?
     ) -> result: Cell<Boolean>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `not` {#safeds.data.tabular.containers.Cell.not data-toc-label='[function] not'}
 
@@ -1064,6 +1080,7 @@ pipeline example {
     @PythonName("not_")
     fun ^not() -> result: Cell<Boolean>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `or` {#safeds.data.tabular.containers.Cell.or data-toc-label='[function] or'}
 
@@ -1107,6 +1124,7 @@ pipeline example {
         other: union<Boolean, Cell> // TODO, once cell types can be inferred: union<Boolean, Cell<Boolean>>
     ) -> result: Cell<Boolean>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `pow` {#safeds.data.tabular.containers.Cell.pow data-toc-label='[function] pow'}
 
@@ -1142,6 +1160,7 @@ pipeline example {
         other: union<Number, Cell> // TODO, once cell types can be inferred: union<Number, Cell<Number>>
     ) -> result: Cell<Number>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `sub` {#safeds.data.tabular.containers.Cell.sub data-toc-label='[function] sub'}
 
@@ -1184,6 +1203,7 @@ pipeline example {
         other: union<Number, Cell> // TODO, once cell types can be inferred: union<Number, Cell<Number>>
     ) -> result: Cell<Number>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `xor` {#safeds.data.tabular.containers.Cell.xor data-toc-label='[function] xor'}
 
@@ -1219,6 +1239,7 @@ pipeline example {
         other: union<Boolean, Cell> // TODO, once cell types can be inferred: union<Boolean, Cell<Boolean>>
     ) -> result: Cell<Boolean>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `firstNotNone` {#safeds.data.tabular.containers.Cell.firstNotNone data-toc-label='[static-function] firstNotNone'}
 
@@ -1251,3 +1272,4 @@ Return the first cell from the given list that is not None.
         cells: List<Cell<T>>
     ) -> cell: Cell<T?>
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/tabular/containers/Column.md
+++ b/docs/api/safeds/data/tabular/containers/Column.md
@@ -613,6 +613,7 @@ pipeline example {
         fun toTable() -> table: Table
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isNumeric` {#safeds.data.tabular.containers.Column.isNumeric data-toc-label='[attribute] isNumeric'}
 
@@ -708,6 +709,7 @@ pipeline example {
         @PythonName("ignore_unknown") ignoreUnknown: Boolean = true,
     ) -> allSatisfyPredicate: Boolean?
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `any` {#safeds.data.tabular.containers.Column.any data-toc-label='[function] any'}
 
@@ -767,6 +769,7 @@ pipeline example {
         @PythonName("ignore_unknown") ignoreUnknown: Boolean = true,
     ) -> anySatisfyPredicate: Boolean?
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `correlationWith` {#safeds.data.tabular.containers.Column.correlationWith data-toc-label='[function] correlationWith'}
 
@@ -817,6 +820,7 @@ pipeline example {
         other: Column<Any>
     ) -> correlation: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `countIf` {#safeds.data.tabular.containers.Column.countIf data-toc-label='[function] countIf'}
 
@@ -871,6 +875,7 @@ pipeline example {
         @PythonName("ignore_unknown") ignoreUnknown: Boolean = true,
     ) -> count: Int?
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `distinctValueCount` {#safeds.data.tabular.containers.Column.distinctValueCount data-toc-label='[function] distinctValueCount'}
 
@@ -906,6 +911,7 @@ pipeline example {
         @PythonName("ignore_missing_values") ignoreMissingValues: Boolean = true
     ) -> distinctValueCount: Int
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getDistinctValues` {#safeds.data.tabular.containers.Column.getDistinctValues data-toc-label='[function] getDistinctValues'}
 
@@ -930,6 +936,7 @@ pipeline example {
         @PythonName("ignore_missing_values") ignoreMissingValues: Boolean = true,
     ) -> distinctValues: List<T?>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getValue` {#safeds.data.tabular.containers.Column.getValue data-toc-label='[function] getValue'}
 
@@ -974,6 +981,7 @@ pipeline example {
         index: Int
     ) -> value: T
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `idness` {#safeds.data.tabular.containers.Column.idness data-toc-label='[function] idness'}
 
@@ -1012,6 +1020,7 @@ pipeline example {
     @Pure
     fun idness() -> idness: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `max` {#safeds.data.tabular.containers.Column.max data-toc-label='[function] max'}
 
@@ -1038,6 +1047,7 @@ pipeline example {
     @Pure
     fun max() -> max: T?
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `mean` {#safeds.data.tabular.containers.Column.mean data-toc-label='[function] mean'}
 
@@ -1066,6 +1076,7 @@ pipeline example {
     @Pure
     fun mean() -> mean: T
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `median` {#safeds.data.tabular.containers.Column.median data-toc-label='[function] median'}
 
@@ -1095,6 +1106,7 @@ pipeline example {
     @Pure
     fun median() -> median: T
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `min` {#safeds.data.tabular.containers.Column.min data-toc-label='[function] min'}
 
@@ -1121,6 +1133,7 @@ pipeline example {
     @Pure
     fun min() -> min: T?
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `missingValueCount` {#safeds.data.tabular.containers.Column.missingValueCount data-toc-label='[function] missingValueCount'}
 
@@ -1148,6 +1161,7 @@ pipeline example {
     @PythonName("missing_value_count")
     fun missingValueCount() -> missingValueCount: Int
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `missingValueRatio` {#safeds.data.tabular.containers.Column.missingValueRatio data-toc-label='[function] missingValueRatio'}
 
@@ -1181,6 +1195,7 @@ pipeline example {
     @PythonName("missing_value_ratio")
     fun missingValueRatio() -> missingValueRatio: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `mode` {#safeds.data.tabular.containers.Column.mode data-toc-label='[function] mode'}
 
@@ -1218,6 +1233,7 @@ pipeline example {
         @PythonName("ignore_missing_values") ignoreMissingValues: Boolean = true,
     ) -> mode: List<T?>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `none` {#safeds.data.tabular.containers.Column.none data-toc-label='[function] none'}
 
@@ -1277,6 +1293,7 @@ pipeline example {
         @PythonName("ignore_unknown") ignoreUnknown: Boolean = true,
     ) -> noneSatisfyPredicate: Int?
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `rename` {#safeds.data.tabular.containers.Column.rename data-toc-label='[function] rename'}
 
@@ -1314,6 +1331,7 @@ pipeline example {
         @PythonName("new_name") newName: String
     ) -> renamedColumn: Column<T>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `stability` {#safeds.data.tabular.containers.Column.stability data-toc-label='[function] stability'}
 
@@ -1346,6 +1364,7 @@ pipeline example {
     @Pure
     fun stability() -> stability: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `standardDeviation` {#safeds.data.tabular.containers.Column.standardDeviation data-toc-label='[function] standardDeviation'}
 
@@ -1375,6 +1394,7 @@ pipeline example {
     @PythonName("standard_deviation")
     fun standardDeviation() -> standardDeviation: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeStatistics` {#safeds.data.tabular.containers.Column.summarizeStatistics data-toc-label='[function] summarizeStatistics'}
 
@@ -1402,6 +1422,7 @@ pipeline example {
     @PythonName("summarize_statistics")
     fun summarizeStatistics() -> statistics: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toList` {#safeds.data.tabular.containers.Column.toList data-toc-label='[function] toList'}
 
@@ -1429,6 +1450,7 @@ pipeline example {
     @PythonName("to_list")
     fun toList() -> values: List<T>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toTable` {#safeds.data.tabular.containers.Column.toTable data-toc-label='[function] toTable'}
 
@@ -1457,6 +1479,7 @@ pipeline example {
     @PythonName("to_table")
     fun toTable() -> table: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `transform` {#safeds.data.tabular.containers.Column.transform data-toc-label='[function] transform'}
 
@@ -1500,6 +1523,7 @@ pipeline example {
         transformer: (cell: Cell<T>) -> transformedCell: Cell<R>
     ) -> transformedColumn: Column<R>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `variance` {#safeds.data.tabular.containers.Column.variance data-toc-label='[function] variance'}
 
@@ -1528,3 +1552,4 @@ pipeline example {
     @Pure
     fun variance() -> variance: Float
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/tabular/containers/Row.md
+++ b/docs/api/safeds/data/tabular/containers/Row.md
@@ -81,6 +81,7 @@ This class cannot be instantiated directly. It is only used for arguments of cal
         ) -> hasColumn: Boolean
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `columnCount` {#safeds.data.tabular.containers.Row.columnCount data-toc-label='[attribute] columnCount'}
 
@@ -125,6 +126,7 @@ Get the type of the specified column.
         name: String
     ) -> type: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getValue` {#safeds.data.tabular.containers.Row.getValue data-toc-label='[function] getValue'}
 
@@ -167,6 +169,7 @@ pipeline example {
         name: String
     ) -> value: Cell
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `hasColumn` {#safeds.data.tabular.containers.Row.hasColumn data-toc-label='[function] hasColumn'}
 
@@ -193,3 +196,4 @@ Check if the row has a column with the specified name.
         name: String
     ) -> hasColumn: Boolean
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/tabular/containers/StringCell.md
+++ b/docs/api/safeds/data/tabular/containers/StringCell.md
@@ -317,6 +317,7 @@ pipeline example {
         fun trimStart() -> trimmed: Cell<String>
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `contains` {#safeds.data.tabular.containers.StringCell.contains data-toc-label='[function] contains'}
 
@@ -351,6 +352,7 @@ pipeline example {
         substring: String
     ) -> contains: Cell<Boolean>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `endsWith` {#safeds.data.tabular.containers.StringCell.endsWith data-toc-label='[function] endsWith'}
 
@@ -386,6 +388,7 @@ pipeline example {
         suffix: String
     ) -> endsWith: Cell<Boolean>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `indexOf` {#safeds.data.tabular.containers.StringCell.indexOf data-toc-label='[function] indexOf'}
 
@@ -422,6 +425,7 @@ pipeline example {
         substring: String
     ) -> indexOf: Cell<Int?>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `length` {#safeds.data.tabular.containers.StringCell.length data-toc-label='[function] length'}
 
@@ -457,6 +461,7 @@ pipeline example {
         @PythonName("optimize_for_ascii") optimizeForAscii: Boolean = false
     ) -> length: Cell<Int>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `replace` {#safeds.data.tabular.containers.StringCell.replace data-toc-label='[function] replace'}
 
@@ -494,6 +499,7 @@ pipeline example {
         new: String
     ) -> replacedString: Cell<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `startsWith` {#safeds.data.tabular.containers.StringCell.startsWith data-toc-label='[function] startsWith'}
 
@@ -529,6 +535,7 @@ pipeline example {
         prefix: String
     ) -> startsWith: Cell<Boolean>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `substring` {#safeds.data.tabular.containers.StringCell.substring data-toc-label='[function] substring'}
 
@@ -566,6 +573,7 @@ pipeline example {
         length: Int? = null
     ) -> substring: Cell<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toDate` {#safeds.data.tabular.containers.StringCell.toDate data-toc-label='[function] toDate'}
 
@@ -593,6 +601,7 @@ pipeline example {
     @PythonName("to_date")
     fun toDate() -> date: Cell
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toDatetime` {#safeds.data.tabular.containers.StringCell.toDatetime data-toc-label='[function] toDatetime'}
 
@@ -620,6 +629,7 @@ pipeline example {
     @PythonName("to_datetime")
     fun toDatetime() -> datetime: Cell
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toFloat` {#safeds.data.tabular.containers.StringCell.toFloat data-toc-label='[function] toFloat'}
 
@@ -648,6 +658,7 @@ pipeline example {
     @PythonName("to_float")
     fun toFloat() -> float: Cell<Float?>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toInt` {#safeds.data.tabular.containers.StringCell.toInt data-toc-label='[function] toInt'}
 
@@ -691,6 +702,7 @@ pipeline example {
         base: Int = 10
     ) -> int: Cell<Int?>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toLowercase` {#safeds.data.tabular.containers.StringCell.toLowercase data-toc-label='[function] toLowercase'}
 
@@ -719,6 +731,7 @@ pipeline example {
     @PythonName("to_lowercase")
     fun toLowercase() -> lowercase: Cell<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toUppercase` {#safeds.data.tabular.containers.StringCell.toUppercase data-toc-label='[function] toUppercase'}
 
@@ -747,6 +760,7 @@ pipeline example {
     @PythonName("to_uppercase")
     fun toUppercase() -> uppercase: Cell<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `trim` {#safeds.data.tabular.containers.StringCell.trim data-toc-label='[function] trim'}
 
@@ -774,6 +788,7 @@ pipeline example {
     @Pure
     fun trim() -> trimmed: Cell<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `trimEnd` {#safeds.data.tabular.containers.StringCell.trimEnd data-toc-label='[function] trimEnd'}
 
@@ -802,6 +817,7 @@ pipeline example {
     @PythonName("trim_end")
     fun trimEnd() -> trimmed: Cell<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `trimStart` {#safeds.data.tabular.containers.StringCell.trimStart data-toc-label='[function] trimStart'}
 
@@ -830,3 +846,4 @@ pipeline example {
     @PythonName("trim_start")
     fun trimStart() -> trimmed: Cell<String>
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/tabular/containers/Table.md
+++ b/docs/api/safeds/data/tabular/containers/Table.md
@@ -1049,6 +1049,7 @@ pipeline example {
         ) -> dataset: TimeSeriesDataset
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `columnCount` {#safeds.data.tabular.containers.Table.columnCount data-toc-label='[attribute] columnCount'}
 
@@ -1122,6 +1123,7 @@ pipeline example {
         columns: union<Column, List<Column>>
     ) -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `addComputedColumn` {#safeds.data.tabular.containers.Table.addComputedColumn data-toc-label='[function] addComputedColumn'}
 
@@ -1161,6 +1163,7 @@ pipeline example {
         computer: (row: Row) -> computedCell: Cell
     ) -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `addTableAsColumns` {#safeds.data.tabular.containers.Table.addTableAsColumns data-toc-label='[function] addTableAsColumns'}
 
@@ -1203,6 +1206,7 @@ pipeline example {
         other: Table
     ) -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `addTableAsRows` {#safeds.data.tabular.containers.Table.addTableAsRows data-toc-label='[function] addTableAsRows'}
 
@@ -1245,6 +1249,7 @@ pipeline example {
         other: Table
     ) -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `countRowIf` {#safeds.data.tabular.containers.Table.countRowIf data-toc-label='[function] countRowIf'}
 
@@ -1300,6 +1305,7 @@ pipeline example {
         @PythonName("ignore_unknown") ignoreUnknown: Boolean = true,
     ) -> count: Int?
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getColumn` {#safeds.data.tabular.containers.Table.getColumn data-toc-label='[function] getColumn'}
 
@@ -1336,6 +1342,7 @@ pipeline example {
         name: String
     ) -> column: Column
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getColumnType` {#safeds.data.tabular.containers.Table.getColumnType data-toc-label='[function] getColumnType'}
 
@@ -1371,6 +1378,7 @@ pipeline example {
         name: String
     ) -> type: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `hasColumn` {#safeds.data.tabular.containers.Table.hasColumn data-toc-label='[function] hasColumn'}
 
@@ -1406,6 +1414,7 @@ pipeline example {
         name: String
     ) -> hasColumn: Boolean
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `inverseTransformTable` {#safeds.data.tabular.containers.Table.inverseTransformTable data-toc-label='[function] inverseTransformTable'}
 
@@ -1448,6 +1457,7 @@ pipeline example {
         @PythonName("fitted_transformer") fittedTransformer: InvertibleTableTransformer
     ) -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `join` {#safeds.data.tabular.containers.Table.join data-toc-label='[function] join'}
 
@@ -1490,6 +1500,7 @@ pipeline example {
         mode: literal<"inner", "left", "outer"> = "inner"
     ) -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `removeColumns` {#safeds.data.tabular.containers.Table.removeColumns data-toc-label='[function] removeColumns'}
 
@@ -1537,6 +1548,7 @@ pipeline example {
         @PythonName("ignore_unknown_names") ignoreUnknownNames: Boolean = false
     ) -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `removeColumnsExcept` {#safeds.data.tabular.containers.Table.removeColumnsExcept data-toc-label='[function] removeColumnsExcept'}
 
@@ -1573,6 +1585,7 @@ pipeline example {
         names: union<List<String>, String>
     ) -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `removeColumnsWithMissingValues` {#safeds.data.tabular.containers.Table.removeColumnsWithMissingValues data-toc-label='[function] removeColumnsWithMissingValues'}
 
@@ -1606,6 +1619,7 @@ pipeline example {
     @PythonName("remove_columns_with_missing_values")
     fun removeColumnsWithMissingValues() -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `removeDuplicateRows` {#safeds.data.tabular.containers.Table.removeDuplicateRows data-toc-label='[function] removeDuplicateRows'}
 
@@ -1636,6 +1650,7 @@ pipeline example {
     @PythonName("remove_duplicate_rows")
     fun removeDuplicateRows() -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `removeNonNumericColumns` {#safeds.data.tabular.containers.Table.removeNonNumericColumns data-toc-label='[function] removeNonNumericColumns'}
 
@@ -1666,6 +1681,7 @@ pipeline example {
     @PythonName("remove_non_numeric_columns")
     fun removeNonNumericColumns() -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `removeRows` {#safeds.data.tabular.containers.Table.removeRows data-toc-label='[function] removeRows'}
 
@@ -1704,6 +1720,7 @@ pipeline example {
         query: (row: Row) -> shouldRemoveRow: Cell<Boolean>
     ) -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `removeRowsByColumn` {#safeds.data.tabular.containers.Table.removeRowsByColumn data-toc-label='[function] removeRowsByColumn'}
 
@@ -1744,6 +1761,7 @@ pipeline example {
         query: (cell: Cell) -> shouldRemoveRow: Cell<Boolean>
     ) -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `removeRowsWithMissingValues` {#safeds.data.tabular.containers.Table.removeRowsWithMissingValues data-toc-label='[function] removeRowsWithMissingValues'}
 
@@ -1782,6 +1800,7 @@ pipeline example {
         @PythonName("column_names") columnNames: List<String>? = null
     ) -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `removeRowsWithOutliers` {#safeds.data.tabular.containers.Table.removeRowsWithOutliers data-toc-label='[function] removeRowsWithOutliers'}
 
@@ -1838,6 +1857,7 @@ pipeline example {
         @PythonName("z_score_threshold") zScoreThreshold: Float = 3.0
     ) -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `renameColumn` {#safeds.data.tabular.containers.Table.renameColumn data-toc-label='[function] renameColumn'}
 
@@ -1878,6 +1898,7 @@ pipeline example {
         @PythonName("new_name") newName: String
     ) -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `replaceColumn` {#safeds.data.tabular.containers.Table.replaceColumn data-toc-label='[function] replaceColumn'}
 
@@ -1942,6 +1963,7 @@ pipeline example {
         @PythonName("new_columns") newColumns: union<Column, List<Column>, Table>
     ) -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `shuffleRows` {#safeds.data.tabular.containers.Table.shuffleRows data-toc-label='[function] shuffleRows'}
 
@@ -1972,6 +1994,7 @@ pipeline example {
     @PythonName("shuffle_rows")
     fun shuffleRows() -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `sliceRows` {#safeds.data.tabular.containers.Table.sliceRows data-toc-label='[function] sliceRows'}
 
@@ -2019,6 +2042,7 @@ pipeline example {
         length: Int? = null
     ) -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `sortRows` {#safeds.data.tabular.containers.Table.sortRows data-toc-label='[function] sortRows'}
 
@@ -2059,6 +2083,7 @@ pipeline example {
         descending: Boolean = false
     ) -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `sortRowsByColumn` {#safeds.data.tabular.containers.Table.sortRowsByColumn data-toc-label='[function] sortRowsByColumn'}
 
@@ -2099,6 +2124,7 @@ pipeline example {
         descending: Boolean = false
     ) -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `splitRows` {#safeds.data.tabular.containers.Table.splitRows data-toc-label='[function] splitRows'}
 
@@ -2145,6 +2171,7 @@ pipeline example {
         shuffle: Boolean = true
     ) -> (firstTable: Table, secondTable: Table)
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeStatistics` {#safeds.data.tabular.containers.Table.summarizeStatistics data-toc-label='[function] summarizeStatistics'}
 
@@ -2172,6 +2199,7 @@ pipeline example {
     @PythonName("summarize_statistics")
     fun summarizeStatistics() -> statistics: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toColumns` {#safeds.data.tabular.containers.Table.toColumns data-toc-label='[function] toColumns'}
 
@@ -2199,6 +2227,7 @@ pipeline example {
     @PythonName("to_columns")
     fun toColumns() -> columns: List<Column>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toCsvFile` {#safeds.data.tabular.containers.Table.toCsvFile data-toc-label='[function] toCsvFile'}
 
@@ -2231,6 +2260,7 @@ pipeline example {
         path: String
     )
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toJsonFile` {#safeds.data.tabular.containers.Table.toJsonFile data-toc-label='[function] toJsonFile'}
 
@@ -2265,6 +2295,7 @@ pipeline example {
         path: String
     )
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toMap` {#safeds.data.tabular.containers.Table.toMap data-toc-label='[function] toMap'}
 
@@ -2293,6 +2324,7 @@ pipeline example {
     @PythonName("to_dict")
     fun toMap() -> map: Map<String, List<Any>>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toParquetFile` {#safeds.data.tabular.containers.Table.toParquetFile data-toc-label='[function] toParquetFile'}
 
@@ -2325,6 +2357,7 @@ pipeline example {
         path: String
     )
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toTabularDataset` {#safeds.data.tabular.containers.Table.toTabularDataset data-toc-label='[function] toTabularDataset'}
 
@@ -2376,6 +2409,7 @@ pipeline example {
         @PythonName("extra_names") extraNames: List<String>? = null
     ) -> dataset: TabularDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toTimeSeriesDataset` {#safeds.data.tabular.containers.Table.toTimeSeriesDataset data-toc-label='[function] toTimeSeriesDataset'}
 
@@ -2427,6 +2461,7 @@ pipeline example {
         continuous: Boolean = false
     ) -> dataset: TimeSeriesDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `transformColumn` {#safeds.data.tabular.containers.Table.transformColumn data-toc-label='[function] transformColumn'}
 
@@ -2467,6 +2502,7 @@ pipeline example {
         transformer: (cell: Cell) -> transformedCell: Cell
     ) -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `transformTable` {#safeds.data.tabular.containers.Table.transformTable data-toc-label='[function] transformTable'}
 
@@ -2509,6 +2545,7 @@ pipeline example {
         @PythonName("fitted_transformer") fittedTransformer: TableTransformer
     ) -> newTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `fromColumns` {#safeds.data.tabular.containers.Table.fromColumns data-toc-label='[static-function] fromColumns'}
 
@@ -2545,6 +2582,7 @@ pipeline example {
         columns: union<Column, List<Column>>
     ) -> table: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `fromCsvFile` {#safeds.data.tabular.containers.Table.fromCsvFile data-toc-label='[static-function] fromCsvFile'}
 
@@ -2581,6 +2619,7 @@ pipeline example {
         separator: String = ","
     ) -> table: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `fromJsonFile` {#safeds.data.tabular.containers.Table.fromJsonFile data-toc-label='[static-function] fromJsonFile'}
 
@@ -2615,6 +2654,7 @@ pipeline example {
         path: String
     ) -> table: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `fromMap` {#safeds.data.tabular.containers.Table.fromMap data-toc-label='[static-function] fromMap'}
 
@@ -2650,6 +2690,7 @@ pipeline example {
         data: Map<String, List<Any>>
     ) -> table: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `fromParquetFile` {#safeds.data.tabular.containers.Table.fromParquetFile data-toc-label='[static-function] fromParquetFile'}
 
@@ -2684,3 +2725,4 @@ pipeline example {
         path: String
     ) -> table: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/tabular/containers/TemporalCell.md
+++ b/docs/api/safeds/data/tabular/containers/TemporalCell.md
@@ -153,6 +153,7 @@ pipeline example {
         ) -> string: Cell<String>
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `century` {#safeds.data.tabular.containers.TemporalCell.century data-toc-label='[function] century'}
 
@@ -181,6 +182,7 @@ pipeline example {
     @Pure
     fun century() -> century: Cell<Int>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `datetimeToString` {#safeds.data.tabular.containers.TemporalCell.datetimeToString data-toc-label='[function] datetimeToString'}
 
@@ -218,6 +220,7 @@ pipeline example {
         @PythonName("format_string") formatString: String = "%Y/%m/%d %H:%M:%S"
     ) -> string: Cell<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `dateToString` {#safeds.data.tabular.containers.TemporalCell.dateToString data-toc-label='[function] dateToString'}
 
@@ -255,6 +258,7 @@ pipeline example {
         @PythonName("format_string") formatString: String = "%F"
     ) -> string: Cell<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `day` {#safeds.data.tabular.containers.TemporalCell.day data-toc-label='[function] day'}
 
@@ -283,6 +287,7 @@ pipeline example {
     @Pure
     fun day() -> day: Cell<Int>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `month` {#safeds.data.tabular.containers.TemporalCell.month data-toc-label='[function] month'}
 
@@ -311,6 +316,7 @@ pipeline example {
     @Pure
     fun month() -> month: Cell<Int>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `week` {#safeds.data.tabular.containers.TemporalCell.week data-toc-label='[function] week'}
 
@@ -339,6 +345,7 @@ pipeline example {
     @Pure
     fun week() -> week: Cell<Int>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `weekday` {#safeds.data.tabular.containers.TemporalCell.weekday data-toc-label='[function] weekday'}
 
@@ -367,6 +374,7 @@ pipeline example {
     @Pure
     fun weekday() -> weekday: Cell<Int>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `year` {#safeds.data.tabular.containers.TemporalCell.year data-toc-label='[function] year'}
 
@@ -395,3 +403,4 @@ pipeline example {
     @Pure
     fun year() -> year: Cell<Int>
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/tabular/plotting/ColumnPlotter.md
+++ b/docs/api/safeds/data/tabular/plotting/ColumnPlotter.md
@@ -107,6 +107,7 @@ pipeline example {
         ) -> plot: Image
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `boxPlot` {#safeds.data.tabular.plotting.ColumnPlotter.boxPlot data-toc-label='[function] boxPlot'}
 
@@ -142,6 +143,7 @@ pipeline example {
         theme: literal<"dark", "light"> = "light"
     ) -> plot: Image
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `histogram` {#safeds.data.tabular.plotting.ColumnPlotter.histogram data-toc-label='[function] histogram'}
 
@@ -180,6 +182,7 @@ pipeline example {
         maxBinCount > 0
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `lagPlot` {#safeds.data.tabular.plotting.ColumnPlotter.lagPlot data-toc-label='[function] lagPlot'}
 
@@ -217,6 +220,7 @@ pipeline example {
         theme: literal<"dark", "light"> = "light"
     ) -> plot: Image
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `violinPlot` {#safeds.data.tabular.plotting.ColumnPlotter.violinPlot data-toc-label='[function] violinPlot'}
 
@@ -252,3 +256,4 @@ pipeline example {
         theme: literal<"dark", "light"> = "light"
     ) -> plot: Image
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/tabular/plotting/TablePlotter.md
+++ b/docs/api/safeds/data/tabular/plotting/TablePlotter.md
@@ -225,6 +225,7 @@ pipeline example {
         ) -> plot: Image
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `boxPlots` {#safeds.data.tabular.plotting.TablePlotter.boxPlots data-toc-label='[function] boxPlots'}
 
@@ -260,6 +261,7 @@ pipeline example {
         theme: literal<"dark", "light"> = "light"
     ) -> plot: Image
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `correlationHeatmap` {#safeds.data.tabular.plotting.TablePlotter.correlationHeatmap data-toc-label='[function] correlationHeatmap'}
 
@@ -295,6 +297,7 @@ pipeline example {
         theme: literal<"dark", "light"> = "light"
     ) -> plot: Image
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `histogram2d` {#safeds.data.tabular.plotting.TablePlotter.histogram2d data-toc-label='[function] histogram2d'}
 
@@ -343,6 +346,7 @@ pipeline example {
         theme: literal<"dark", "light"> = "light"
     ) -> plot: Image
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `histograms` {#safeds.data.tabular.plotting.TablePlotter.histograms data-toc-label='[function] histograms'}
 
@@ -381,6 +385,7 @@ pipeline example {
         maxBinCount > 0
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `linePlot` {#safeds.data.tabular.plotting.TablePlotter.linePlot data-toc-label='[function] linePlot'}
 
@@ -427,6 +432,7 @@ pipeline example {
         theme: literal<"dark", "light"> = "light"
     ) -> plot: Image
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `movingAveragePlot` {#safeds.data.tabular.plotting.TablePlotter.movingAveragePlot data-toc-label='[function] movingAveragePlot'}
 
@@ -473,6 +479,7 @@ pipeline example {
         theme: literal<"dark", "light"> = "light"
     ) -> plot: Image
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `scatterPlot` {#safeds.data.tabular.plotting.TablePlotter.scatterPlot data-toc-label='[function] scatterPlot'}
 
@@ -517,6 +524,7 @@ pipeline example {
         theme: literal<"dark", "light"> = "light"
     ) -> plot: Image
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `violinPlots` {#safeds.data.tabular.plotting.TablePlotter.violinPlots data-toc-label='[function] violinPlots'}
 
@@ -552,3 +560,4 @@ pipeline example {
         theme: literal<"dark", "light"> = "light"
     ) -> plot: Image
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/tabular/transformation/Discretizer.md
+++ b/docs/api/safeds/data/tabular/transformation/Discretizer.md
@@ -69,6 +69,7 @@ pipeline example {
         ) -> (fittedTransformer: Discretizer, transformedTable: Table)
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `binCount` {#safeds.data.tabular.transformation.Discretizer.binCount data-toc-label='[attribute] binCount'}
 
@@ -108,6 +109,7 @@ This transformer is not modified.
         table: Table
     ) -> fittedTransformer: Discretizer
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fitAndTransform` {#safeds.data.tabular.transformation.Discretizer.fitAndTransform data-toc-label='[function] fitAndTransform'}
 
@@ -137,6 +139,7 @@ Learn a transformation for a set of columns in a table and apply the learned tra
         table: Table
     ) -> (fittedTransformer: Discretizer, transformedTable: Table)
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `transform` {#safeds.data.tabular.transformation.Discretizer.transform data-toc-label='[function] transform'}
 
@@ -164,3 +167,4 @@ Apply the learned transformation to a table.
         table: Table
     ) -> transformedTable: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/tabular/transformation/FunctionalTableTransformer.md
+++ b/docs/api/safeds/data/tabular/transformation/FunctionalTableTransformer.md
@@ -45,6 +45,7 @@ Wraps a callable so that it conforms to the TableTransformer interface.
         ) -> (fittedTransformer: FunctionalTableTransformer, transformedTable: Table)
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.data.tabular.transformation.FunctionalTableTransformer.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -76,6 +77,7 @@ Whether the transformer is fitted.
         table: Table
     ) -> fittedTransformer: FunctionalTableTransformer
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fitAndTransform` {#safeds.data.tabular.transformation.FunctionalTableTransformer.fitAndTransform data-toc-label='[function] fitAndTransform'}
 
@@ -103,6 +105,7 @@ Whether the transformer is fitted.
         table: Table
     ) -> (fittedTransformer: FunctionalTableTransformer, transformedTable: Table)
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `transform` {#safeds.data.tabular.transformation.FunctionalTableTransformer.transform data-toc-label='[function] transform'}
 
@@ -130,3 +133,4 @@ Apply the learned transformation to a table.
         table: Table
     ) -> transformedTable: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/tabular/transformation/InvertibleTableTransformer.md
+++ b/docs/api/safeds/data/tabular/transformation/InvertibleTableTransformer.md
@@ -67,6 +67,7 @@ A `TableTransformer` that can also undo the learned transformation after it has 
         ) -> originalTable: Table
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.data.tabular.transformation.InvertibleTableTransformer.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -100,6 +101,7 @@ Learn a transformation for a set of columns in a table.
         table: Table
     ) -> fittedTransformer: InvertibleTableTransformer
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fitAndTransform` {#safeds.data.tabular.transformation.InvertibleTableTransformer.fitAndTransform data-toc-label='[function] fitAndTransform'}
 
@@ -129,6 +131,7 @@ Learn a transformation for a set of columns in a table and apply the learned tra
         table: Table
     ) -> (fittedTransformer: InvertibleTableTransformer, transformedTable: Table)
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `inverseTransform` {#safeds.data.tabular.transformation.InvertibleTableTransformer.inverseTransform data-toc-label='[function] inverseTransform'}
 
@@ -159,6 +162,7 @@ Column order and types may differ from the original table. Likewise, some values
         @PythonName("transformed_table") transformedTable: Table
     ) -> originalTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `transform` {#safeds.data.tabular.transformation.InvertibleTableTransformer.transform data-toc-label='[function] transform'}
 
@@ -186,3 +190,4 @@ Apply the learned transformation to a table.
         table: Table
     ) -> transformedTable: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/tabular/transformation/KNearestNeighborsImputer.md
+++ b/docs/api/safeds/data/tabular/transformation/KNearestNeighborsImputer.md
@@ -62,6 +62,7 @@ The KNearestNeighborsImputer replaces missing values in given Columns with the m
         ) -> (fittedTransformer: KNearestNeighborsImputer, transformedTable: Table)
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.data.tabular.transformation.KNearestNeighborsImputer.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -107,6 +108,7 @@ Learn a transformation for a set of columns in a table.
         table: Table
     ) -> fittedTransformer: KNearestNeighborsImputer
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fitAndTransform` {#safeds.data.tabular.transformation.KNearestNeighborsImputer.fitAndTransform data-toc-label='[function] fitAndTransform'}
 
@@ -136,6 +138,7 @@ Learn a transformation for a set of columns in a table and apply the learned tra
         table: Table
     ) -> (fittedTransformer: KNearestNeighborsImputer, transformedTable: Table)
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `transform` {#safeds.data.tabular.transformation.KNearestNeighborsImputer.transform data-toc-label='[function] transform'}
 
@@ -163,3 +166,4 @@ Apply the learned transformation to a table.
         table: Table
     ) -> transformedTable: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/tabular/transformation/LabelEncoder.md
+++ b/docs/api/safeds/data/tabular/transformation/LabelEncoder.md
@@ -69,6 +69,7 @@ pipeline example {
         ) -> (fittedTransformer: LabelEncoder, transformedTable: Table)
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.data.tabular.transformation.LabelEncoder.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -108,6 +109,7 @@ This transformer is not modified.
         table: Table
     ) -> fittedTransformer: LabelEncoder
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fitAndTransform` {#safeds.data.tabular.transformation.LabelEncoder.fitAndTransform data-toc-label='[function] fitAndTransform'}
 
@@ -137,6 +139,7 @@ Learn a transformation for a set of columns in a table and apply the learned tra
         table: Table
     ) -> (fittedTransformer: LabelEncoder, transformedTable: Table)
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `inverseTransform` {#safeds.data.tabular.transformation.LabelEncoder.inverseTransform data-toc-label='[function] inverseTransform'}
 
@@ -167,6 +170,7 @@ Column order and types may differ from the original table. Likewise, some values
         @PythonName("transformed_table") transformedTable: Table
     ) -> originalTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `transform` {#safeds.data.tabular.transformation.LabelEncoder.transform data-toc-label='[function] transform'}
 
@@ -194,3 +198,4 @@ Apply the learned transformation to a table.
         table: Table
     ) -> transformedTable: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/tabular/transformation/OneHotEncoder.md
+++ b/docs/api/safeds/data/tabular/transformation/OneHotEncoder.md
@@ -92,6 +92,7 @@ pipeline example {
         ) -> (fittedTransformer: OneHotEncoder, transformedTable: Table)
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.data.tabular.transformation.OneHotEncoder.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -131,6 +132,7 @@ This transformer is not modified.
         table: Table
     ) -> fittedTransformer: OneHotEncoder
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fitAndTransform` {#safeds.data.tabular.transformation.OneHotEncoder.fitAndTransform data-toc-label='[function] fitAndTransform'}
 
@@ -160,6 +162,7 @@ Learn a transformation for a set of columns in a table and apply the learned tra
         table: Table
     ) -> (fittedTransformer: OneHotEncoder, transformedTable: Table)
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `inverseTransform` {#safeds.data.tabular.transformation.OneHotEncoder.inverseTransform data-toc-label='[function] inverseTransform'}
 
@@ -190,6 +193,7 @@ Column order and types may differ from the original table. Likewise, some values
         @PythonName("transformed_table") transformedTable: Table
     ) -> originalTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `transform` {#safeds.data.tabular.transformation.OneHotEncoder.transform data-toc-label='[function] transform'}
 
@@ -217,3 +221,4 @@ Apply the learned transformation to a table.
         table: Table
     ) -> transformedTable: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/tabular/transformation/RangeScaler.md
+++ b/docs/api/safeds/data/tabular/transformation/RangeScaler.md
@@ -75,6 +75,7 @@ pipeline example {
         ) -> (fittedTransformer: RangeScaler, transformedTable: Table)
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.data.tabular.transformation.RangeScaler.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -120,6 +121,7 @@ This transformer is not modified.
         table: Table
     ) -> fittedTransformer: RangeScaler
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fitAndTransform` {#safeds.data.tabular.transformation.RangeScaler.fitAndTransform data-toc-label='[function] fitAndTransform'}
 
@@ -149,6 +151,7 @@ Learn a transformation for a set of columns in a table and apply the learned tra
         table: Table
     ) -> (fittedTransformer: RangeScaler, transformedTable: Table)
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `inverseTransform` {#safeds.data.tabular.transformation.RangeScaler.inverseTransform data-toc-label='[function] inverseTransform'}
 
@@ -179,6 +182,7 @@ Column order and types may differ from the original table. Likewise, some values
         @PythonName("transformed_table") transformedTable: Table
     ) -> originalTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `transform` {#safeds.data.tabular.transformation.RangeScaler.transform data-toc-label='[function] transform'}
 
@@ -206,3 +210,4 @@ Apply the learned transformation to a table.
         table: Table
     ) -> transformedTable: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/tabular/transformation/RobustScaler.md
+++ b/docs/api/safeds/data/tabular/transformation/RobustScaler.md
@@ -51,6 +51,7 @@ Currently, for columns with high stability (IQR == 0), it will only substract th
         ) -> (fittedTransformer: RobustScaler, transformedTable: Table)
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.data.tabular.transformation.RobustScaler.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -84,6 +85,7 @@ Learn a transformation for a set of columns in a table.
         table: Table
     ) -> fittedTransformer: RobustScaler
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fitAndTransform` {#safeds.data.tabular.transformation.RobustScaler.fitAndTransform data-toc-label='[function] fitAndTransform'}
 
@@ -113,6 +115,7 @@ Learn a transformation for a set of columns in a table and apply the learned tra
         table: Table
     ) -> (fittedTransformer: RobustScaler, transformedTable: Table)
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `inverseTransform` {#safeds.data.tabular.transformation.RobustScaler.inverseTransform data-toc-label='[function] inverseTransform'}
 
@@ -143,6 +146,7 @@ Column order and types may differ from the original table. Likewise, some values
         @PythonName("transformed_table") transformedTable: Table
     ) -> originalTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `transform` {#safeds.data.tabular.transformation.RobustScaler.transform data-toc-label='[function] transform'}
 
@@ -170,3 +174,4 @@ Apply the learned transformation to a table.
         table: Table
     ) -> transformedTable: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/tabular/transformation/SequentialTableTransformer.md
+++ b/docs/api/safeds/data/tabular/transformation/SequentialTableTransformer.md
@@ -47,6 +47,7 @@ The SequentialTableTransformer transforms a table using multiple transformers in
         ) -> (fittedTransformer: SequentialTableTransformer, transformedTable: Table)
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.data.tabular.transformation.SequentialTableTransformer.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -78,6 +79,7 @@ Fits all the transformers in order.
         table: Table
     ) -> fittedTransformer: SequentialTableTransformer
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fitAndTransform` {#safeds.data.tabular.transformation.SequentialTableTransformer.fitAndTransform data-toc-label='[function] fitAndTransform'}
 
@@ -107,6 +109,7 @@ Learn a transformation for a set of columns in a table and apply the learned tra
         table: Table
     ) -> (fittedTransformer: SequentialTableTransformer, transformedTable: Table)
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `inverseTransform` {#safeds.data.tabular.transformation.SequentialTableTransformer.inverseTransform data-toc-label='[function] inverseTransform'}
 
@@ -137,6 +140,7 @@ Column order and types may differ from the original table. Likewise, some values
         @PythonName("transformed_table") transformedTable: Table
     ) -> originalTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `transform` {#safeds.data.tabular.transformation.SequentialTableTransformer.transform data-toc-label='[function] transform'}
 
@@ -164,3 +168,4 @@ Apply the learned transformation to a table.
         table: Table
     ) -> transformedTable: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/tabular/transformation/SimpleImputer.md
+++ b/docs/api/safeds/data/tabular/transformation/SimpleImputer.md
@@ -112,6 +112,7 @@ pipeline example {
         ) -> (fittedTransformer: SimpleImputer, transformedTable: Table)
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.data.tabular.transformation.SimpleImputer.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -157,6 +158,7 @@ This transformer is not modified.
         table: Table
     ) -> fittedTransformer: SimpleImputer
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fitAndTransform` {#safeds.data.tabular.transformation.SimpleImputer.fitAndTransform data-toc-label='[function] fitAndTransform'}
 
@@ -186,6 +188,7 @@ Learn a transformation for a set of columns in a table and apply the learned tra
         table: Table
     ) -> (fittedTransformer: SimpleImputer, transformedTable: Table)
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `transform` {#safeds.data.tabular.transformation.SimpleImputer.transform data-toc-label='[function] transform'}
 
@@ -213,6 +216,7 @@ Apply the learned transformation to a table.
         table: Table
     ) -> transformedTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-enum"></code> `Strategy` {#safeds.data.tabular.transformation.SimpleImputer.Strategy data-toc-label='[enum] Strategy'}
 
@@ -249,6 +253,7 @@ Various strategies to replace missing values.
         Mode
     }
     ```
+    { data-search-exclude }
 
 ### <code class="doc-symbol doc-symbol-variant"></code> `Constant` {#safeds.data.tabular.transformation.SimpleImputer.Strategy.Constant data-toc-label='[variant] Constant'}
 

--- a/docs/api/safeds/data/tabular/transformation/StandardScaler.md
+++ b/docs/api/safeds/data/tabular/transformation/StandardScaler.md
@@ -62,6 +62,7 @@ pipeline example {
         ) -> (fittedTransformer: StandardScaler, transformedTable: Table)
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.data.tabular.transformation.StandardScaler.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -95,6 +96,7 @@ This transformer is not modified.
         table: Table
     ) -> fittedTransformer: StandardScaler
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fitAndTransform` {#safeds.data.tabular.transformation.StandardScaler.fitAndTransform data-toc-label='[function] fitAndTransform'}
 
@@ -124,6 +126,7 @@ Learn a transformation for a set of columns in a table and apply the learned tra
         table: Table
     ) -> (fittedTransformer: StandardScaler, transformedTable: Table)
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `inverseTransform` {#safeds.data.tabular.transformation.StandardScaler.inverseTransform data-toc-label='[function] inverseTransform'}
 
@@ -154,6 +157,7 @@ Column order and types may differ from the original table. Likewise, some values
         @PythonName("transformed_table") transformedTable: Table
     ) -> originalTable: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `transform` {#safeds.data.tabular.transformation.StandardScaler.transform data-toc-label='[function] transform'}
 
@@ -181,3 +185,4 @@ Apply the learned transformation to a table.
         table: Table
     ) -> transformedTable: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/tabular/transformation/TableTransformer.md
+++ b/docs/api/safeds/data/tabular/transformation/TableTransformer.md
@@ -71,6 +71,7 @@ Learn a transformation for a set of columns in a `Table` and transform another `
         ) -> (fittedTransformer: TableTransformer, transformedTable: Table)
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.data.tabular.transformation.TableTransformer.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -104,6 +105,7 @@ Learn a transformation for a set of columns in a table.
         table: Table
     ) -> fittedTransformer: TableTransformer
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fitAndTransform` {#safeds.data.tabular.transformation.TableTransformer.fitAndTransform data-toc-label='[function] fitAndTransform'}
 
@@ -133,6 +135,7 @@ Learn a transformation for a set of columns in a table and apply the learned tra
         table: Table
     ) -> (fittedTransformer: TableTransformer, transformedTable: Table)
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `transform` {#safeds.data.tabular.transformation.TableTransformer.transform data-toc-label='[function] transform'}
 
@@ -160,3 +163,4 @@ Apply the learned transformation to a table.
         table: Table
     ) -> transformedTable: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/data/tabular/typing/DataType.md
+++ b/docs/api/safeds/data/tabular/typing/DataType.md
@@ -23,6 +23,7 @@ The type of a column or cell in a table.
         @PythonName("is_temporal") attr isTemporal: Boolean
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isNumeric` {#safeds.data.tabular.typing.DataType.isNumeric data-toc-label='[attribute] isNumeric'}
 

--- a/docs/api/safeds/data/tabular/typing/Schema.md
+++ b/docs/api/safeds/data/tabular/typing/Schema.md
@@ -78,6 +78,7 @@ The schema of a row or table.
         fun toMap() -> data: Map<String, DataType>
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `columnNames` {#safeds.data.tabular.typing.Schema.columnNames data-toc-label='[attribute] columnNames'}
 
@@ -119,6 +120,7 @@ pipeline example {
         name: String
     ) -> type: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `hasColumn` {#safeds.data.tabular.typing.Schema.hasColumn data-toc-label='[function] hasColumn'}
 
@@ -160,6 +162,7 @@ pipeline example {
         name: String
     ) -> contains: Boolean
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toMap` {#safeds.data.tabular.typing.Schema.toMap data-toc-label='[function] toMap'}
 
@@ -187,3 +190,4 @@ pipeline example {
     @PythonName("to_dict")
     fun toMap() -> data: Map<String, DataType>
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/AnnotationTarget.md
+++ b/docs/api/safeds/lang/AnnotationTarget.md
@@ -75,6 +75,7 @@ The declaration types that can be targeted by annotations.
         TypeParameter
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-variant"></code> `Annotation` {#safeds.lang.AnnotationTarget.Annotation data-toc-label='[variant] Annotation'}
 

--- a/docs/api/safeds/lang/Any.md
+++ b/docs/api/safeds/lang/Any.md
@@ -44,6 +44,7 @@ The common superclass of all classes.
         fun toString() -> string: String
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toBoolean` {#safeds.lang.Any.toBoolean data-toc-label='[function] toBoolean'}
 
@@ -75,6 +76,7 @@ pipeline example {
     @PythonMacro("bool($this)")
     fun toBoolean() -> boolean: Boolean
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toString` {#safeds.lang.Any.toString data-toc-label='[function] toString'}
 
@@ -101,3 +103,4 @@ pipeline example {
     @PythonMacro("str($this)")
     fun toString() -> string: String
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/Boolean.md
+++ b/docs/api/safeds/lang/Boolean.md
@@ -27,3 +27,4 @@ pipeline example {
     ```sds linenums="56"
     class Boolean
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/Category.md
+++ b/docs/api/safeds/lang/Category.md
@@ -22,3 +22,4 @@ The category of a declaration. It can be used for grouping.
     ```sds linenums="20"
     annotation Category(category: DataScienceCategory)
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/DataScienceCategory.md
+++ b/docs/api/safeds/lang/DataScienceCategory.md
@@ -39,6 +39,7 @@ A step in the data science process.
         ModelEvaluation
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-variant"></code> `DataExploration` {#safeds.lang.DataScienceCategory.DataExploration data-toc-label='[variant] DataExploration'}
 

--- a/docs/api/safeds/lang/Deprecated.md
+++ b/docs/api/safeds/lang/Deprecated.md
@@ -36,3 +36,4 @@ The declaration should no longer be used.
         removalVersion: String? = null,
     )
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/Experimental.md
+++ b/docs/api/safeds/lang/Experimental.md
@@ -22,3 +22,4 @@ The declaration might change without a major version bump.
     ```sds linenums="45"
     annotation Experimental
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/Expert.md
+++ b/docs/api/safeds/lang/Expert.md
@@ -13,3 +13,4 @@ This parameter should only be used by expert users.
     ```sds linenums="8"
     annotation Expert
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/Float.md
+++ b/docs/api/safeds/lang/Float.md
@@ -41,6 +41,7 @@ pipeline example {
         fun toInt() -> int: Int
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toInt` {#safeds.lang.Float.toInt data-toc-label='[function] toInt'}
 
@@ -67,3 +68,4 @@ pipeline example {
     @PythonMacro("int($this)")
     fun toInt() -> int: Int
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/Impure.md
+++ b/docs/api/safeds/lang/Impure.md
@@ -19,3 +19,4 @@ The function has side effects and/or does not always return the same results giv
     ```sds linenums="23"
     annotation Impure(allReasons: List<ImpurityReason>)
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/ImpurityReason.md
+++ b/docs/api/safeds/lang/ImpurityReason.md
@@ -50,6 +50,7 @@ A reason why a function is impure.
         Other
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-variant"></code> `FileReadFromConstantPath` {#safeds.lang.ImpurityReason.FileReadFromConstantPath data-toc-label='[variant] FileReadFromConstantPath'}
 

--- a/docs/api/safeds/lang/Int.md
+++ b/docs/api/safeds/lang/Int.md
@@ -37,6 +37,7 @@ pipeline example {
         fun toFloat() -> float: Float
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toFloat` {#safeds.lang.Int.toFloat data-toc-label='[function] toFloat'}
 
@@ -63,6 +64,7 @@ pipeline example {
     @PythonMacro("float($this)")
     fun toFloat() -> float: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toInt` {#safeds.lang.Int.toInt data-toc-label='[function] toInt'}
 
@@ -89,3 +91,4 @@ pipeline example {
     @PythonMacro("int($this)")
     fun toInt() -> int: Int
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/List.md
+++ b/docs/api/safeds/lang/List.md
@@ -73,6 +73,7 @@ pipeline example {
         fun size() -> size: Int
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `join` {#safeds.lang.List.join data-toc-label='[function] join'}
 
@@ -110,6 +111,7 @@ pipeline example {
     @PythonMacro("$separator.join($this)")
     fun join(separator: String = ", ") -> string: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `size` {#safeds.lang.List.size data-toc-label='[function] size'}
 
@@ -136,6 +138,7 @@ pipeline example {
     @PythonMacro("len($this)")
     fun size() -> size: Int
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `slice` {#safeds.lang.List.slice data-toc-label='[function] slice'}
 
@@ -169,3 +172,4 @@ pipeline example {
     @PythonMacro("$this[$start:$end]")
     fun slice(start: Int = 0, end: Int = this.size()) -> slice: List<E>
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/Map.md
+++ b/docs/api/safeds/lang/Map.md
@@ -85,6 +85,7 @@ pipeline example {
         fun values() -> values: List<V>
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `keys` {#safeds.lang.Map.keys data-toc-label='[function] keys'}
 
@@ -116,6 +117,7 @@ pipeline example {
     @PythonMacro("list($this.keys())")
     fun keys() -> keys: List<K>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `size` {#safeds.lang.Map.size data-toc-label='[function] size'}
 
@@ -147,6 +149,7 @@ pipeline example {
     @PythonMacro("len($this)")
     fun size() -> size: Int
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `values` {#safeds.lang.Map.values data-toc-label='[function] values'}
 
@@ -178,3 +181,4 @@ pipeline example {
     @PythonMacro("list($this.values())")
     fun values() -> values: List<V>
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/Nothing.md
+++ b/docs/api/safeds/lang/Nothing.md
@@ -14,3 +14,4 @@ The common subclass of all classes.
     ```sds linenums="41"
     class Nothing
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/Number.md
+++ b/docs/api/safeds/lang/Number.md
@@ -18,3 +18,4 @@ A number.
     ```sds linenums="61"
     class Number
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/Pure.md
+++ b/docs/api/safeds/lang/Pure.md
@@ -17,3 +17,4 @@ reordering of calls or parallelization.
     ```sds linenums="12"
     annotation Pure
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/PythonMacro.md
+++ b/docs/api/safeds/lang/PythonMacro.md
@@ -25,3 +25,4 @@ call. `$this` is replaced by the receiver of the call. `$param` is replaced by t
         template: String
     )
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/PythonModule.md
+++ b/docs/api/safeds/lang/PythonModule.md
@@ -22,3 +22,4 @@ stubs.
         qualifiedName: String
     )
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/PythonName.md
+++ b/docs/api/safeds/lang/PythonName.md
@@ -28,3 +28,4 @@ The name of the corresponding API element in Python. By default, this is the nam
         name: String
     )
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/Repeatable.md
+++ b/docs/api/safeds/lang/Repeatable.md
@@ -13,3 +13,4 @@ The annotation can be called multiple times for the same declaration.
     ```sds linenums="88"
     annotation Repeatable
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/String.md
+++ b/docs/api/safeds/lang/String.md
@@ -271,6 +271,7 @@ pipeline example {
         fun toInt(base: Int = 10) -> int: Int
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `contains` {#safeds.lang.String.contains data-toc-label='[function] contains'}
 
@@ -303,6 +304,7 @@ pipeline example {
     @PythonMacro("$substring in $this")
     fun contains(substring: String) -> contains: Boolean
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `endsWith` {#safeds.lang.String.endsWith data-toc-label='[function] endsWith'}
 
@@ -335,6 +337,7 @@ pipeline example {
     @PythonMacro("$this.endswith($suffix)")
     fun endsWith(suffix: String) -> endsWith: Boolean
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `indexOf` {#safeds.lang.String.indexOf data-toc-label='[function] indexOf'}
 
@@ -367,6 +370,7 @@ pipeline example {
     @PythonMacro("$this.find($substring)")
     fun indexOf(substring: String) -> index: Int
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `lastIndexOf` {#safeds.lang.String.lastIndexOf data-toc-label='[function] lastIndexOf'}
 
@@ -399,6 +403,7 @@ pipeline example {
     @PythonMacro("$this.rfind($substring)")
     fun lastIndexOf(substring: String) -> index: Int
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `length` {#safeds.lang.String.length data-toc-label='[function] length'}
 
@@ -425,6 +430,7 @@ pipeline example {
     @PythonMacro("len($this)")
     fun length() -> length: Int
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `repeat` {#safeds.lang.String.repeat data-toc-label='[function] repeat'}
 
@@ -457,6 +463,7 @@ pipeline example {
     @PythonMacro("$this * $n")
     fun repeat(n: Int) -> repeatedString: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `replace` {#safeds.lang.String.replace data-toc-label='[function] replace'}
 
@@ -490,6 +497,7 @@ pipeline example {
     @PythonMacro("$this.replace($old, $new)")
     fun replace(old: String, new: String) -> replacedString: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `split` {#safeds.lang.String.split data-toc-label='[function] split'}
 
@@ -522,6 +530,7 @@ pipeline example {
     @PythonMacro("$this.split($separator)")
     fun split(separator: String) -> parts: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `startsWith` {#safeds.lang.String.startsWith data-toc-label='[function] startsWith'}
 
@@ -554,6 +563,7 @@ pipeline example {
     @PythonMacro("$this.startswith($prefix)")
     fun startsWith(prefix: String) -> startsWith: Boolean
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `substring` {#safeds.lang.String.substring data-toc-label='[function] substring'}
 
@@ -587,6 +597,7 @@ pipeline example {
     @PythonMacro("$this[$start:$end]")
     fun substring(start: Int = 0, end: Int = this.length()) -> substring: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toCasefolded` {#safeds.lang.String.toCasefolded data-toc-label='[function] toCasefolded'}
 
@@ -621,6 +632,7 @@ pipeline example {
     @PythonMacro("$this.casefold()")
     fun toCasefolded() -> casefolded: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toFloat` {#safeds.lang.String.toFloat data-toc-label='[function] toFloat'}
 
@@ -647,6 +659,7 @@ pipeline example {
     @PythonMacro("float($this)")
     fun toFloat() -> float: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toInt` {#safeds.lang.String.toInt data-toc-label='[function] toInt'}
 
@@ -684,6 +697,7 @@ pipeline example {
     @PythonMacro("int($this, $base)")
     fun toInt(base: Int = 10) -> int: Int
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toLowercase` {#safeds.lang.String.toLowercase data-toc-label='[function] toLowercase'}
 
@@ -717,6 +731,7 @@ pipeline example {
     @PythonMacro("$this.lower()")
     fun toLowercase() -> lowercase: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `toUppercase` {#safeds.lang.String.toUppercase data-toc-label='[function] toUppercase'}
 
@@ -750,6 +765,7 @@ pipeline example {
     @PythonMacro("$this.upper()")
     fun toUppercase() -> uppercase: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `trim` {#safeds.lang.String.trim data-toc-label='[function] trim'}
 
@@ -776,6 +792,7 @@ pipeline example {
     @PythonMacro("$this.strip()")
     fun trim() -> trimmed: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `trimEnd` {#safeds.lang.String.trimEnd data-toc-label='[function] trimEnd'}
 
@@ -802,6 +819,7 @@ pipeline example {
     @PythonMacro("$this.rstrip()")
     fun trimEnd() -> trimmed: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `trimStart` {#safeds.lang.String.trimStart data-toc-label='[function] trimStart'}
 
@@ -828,3 +846,4 @@ pipeline example {
     @PythonMacro("$this.lstrip()")
     fun trimStart() -> trimmed: String
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/Tags.md
+++ b/docs/api/safeds/lang/Tags.md
@@ -25,3 +25,4 @@ Tags to associate with a declaration. They can be used for filtering.
     ```sds linenums="71"
     annotation Tags(tags: List<String>)
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/lang/Targets.md
+++ b/docs/api/safeds/lang/Targets.md
@@ -21,3 +21,4 @@ The annotation must target only the specified declaration types. By default, any
         targets: List<AnnotationTarget>
     )
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/SupervisedModel.md
+++ b/docs/api/safeds/ml/classical/SupervisedModel.md
@@ -96,6 +96,7 @@ A model for supervised learning tasks.
         fun getTargetType() -> targetType: DataType
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.ml.classical.SupervisedModel.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -129,6 +130,7 @@ Create a copy of this model and fit it with the given training data.
         @PythonName("training_set") trainingSet: TabularDataset
     ) -> fittedModel: SupervisedModel
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeatureNames` {#safeds.ml.classical.SupervisedModel.getFeatureNames data-toc-label='[function] getFeatureNames'}
 
@@ -149,6 +151,7 @@ Return the names of the feature columns.
     @PythonName("get_feature_names")
     fun getFeatureNames() -> featureNames: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeaturesSchema` {#safeds.ml.classical.SupervisedModel.getFeaturesSchema data-toc-label='[function] getFeaturesSchema'}
 
@@ -169,6 +172,7 @@ Return the schema of the feature columns.
     @PythonName("get_features_schema")
     fun getFeaturesSchema() -> featureSchema: Schema
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetName` {#safeds.ml.classical.SupervisedModel.getTargetName data-toc-label='[function] getTargetName'}
 
@@ -189,6 +193,7 @@ Return the name of the target column.
     @PythonName("get_target_name")
     fun getTargetName() -> targetName: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetType` {#safeds.ml.classical.SupervisedModel.getTargetType data-toc-label='[function] getTargetType'}
 
@@ -209,6 +214,7 @@ Return the type of the target column.
     @PythonName("get_target_type")
     fun getTargetType() -> targetType: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.SupervisedModel.predict data-toc-label='[function] predict'}
 
@@ -236,3 +242,4 @@ Predict the target values on the given dataset.
         dataset: union<Table, TabularDataset>
     ) -> prediction: TabularDataset
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/classification/AdaBoostClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/AdaBoostClassifier.md
@@ -64,6 +64,7 @@ pipeline example {
         ) -> fittedClassifier: AdaBoostClassifier
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.ml.classical.classification.AdaBoostClassifier.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -118,6 +119,7 @@ better. Results range from 0.0 to 1.0.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> accuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `f1Score` {#safeds.ml.classical.classification.AdaBoostClassifier.f1Score data-toc-label='[function] f1Score'}
 
@@ -151,6 +153,7 @@ classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> f1Score: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fit` {#safeds.ml.classical.classification.AdaBoostClassifier.fit data-toc-label='[function] fit'}
 
@@ -178,6 +181,7 @@ This classifier is not modified.
         @PythonName("training_set") trainingSet: TabularDataset
     ) -> fittedClassifier: AdaBoostClassifier
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeatureNames` {#safeds.ml.classical.classification.AdaBoostClassifier.getFeatureNames data-toc-label='[function] getFeatureNames'}
 
@@ -198,6 +202,7 @@ Return the names of the feature columns.
     @PythonName("get_feature_names")
     fun getFeatureNames() -> featureNames: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeaturesSchema` {#safeds.ml.classical.classification.AdaBoostClassifier.getFeaturesSchema data-toc-label='[function] getFeaturesSchema'}
 
@@ -218,6 +223,7 @@ Return the schema of the feature columns.
     @PythonName("get_features_schema")
     fun getFeaturesSchema() -> featureSchema: Schema
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetName` {#safeds.ml.classical.classification.AdaBoostClassifier.getTargetName data-toc-label='[function] getTargetName'}
 
@@ -238,6 +244,7 @@ Return the name of the target column.
     @PythonName("get_target_name")
     fun getTargetName() -> targetName: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetType` {#safeds.ml.classical.classification.AdaBoostClassifier.getTargetType data-toc-label='[function] getTargetType'}
 
@@ -258,6 +265,7 @@ Return the type of the target column.
     @PythonName("get_target_type")
     fun getTargetType() -> targetType: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `precision` {#safeds.ml.classical.classification.AdaBoostClassifier.precision data-toc-label='[function] precision'}
 
@@ -290,6 +298,7 @@ better the classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> precision: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.classification.AdaBoostClassifier.predict data-toc-label='[function] predict'}
 
@@ -317,6 +326,7 @@ Predict the target values on the given dataset.
         dataset: union<Table, TabularDataset>
     ) -> prediction: TabularDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `recall` {#safeds.ml.classical.classification.AdaBoostClassifier.recall data-toc-label='[function] recall'}
 
@@ -349,6 +359,7 @@ better the classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> recall: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeMetrics` {#safeds.ml.classical.classification.AdaBoostClassifier.summarizeMetrics data-toc-label='[function] summarizeMetrics'}
 
@@ -379,3 +390,4 @@ Summarize the classifier's metrics on the given data.
         @PythonName("positive_class") positiveClass: Any
     ) -> metrics: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/classification/BaselineClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/BaselineClassifier.md
@@ -52,6 +52,7 @@ Get a baseline by fitting data on multiple different models and comparing the be
         ) -> bestMetrics: Map<String, Float>
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.ml.classical.classification.BaselineClassifier.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -85,6 +86,7 @@ The original model is not modified.
         @PythonName("train_data") trainData: TabularDataset
     ) -> trainedClassifier: BaselineClassifier
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.classification.BaselineClassifier.predict data-toc-label='[function] predict'}
 
@@ -112,3 +114,4 @@ The original Model is not modified.
         @PythonName("test_data") testData: TabularDataset
     ) -> bestMetrics: Map<String, Float>
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/classification/Classifier.md
+++ b/docs/api/safeds/ml/classical/classification/Classifier.md
@@ -132,6 +132,7 @@ A model for classification tasks.
         ) -> recall: Float
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.ml.classical.classification.Classifier.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -168,6 +169,7 @@ better. Results range from 0.0 to 1.0.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> accuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `f1Score` {#safeds.ml.classical.classification.Classifier.f1Score data-toc-label='[function] f1Score'}
 
@@ -201,6 +203,7 @@ classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> f1Score: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fit` {#safeds.ml.classical.classification.Classifier.fit data-toc-label='[function] fit'}
 
@@ -228,6 +231,7 @@ Create a copy of this model and fit it with the given training data.
         @PythonName("training_set") trainingSet: TabularDataset
     ) -> fittedModel: Classifier
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeatureNames` {#safeds.ml.classical.classification.Classifier.getFeatureNames data-toc-label='[function] getFeatureNames'}
 
@@ -248,6 +252,7 @@ Return the names of the feature columns.
     @PythonName("get_feature_names")
     fun getFeatureNames() -> featureNames: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeaturesSchema` {#safeds.ml.classical.classification.Classifier.getFeaturesSchema data-toc-label='[function] getFeaturesSchema'}
 
@@ -268,6 +273,7 @@ Return the schema of the feature columns.
     @PythonName("get_features_schema")
     fun getFeaturesSchema() -> featureSchema: Schema
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetName` {#safeds.ml.classical.classification.Classifier.getTargetName data-toc-label='[function] getTargetName'}
 
@@ -288,6 +294,7 @@ Return the name of the target column.
     @PythonName("get_target_name")
     fun getTargetName() -> targetName: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetType` {#safeds.ml.classical.classification.Classifier.getTargetType data-toc-label='[function] getTargetType'}
 
@@ -308,6 +315,7 @@ Return the type of the target column.
     @PythonName("get_target_type")
     fun getTargetType() -> targetType: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `precision` {#safeds.ml.classical.classification.Classifier.precision data-toc-label='[function] precision'}
 
@@ -340,6 +348,7 @@ better the classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> precision: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.classification.Classifier.predict data-toc-label='[function] predict'}
 
@@ -367,6 +376,7 @@ Predict the target values on the given dataset.
         dataset: union<Table, TabularDataset>
     ) -> prediction: TabularDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `recall` {#safeds.ml.classical.classification.Classifier.recall data-toc-label='[function] recall'}
 
@@ -399,6 +409,7 @@ better the classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> recall: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeMetrics` {#safeds.ml.classical.classification.Classifier.summarizeMetrics data-toc-label='[function] summarizeMetrics'}
 
@@ -429,3 +440,4 @@ Summarize the classifier's metrics on the given data.
         @PythonName("positive_class") positiveClass: Any
     ) -> metrics: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/classification/DecisionTreeClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/DecisionTreeClassifier.md
@@ -65,6 +65,7 @@ pipeline example {
         fun plot() -> plot: Image
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.ml.classical.classification.DecisionTreeClassifier.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -113,6 +114,7 @@ better. Results range from 0.0 to 1.0.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> accuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `f1Score` {#safeds.ml.classical.classification.DecisionTreeClassifier.f1Score data-toc-label='[function] f1Score'}
 
@@ -146,6 +148,7 @@ classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> f1Score: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fit` {#safeds.ml.classical.classification.DecisionTreeClassifier.fit data-toc-label='[function] fit'}
 
@@ -173,6 +176,7 @@ This classifier is not modified.
         @PythonName("training_set") trainingSet: TabularDataset
     ) -> fittedClassifier: DecisionTreeClassifier
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeatureNames` {#safeds.ml.classical.classification.DecisionTreeClassifier.getFeatureNames data-toc-label='[function] getFeatureNames'}
 
@@ -193,6 +197,7 @@ Return the names of the feature columns.
     @PythonName("get_feature_names")
     fun getFeatureNames() -> featureNames: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeaturesSchema` {#safeds.ml.classical.classification.DecisionTreeClassifier.getFeaturesSchema data-toc-label='[function] getFeaturesSchema'}
 
@@ -213,6 +218,7 @@ Return the schema of the feature columns.
     @PythonName("get_features_schema")
     fun getFeaturesSchema() -> featureSchema: Schema
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetName` {#safeds.ml.classical.classification.DecisionTreeClassifier.getTargetName data-toc-label='[function] getTargetName'}
 
@@ -233,6 +239,7 @@ Return the name of the target column.
     @PythonName("get_target_name")
     fun getTargetName() -> targetName: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetType` {#safeds.ml.classical.classification.DecisionTreeClassifier.getTargetType data-toc-label='[function] getTargetType'}
 
@@ -253,6 +260,7 @@ Return the type of the target column.
     @PythonName("get_target_type")
     fun getTargetType() -> targetType: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `plot` {#safeds.ml.classical.classification.DecisionTreeClassifier.plot data-toc-label='[function] plot'}
 
@@ -270,6 +278,7 @@ Get the image of the decision tree.
     @Pure
     fun plot() -> plot: Image
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `precision` {#safeds.ml.classical.classification.DecisionTreeClassifier.precision data-toc-label='[function] precision'}
 
@@ -302,6 +311,7 @@ better the classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> precision: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.classification.DecisionTreeClassifier.predict data-toc-label='[function] predict'}
 
@@ -329,6 +339,7 @@ Predict the target values on the given dataset.
         dataset: union<Table, TabularDataset>
     ) -> prediction: TabularDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `recall` {#safeds.ml.classical.classification.DecisionTreeClassifier.recall data-toc-label='[function] recall'}
 
@@ -361,6 +372,7 @@ better the classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> recall: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeMetrics` {#safeds.ml.classical.classification.DecisionTreeClassifier.summarizeMetrics data-toc-label='[function] summarizeMetrics'}
 
@@ -391,3 +403,4 @@ Summarize the classifier's metrics on the given data.
         @PythonName("positive_class") positiveClass: Any
     ) -> metrics: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/classification/GradientBoostingClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/GradientBoostingClassifier.md
@@ -58,6 +58,7 @@ pipeline example {
         ) -> fittedClassifier: GradientBoostingClassifier
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.ml.classical.classification.GradientBoostingClassifier.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -106,6 +107,7 @@ better. Results range from 0.0 to 1.0.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> accuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `f1Score` {#safeds.ml.classical.classification.GradientBoostingClassifier.f1Score data-toc-label='[function] f1Score'}
 
@@ -139,6 +141,7 @@ classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> f1Score: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fit` {#safeds.ml.classical.classification.GradientBoostingClassifier.fit data-toc-label='[function] fit'}
 
@@ -166,6 +169,7 @@ This classifier is not modified.
         @PythonName("training_set") trainingSet: TabularDataset
     ) -> fittedClassifier: GradientBoostingClassifier
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeatureNames` {#safeds.ml.classical.classification.GradientBoostingClassifier.getFeatureNames data-toc-label='[function] getFeatureNames'}
 
@@ -186,6 +190,7 @@ Return the names of the feature columns.
     @PythonName("get_feature_names")
     fun getFeatureNames() -> featureNames: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeaturesSchema` {#safeds.ml.classical.classification.GradientBoostingClassifier.getFeaturesSchema data-toc-label='[function] getFeaturesSchema'}
 
@@ -206,6 +211,7 @@ Return the schema of the feature columns.
     @PythonName("get_features_schema")
     fun getFeaturesSchema() -> featureSchema: Schema
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetName` {#safeds.ml.classical.classification.GradientBoostingClassifier.getTargetName data-toc-label='[function] getTargetName'}
 
@@ -226,6 +232,7 @@ Return the name of the target column.
     @PythonName("get_target_name")
     fun getTargetName() -> targetName: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetType` {#safeds.ml.classical.classification.GradientBoostingClassifier.getTargetType data-toc-label='[function] getTargetType'}
 
@@ -246,6 +253,7 @@ Return the type of the target column.
     @PythonName("get_target_type")
     fun getTargetType() -> targetType: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `precision` {#safeds.ml.classical.classification.GradientBoostingClassifier.precision data-toc-label='[function] precision'}
 
@@ -278,6 +286,7 @@ better the classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> precision: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.classification.GradientBoostingClassifier.predict data-toc-label='[function] predict'}
 
@@ -305,6 +314,7 @@ Predict the target values on the given dataset.
         dataset: union<Table, TabularDataset>
     ) -> prediction: TabularDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `recall` {#safeds.ml.classical.classification.GradientBoostingClassifier.recall data-toc-label='[function] recall'}
 
@@ -337,6 +347,7 @@ better the classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> recall: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeMetrics` {#safeds.ml.classical.classification.GradientBoostingClassifier.summarizeMetrics data-toc-label='[function] summarizeMetrics'}
 
@@ -367,3 +378,4 @@ Summarize the classifier's metrics on the given data.
         @PythonName("positive_class") positiveClass: Any
     ) -> metrics: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/classification/KNearestNeighborsClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/KNearestNeighborsClassifier.md
@@ -51,6 +51,7 @@ pipeline example {
         ) -> fittedClassifier: KNearestNeighborsClassifier
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.ml.classical.classification.KNearestNeighborsClassifier.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -93,6 +94,7 @@ better. Results range from 0.0 to 1.0.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> accuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `f1Score` {#safeds.ml.classical.classification.KNearestNeighborsClassifier.f1Score data-toc-label='[function] f1Score'}
 
@@ -126,6 +128,7 @@ classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> f1Score: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fit` {#safeds.ml.classical.classification.KNearestNeighborsClassifier.fit data-toc-label='[function] fit'}
 
@@ -153,6 +156,7 @@ This classifier is not modified.
         @PythonName("training_set") trainingSet: TabularDataset
     ) -> fittedClassifier: KNearestNeighborsClassifier
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeatureNames` {#safeds.ml.classical.classification.KNearestNeighborsClassifier.getFeatureNames data-toc-label='[function] getFeatureNames'}
 
@@ -173,6 +177,7 @@ Return the names of the feature columns.
     @PythonName("get_feature_names")
     fun getFeatureNames() -> featureNames: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeaturesSchema` {#safeds.ml.classical.classification.KNearestNeighborsClassifier.getFeaturesSchema data-toc-label='[function] getFeaturesSchema'}
 
@@ -193,6 +198,7 @@ Return the schema of the feature columns.
     @PythonName("get_features_schema")
     fun getFeaturesSchema() -> featureSchema: Schema
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetName` {#safeds.ml.classical.classification.KNearestNeighborsClassifier.getTargetName data-toc-label='[function] getTargetName'}
 
@@ -213,6 +219,7 @@ Return the name of the target column.
     @PythonName("get_target_name")
     fun getTargetName() -> targetName: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetType` {#safeds.ml.classical.classification.KNearestNeighborsClassifier.getTargetType data-toc-label='[function] getTargetType'}
 
@@ -233,6 +240,7 @@ Return the type of the target column.
     @PythonName("get_target_type")
     fun getTargetType() -> targetType: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `precision` {#safeds.ml.classical.classification.KNearestNeighborsClassifier.precision data-toc-label='[function] precision'}
 
@@ -265,6 +273,7 @@ better the classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> precision: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.classification.KNearestNeighborsClassifier.predict data-toc-label='[function] predict'}
 
@@ -292,6 +301,7 @@ Predict the target values on the given dataset.
         dataset: union<Table, TabularDataset>
     ) -> prediction: TabularDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `recall` {#safeds.ml.classical.classification.KNearestNeighborsClassifier.recall data-toc-label='[function] recall'}
 
@@ -324,6 +334,7 @@ better the classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> recall: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeMetrics` {#safeds.ml.classical.classification.KNearestNeighborsClassifier.summarizeMetrics data-toc-label='[function] summarizeMetrics'}
 
@@ -354,3 +365,4 @@ Summarize the classifier's metrics on the given data.
         @PythonName("positive_class") positiveClass: Any
     ) -> metrics: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/classification/LogisticClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/LogisticClassifier.md
@@ -51,6 +51,7 @@ pipeline example {
         ) -> fittedClassifier: LogisticClassifier
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `c` {#safeds.ml.classical.classification.LogisticClassifier.c data-toc-label='[attribute] c'}
 
@@ -93,6 +94,7 @@ better. Results range from 0.0 to 1.0.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> accuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `f1Score` {#safeds.ml.classical.classification.LogisticClassifier.f1Score data-toc-label='[function] f1Score'}
 
@@ -126,6 +128,7 @@ classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> f1Score: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fit` {#safeds.ml.classical.classification.LogisticClassifier.fit data-toc-label='[function] fit'}
 
@@ -153,6 +156,7 @@ This classifier is not modified.
         @PythonName("training_set") trainingSet: TabularDataset
     ) -> fittedClassifier: LogisticClassifier
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeatureNames` {#safeds.ml.classical.classification.LogisticClassifier.getFeatureNames data-toc-label='[function] getFeatureNames'}
 
@@ -173,6 +177,7 @@ Return the names of the feature columns.
     @PythonName("get_feature_names")
     fun getFeatureNames() -> featureNames: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeaturesSchema` {#safeds.ml.classical.classification.LogisticClassifier.getFeaturesSchema data-toc-label='[function] getFeaturesSchema'}
 
@@ -193,6 +198,7 @@ Return the schema of the feature columns.
     @PythonName("get_features_schema")
     fun getFeaturesSchema() -> featureSchema: Schema
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetName` {#safeds.ml.classical.classification.LogisticClassifier.getTargetName data-toc-label='[function] getTargetName'}
 
@@ -213,6 +219,7 @@ Return the name of the target column.
     @PythonName("get_target_name")
     fun getTargetName() -> targetName: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetType` {#safeds.ml.classical.classification.LogisticClassifier.getTargetType data-toc-label='[function] getTargetType'}
 
@@ -233,6 +240,7 @@ Return the type of the target column.
     @PythonName("get_target_type")
     fun getTargetType() -> targetType: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `precision` {#safeds.ml.classical.classification.LogisticClassifier.precision data-toc-label='[function] precision'}
 
@@ -265,6 +273,7 @@ better the classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> precision: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.classification.LogisticClassifier.predict data-toc-label='[function] predict'}
 
@@ -292,6 +301,7 @@ Predict the target values on the given dataset.
         dataset: union<Table, TabularDataset>
     ) -> prediction: TabularDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `recall` {#safeds.ml.classical.classification.LogisticClassifier.recall data-toc-label='[function] recall'}
 
@@ -324,6 +334,7 @@ better the classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> recall: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeMetrics` {#safeds.ml.classical.classification.LogisticClassifier.summarizeMetrics data-toc-label='[function] summarizeMetrics'}
 
@@ -354,3 +365,4 @@ Summarize the classifier's metrics on the given data.
         @PythonName("positive_class") positiveClass: Any
     ) -> metrics: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/classification/RandomForestClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/RandomForestClassifier.md
@@ -64,6 +64,7 @@ pipeline example {
         ) -> fittedClassifier: RandomForestClassifier
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.ml.classical.classification.RandomForestClassifier.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -118,6 +119,7 @@ better. Results range from 0.0 to 1.0.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> accuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `f1Score` {#safeds.ml.classical.classification.RandomForestClassifier.f1Score data-toc-label='[function] f1Score'}
 
@@ -151,6 +153,7 @@ classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> f1Score: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fit` {#safeds.ml.classical.classification.RandomForestClassifier.fit data-toc-label='[function] fit'}
 
@@ -178,6 +181,7 @@ This classifier is not modified.
         @PythonName("training_set") trainingSet: TabularDataset
     ) -> fittedClassifier: RandomForestClassifier
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeatureNames` {#safeds.ml.classical.classification.RandomForestClassifier.getFeatureNames data-toc-label='[function] getFeatureNames'}
 
@@ -198,6 +202,7 @@ Return the names of the feature columns.
     @PythonName("get_feature_names")
     fun getFeatureNames() -> featureNames: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeaturesSchema` {#safeds.ml.classical.classification.RandomForestClassifier.getFeaturesSchema data-toc-label='[function] getFeaturesSchema'}
 
@@ -218,6 +223,7 @@ Return the schema of the feature columns.
     @PythonName("get_features_schema")
     fun getFeaturesSchema() -> featureSchema: Schema
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetName` {#safeds.ml.classical.classification.RandomForestClassifier.getTargetName data-toc-label='[function] getTargetName'}
 
@@ -238,6 +244,7 @@ Return the name of the target column.
     @PythonName("get_target_name")
     fun getTargetName() -> targetName: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetType` {#safeds.ml.classical.classification.RandomForestClassifier.getTargetType data-toc-label='[function] getTargetType'}
 
@@ -258,6 +265,7 @@ Return the type of the target column.
     @PythonName("get_target_type")
     fun getTargetType() -> targetType: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `precision` {#safeds.ml.classical.classification.RandomForestClassifier.precision data-toc-label='[function] precision'}
 
@@ -290,6 +298,7 @@ better the classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> precision: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.classification.RandomForestClassifier.predict data-toc-label='[function] predict'}
 
@@ -317,6 +326,7 @@ Predict the target values on the given dataset.
         dataset: union<Table, TabularDataset>
     ) -> prediction: TabularDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `recall` {#safeds.ml.classical.classification.RandomForestClassifier.recall data-toc-label='[function] recall'}
 
@@ -349,6 +359,7 @@ better the classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> recall: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeMetrics` {#safeds.ml.classical.classification.RandomForestClassifier.summarizeMetrics data-toc-label='[function] summarizeMetrics'}
 
@@ -379,3 +390,4 @@ Summarize the classifier's metrics on the given data.
         @PythonName("positive_class") positiveClass: Any
     ) -> metrics: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/classification/SupportVectorClassifier.md
+++ b/docs/api/safeds/ml/classical/classification/SupportVectorClassifier.md
@@ -92,6 +92,7 @@ pipeline example {
         ) -> fittedClassifier: SupportVectorClassifier
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `c` {#safeds.ml.classical.classification.SupportVectorClassifier.c data-toc-label='[attribute] c'}
 
@@ -140,6 +141,7 @@ better. Results range from 0.0 to 1.0.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> accuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `f1Score` {#safeds.ml.classical.classification.SupportVectorClassifier.f1Score data-toc-label='[function] f1Score'}
 
@@ -173,6 +175,7 @@ classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> f1Score: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fit` {#safeds.ml.classical.classification.SupportVectorClassifier.fit data-toc-label='[function] fit'}
 
@@ -200,6 +203,7 @@ This classifier is not modified.
         @PythonName("training_set") trainingSet: TabularDataset
     ) -> fittedClassifier: SupportVectorClassifier
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeatureNames` {#safeds.ml.classical.classification.SupportVectorClassifier.getFeatureNames data-toc-label='[function] getFeatureNames'}
 
@@ -220,6 +224,7 @@ Return the names of the feature columns.
     @PythonName("get_feature_names")
     fun getFeatureNames() -> featureNames: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeaturesSchema` {#safeds.ml.classical.classification.SupportVectorClassifier.getFeaturesSchema data-toc-label='[function] getFeaturesSchema'}
 
@@ -240,6 +245,7 @@ Return the schema of the feature columns.
     @PythonName("get_features_schema")
     fun getFeaturesSchema() -> featureSchema: Schema
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetName` {#safeds.ml.classical.classification.SupportVectorClassifier.getTargetName data-toc-label='[function] getTargetName'}
 
@@ -260,6 +266,7 @@ Return the name of the target column.
     @PythonName("get_target_name")
     fun getTargetName() -> targetName: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetType` {#safeds.ml.classical.classification.SupportVectorClassifier.getTargetType data-toc-label='[function] getTargetType'}
 
@@ -280,6 +287,7 @@ Return the type of the target column.
     @PythonName("get_target_type")
     fun getTargetType() -> targetType: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `precision` {#safeds.ml.classical.classification.SupportVectorClassifier.precision data-toc-label='[function] precision'}
 
@@ -312,6 +320,7 @@ better the classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> precision: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.classification.SupportVectorClassifier.predict data-toc-label='[function] predict'}
 
@@ -339,6 +348,7 @@ Predict the target values on the given dataset.
         dataset: union<Table, TabularDataset>
     ) -> prediction: TabularDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `recall` {#safeds.ml.classical.classification.SupportVectorClassifier.recall data-toc-label='[function] recall'}
 
@@ -371,6 +381,7 @@ better the classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> recall: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeMetrics` {#safeds.ml.classical.classification.SupportVectorClassifier.summarizeMetrics data-toc-label='[function] summarizeMetrics'}
 
@@ -401,6 +412,7 @@ Summarize the classifier's metrics on the given data.
         @PythonName("positive_class") positiveClass: Any
     ) -> metrics: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-enum"></code> `Kernel` {#safeds.ml.classical.classification.SupportVectorClassifier.Kernel data-toc-label='[enum] Kernel'}
 
@@ -439,6 +451,7 @@ The kernel functions that can be used in the support vector machine.
         RadialBasisFunction
     }
     ```
+    { data-search-exclude }
 
 ### <code class="doc-symbol doc-symbol-variant"></code> `Linear` {#safeds.ml.classical.classification.SupportVectorClassifier.Kernel.Linear data-toc-label='[variant] Linear'}
 

--- a/docs/api/safeds/ml/classical/regression/AdaBoostRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/AdaBoostRegressor.md
@@ -64,6 +64,7 @@ pipeline example {
         ) -> fittedRegressor: AdaBoostRegressor
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.ml.classical.regression.AdaBoostRegressor.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -132,6 +133,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> coefficientOfDetermination: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fit` {#safeds.ml.classical.regression.AdaBoostRegressor.fit data-toc-label='[function] fit'}
 
@@ -159,6 +161,7 @@ This regressor is not modified.
         @PythonName("training_set") trainingSet: TabularDataset
     ) -> fittedRegressor: AdaBoostRegressor
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeatureNames` {#safeds.ml.classical.regression.AdaBoostRegressor.getFeatureNames data-toc-label='[function] getFeatureNames'}
 
@@ -179,6 +182,7 @@ Return the names of the feature columns.
     @PythonName("get_feature_names")
     fun getFeatureNames() -> featureNames: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeaturesSchema` {#safeds.ml.classical.regression.AdaBoostRegressor.getFeaturesSchema data-toc-label='[function] getFeaturesSchema'}
 
@@ -199,6 +203,7 @@ Return the schema of the feature columns.
     @PythonName("get_features_schema")
     fun getFeaturesSchema() -> featureSchema: Schema
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetName` {#safeds.ml.classical.regression.AdaBoostRegressor.getTargetName data-toc-label='[function] getTargetName'}
 
@@ -219,6 +224,7 @@ Return the name of the target column.
     @PythonName("get_target_name")
     fun getTargetName() -> targetName: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetType` {#safeds.ml.classical.regression.AdaBoostRegressor.getTargetType data-toc-label='[function] getTargetType'}
 
@@ -239,6 +245,7 @@ Return the type of the target column.
     @PythonName("get_target_type")
     fun getTargetType() -> targetType: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanAbsoluteError` {#safeds.ml.classical.regression.AdaBoostRegressor.meanAbsoluteError data-toc-label='[function] meanAbsoluteError'}
 
@@ -272,6 +279,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanAbsoluteError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanDirectionalAccuracy` {#safeds.ml.classical.regression.AdaBoostRegressor.meanDirectionalAccuracy data-toc-label='[function] meanDirectionalAccuracy'}
 
@@ -309,6 +317,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanDirectionalAccuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanSquaredError` {#safeds.ml.classical.regression.AdaBoostRegressor.meanSquaredError data-toc-label='[function] meanSquaredError'}
 
@@ -344,6 +353,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanSquaredError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `medianAbsoluteDeviation` {#safeds.ml.classical.regression.AdaBoostRegressor.medianAbsoluteDeviation data-toc-label='[function] medianAbsoluteDeviation'}
 
@@ -377,6 +387,7 @@ positive infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> medianAbsoluteDeviation: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.regression.AdaBoostRegressor.predict data-toc-label='[function] predict'}
 
@@ -404,6 +415,7 @@ Predict the target values on the given dataset.
         dataset: union<Table, TabularDataset>
     ) -> prediction: TabularDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeMetrics` {#safeds.ml.classical.regression.AdaBoostRegressor.summarizeMetrics data-toc-label='[function] summarizeMetrics'}
 
@@ -432,3 +444,4 @@ Summarize the regressor's metrics on the given data.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> metrics: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/regression/ArimaRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/ArimaRegressor.md
@@ -61,6 +61,7 @@ pipeline example {
         ) -> image: Image
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.ml.classical.regression.ArimaRegressor.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -94,6 +95,7 @@ This ARIMA Model is not modified.
         @PythonName("time_series") timeSeries: TimeSeriesDataset
     ) -> fittedArima: ArimaRegressor
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `plotPredictions` {#safeds.ml.classical.regression.ArimaRegressor.plotPredictions data-toc-label='[function] plotPredictions'}
 
@@ -120,6 +122,7 @@ Plot the predictions of the trained model to the given target of the time series
         @PythonName("test_series") testSeries: TimeSeriesDataset
     ) -> image: Image
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.regression.ArimaRegressor.predict data-toc-label='[function] predict'}
 
@@ -145,3 +148,4 @@ Predict a target vector using a time series target column. The model has to be t
         @PythonName("time_series") timeSeries: TimeSeriesDataset
     ) -> prediction: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/regression/BaselineRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/BaselineRegressor.md
@@ -52,6 +52,7 @@ Get a baseline by fitting data on multiple different models and comparing the be
         ) -> bestMetrics: Map<String, Float>
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.ml.classical.regression.BaselineRegressor.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -85,6 +86,7 @@ The original model is not modified.
         @PythonName("train_data") trainData: TabularDataset
     ) -> trainedClassifier: BaselineRegressor
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.regression.BaselineRegressor.predict data-toc-label='[function] predict'}
 
@@ -112,3 +114,4 @@ The original Model is not modified.
         @PythonName("test_data") testData: TabularDataset
     ) -> bestMetrics: Map<String, Float>
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/regression/DecisionTreeRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/DecisionTreeRegressor.md
@@ -65,6 +65,7 @@ pipeline example {
         fun plot() -> plot: Image
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.ml.classical.regression.DecisionTreeRegressor.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -127,6 +128,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> coefficientOfDetermination: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fit` {#safeds.ml.classical.regression.DecisionTreeRegressor.fit data-toc-label='[function] fit'}
 
@@ -154,6 +156,7 @@ This regressor is not modified.
         @PythonName("training_set") trainingSet: TabularDataset
     ) -> fittedRegressor: DecisionTreeRegressor
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeatureNames` {#safeds.ml.classical.regression.DecisionTreeRegressor.getFeatureNames data-toc-label='[function] getFeatureNames'}
 
@@ -174,6 +177,7 @@ Return the names of the feature columns.
     @PythonName("get_feature_names")
     fun getFeatureNames() -> featureNames: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeaturesSchema` {#safeds.ml.classical.regression.DecisionTreeRegressor.getFeaturesSchema data-toc-label='[function] getFeaturesSchema'}
 
@@ -194,6 +198,7 @@ Return the schema of the feature columns.
     @PythonName("get_features_schema")
     fun getFeaturesSchema() -> featureSchema: Schema
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetName` {#safeds.ml.classical.regression.DecisionTreeRegressor.getTargetName data-toc-label='[function] getTargetName'}
 
@@ -214,6 +219,7 @@ Return the name of the target column.
     @PythonName("get_target_name")
     fun getTargetName() -> targetName: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetType` {#safeds.ml.classical.regression.DecisionTreeRegressor.getTargetType data-toc-label='[function] getTargetType'}
 
@@ -234,6 +240,7 @@ Return the type of the target column.
     @PythonName("get_target_type")
     fun getTargetType() -> targetType: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanAbsoluteError` {#safeds.ml.classical.regression.DecisionTreeRegressor.meanAbsoluteError data-toc-label='[function] meanAbsoluteError'}
 
@@ -267,6 +274,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanAbsoluteError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanDirectionalAccuracy` {#safeds.ml.classical.regression.DecisionTreeRegressor.meanDirectionalAccuracy data-toc-label='[function] meanDirectionalAccuracy'}
 
@@ -304,6 +312,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanDirectionalAccuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanSquaredError` {#safeds.ml.classical.regression.DecisionTreeRegressor.meanSquaredError data-toc-label='[function] meanSquaredError'}
 
@@ -339,6 +348,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanSquaredError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `medianAbsoluteDeviation` {#safeds.ml.classical.regression.DecisionTreeRegressor.medianAbsoluteDeviation data-toc-label='[function] medianAbsoluteDeviation'}
 
@@ -372,6 +382,7 @@ positive infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> medianAbsoluteDeviation: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `plot` {#safeds.ml.classical.regression.DecisionTreeRegressor.plot data-toc-label='[function] plot'}
 
@@ -389,6 +400,7 @@ Get the image of the decision tree.
     @Pure
     fun plot() -> plot: Image
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.regression.DecisionTreeRegressor.predict data-toc-label='[function] predict'}
 
@@ -416,6 +428,7 @@ Predict the target values on the given dataset.
         dataset: union<Table, TabularDataset>
     ) -> prediction: TabularDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeMetrics` {#safeds.ml.classical.regression.DecisionTreeRegressor.summarizeMetrics data-toc-label='[function] summarizeMetrics'}
 
@@ -444,3 +457,4 @@ Summarize the regressor's metrics on the given data.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> metrics: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/regression/ElasticNetRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/ElasticNetRegressor.md
@@ -66,6 +66,7 @@ pipeline example {
         ) -> fittedRegressor: ElasticNetRegressor
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `alpha` {#safeds.ml.classical.regression.ElasticNetRegressor.alpha data-toc-label='[attribute] alpha'}
 
@@ -128,6 +129,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> coefficientOfDetermination: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fit` {#safeds.ml.classical.regression.ElasticNetRegressor.fit data-toc-label='[function] fit'}
 
@@ -155,6 +157,7 @@ This regressor is not modified.
         @PythonName("training_set") trainingSet: TabularDataset
     ) -> fittedRegressor: ElasticNetRegressor
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeatureNames` {#safeds.ml.classical.regression.ElasticNetRegressor.getFeatureNames data-toc-label='[function] getFeatureNames'}
 
@@ -175,6 +178,7 @@ Return the names of the feature columns.
     @PythonName("get_feature_names")
     fun getFeatureNames() -> featureNames: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeaturesSchema` {#safeds.ml.classical.regression.ElasticNetRegressor.getFeaturesSchema data-toc-label='[function] getFeaturesSchema'}
 
@@ -195,6 +199,7 @@ Return the schema of the feature columns.
     @PythonName("get_features_schema")
     fun getFeaturesSchema() -> featureSchema: Schema
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetName` {#safeds.ml.classical.regression.ElasticNetRegressor.getTargetName data-toc-label='[function] getTargetName'}
 
@@ -215,6 +220,7 @@ Return the name of the target column.
     @PythonName("get_target_name")
     fun getTargetName() -> targetName: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetType` {#safeds.ml.classical.regression.ElasticNetRegressor.getTargetType data-toc-label='[function] getTargetType'}
 
@@ -235,6 +241,7 @@ Return the type of the target column.
     @PythonName("get_target_type")
     fun getTargetType() -> targetType: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanAbsoluteError` {#safeds.ml.classical.regression.ElasticNetRegressor.meanAbsoluteError data-toc-label='[function] meanAbsoluteError'}
 
@@ -268,6 +275,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanAbsoluteError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanDirectionalAccuracy` {#safeds.ml.classical.regression.ElasticNetRegressor.meanDirectionalAccuracy data-toc-label='[function] meanDirectionalAccuracy'}
 
@@ -305,6 +313,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanDirectionalAccuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanSquaredError` {#safeds.ml.classical.regression.ElasticNetRegressor.meanSquaredError data-toc-label='[function] meanSquaredError'}
 
@@ -340,6 +349,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanSquaredError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `medianAbsoluteDeviation` {#safeds.ml.classical.regression.ElasticNetRegressor.medianAbsoluteDeviation data-toc-label='[function] medianAbsoluteDeviation'}
 
@@ -373,6 +383,7 @@ positive infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> medianAbsoluteDeviation: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.regression.ElasticNetRegressor.predict data-toc-label='[function] predict'}
 
@@ -400,6 +411,7 @@ Predict the target values on the given dataset.
         dataset: union<Table, TabularDataset>
     ) -> prediction: TabularDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeMetrics` {#safeds.ml.classical.regression.ElasticNetRegressor.summarizeMetrics data-toc-label='[function] summarizeMetrics'}
 
@@ -428,3 +440,4 @@ Summarize the regressor's metrics on the given data.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> metrics: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/regression/GradientBoostingRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/GradientBoostingRegressor.md
@@ -58,6 +58,7 @@ pipeline example {
         ) -> fittedRegressor: GradientBoostingRegressor
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.ml.classical.regression.GradientBoostingRegressor.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -120,6 +121,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> coefficientOfDetermination: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fit` {#safeds.ml.classical.regression.GradientBoostingRegressor.fit data-toc-label='[function] fit'}
 
@@ -147,6 +149,7 @@ This regressor is not modified.
         @PythonName("training_set") trainingSet: TabularDataset
     ) -> fittedRegressor: GradientBoostingRegressor
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeatureNames` {#safeds.ml.classical.regression.GradientBoostingRegressor.getFeatureNames data-toc-label='[function] getFeatureNames'}
 
@@ -167,6 +170,7 @@ Return the names of the feature columns.
     @PythonName("get_feature_names")
     fun getFeatureNames() -> featureNames: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeaturesSchema` {#safeds.ml.classical.regression.GradientBoostingRegressor.getFeaturesSchema data-toc-label='[function] getFeaturesSchema'}
 
@@ -187,6 +191,7 @@ Return the schema of the feature columns.
     @PythonName("get_features_schema")
     fun getFeaturesSchema() -> featureSchema: Schema
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetName` {#safeds.ml.classical.regression.GradientBoostingRegressor.getTargetName data-toc-label='[function] getTargetName'}
 
@@ -207,6 +212,7 @@ Return the name of the target column.
     @PythonName("get_target_name")
     fun getTargetName() -> targetName: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetType` {#safeds.ml.classical.regression.GradientBoostingRegressor.getTargetType data-toc-label='[function] getTargetType'}
 
@@ -227,6 +233,7 @@ Return the type of the target column.
     @PythonName("get_target_type")
     fun getTargetType() -> targetType: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanAbsoluteError` {#safeds.ml.classical.regression.GradientBoostingRegressor.meanAbsoluteError data-toc-label='[function] meanAbsoluteError'}
 
@@ -260,6 +267,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanAbsoluteError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanDirectionalAccuracy` {#safeds.ml.classical.regression.GradientBoostingRegressor.meanDirectionalAccuracy data-toc-label='[function] meanDirectionalAccuracy'}
 
@@ -297,6 +305,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanDirectionalAccuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanSquaredError` {#safeds.ml.classical.regression.GradientBoostingRegressor.meanSquaredError data-toc-label='[function] meanSquaredError'}
 
@@ -332,6 +341,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanSquaredError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `medianAbsoluteDeviation` {#safeds.ml.classical.regression.GradientBoostingRegressor.medianAbsoluteDeviation data-toc-label='[function] medianAbsoluteDeviation'}
 
@@ -365,6 +375,7 @@ positive infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> medianAbsoluteDeviation: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.regression.GradientBoostingRegressor.predict data-toc-label='[function] predict'}
 
@@ -392,6 +403,7 @@ Predict the target values on the given dataset.
         dataset: union<Table, TabularDataset>
     ) -> prediction: TabularDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeMetrics` {#safeds.ml.classical.regression.GradientBoostingRegressor.summarizeMetrics data-toc-label='[function] summarizeMetrics'}
 
@@ -420,3 +432,4 @@ Summarize the regressor's metrics on the given data.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> metrics: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/regression/KNearestNeighborsRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/KNearestNeighborsRegressor.md
@@ -51,6 +51,7 @@ pipeline example {
         ) -> fittedRegressor: KNearestNeighborsRegressor
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.ml.classical.regression.KNearestNeighborsRegressor.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -107,6 +108,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> coefficientOfDetermination: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fit` {#safeds.ml.classical.regression.KNearestNeighborsRegressor.fit data-toc-label='[function] fit'}
 
@@ -134,6 +136,7 @@ This regressor is not modified.
         @PythonName("training_set") trainingSet: TabularDataset
     ) -> fittedRegressor: KNearestNeighborsRegressor
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeatureNames` {#safeds.ml.classical.regression.KNearestNeighborsRegressor.getFeatureNames data-toc-label='[function] getFeatureNames'}
 
@@ -154,6 +157,7 @@ Return the names of the feature columns.
     @PythonName("get_feature_names")
     fun getFeatureNames() -> featureNames: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeaturesSchema` {#safeds.ml.classical.regression.KNearestNeighborsRegressor.getFeaturesSchema data-toc-label='[function] getFeaturesSchema'}
 
@@ -174,6 +178,7 @@ Return the schema of the feature columns.
     @PythonName("get_features_schema")
     fun getFeaturesSchema() -> featureSchema: Schema
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetName` {#safeds.ml.classical.regression.KNearestNeighborsRegressor.getTargetName data-toc-label='[function] getTargetName'}
 
@@ -194,6 +199,7 @@ Return the name of the target column.
     @PythonName("get_target_name")
     fun getTargetName() -> targetName: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetType` {#safeds.ml.classical.regression.KNearestNeighborsRegressor.getTargetType data-toc-label='[function] getTargetType'}
 
@@ -214,6 +220,7 @@ Return the type of the target column.
     @PythonName("get_target_type")
     fun getTargetType() -> targetType: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanAbsoluteError` {#safeds.ml.classical.regression.KNearestNeighborsRegressor.meanAbsoluteError data-toc-label='[function] meanAbsoluteError'}
 
@@ -247,6 +254,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanAbsoluteError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanDirectionalAccuracy` {#safeds.ml.classical.regression.KNearestNeighborsRegressor.meanDirectionalAccuracy data-toc-label='[function] meanDirectionalAccuracy'}
 
@@ -284,6 +292,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanDirectionalAccuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanSquaredError` {#safeds.ml.classical.regression.KNearestNeighborsRegressor.meanSquaredError data-toc-label='[function] meanSquaredError'}
 
@@ -319,6 +328,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanSquaredError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `medianAbsoluteDeviation` {#safeds.ml.classical.regression.KNearestNeighborsRegressor.medianAbsoluteDeviation data-toc-label='[function] medianAbsoluteDeviation'}
 
@@ -352,6 +362,7 @@ positive infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> medianAbsoluteDeviation: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.regression.KNearestNeighborsRegressor.predict data-toc-label='[function] predict'}
 
@@ -379,6 +390,7 @@ Predict the target values on the given dataset.
         dataset: union<Table, TabularDataset>
     ) -> prediction: TabularDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeMetrics` {#safeds.ml.classical.regression.KNearestNeighborsRegressor.summarizeMetrics data-toc-label='[function] summarizeMetrics'}
 
@@ -407,3 +419,4 @@ Summarize the regressor's metrics on the given data.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> metrics: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/regression/LassoRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/LassoRegressor.md
@@ -58,6 +58,7 @@ pipeline example {
         ) -> fittedRegressor: LassoRegressor
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `alpha` {#safeds.ml.classical.regression.LassoRegressor.alpha data-toc-label='[attribute] alpha'}
 
@@ -114,6 +115,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> coefficientOfDetermination: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fit` {#safeds.ml.classical.regression.LassoRegressor.fit data-toc-label='[function] fit'}
 
@@ -141,6 +143,7 @@ This regressor is not modified.
         @PythonName("training_set") trainingSet: TabularDataset
     ) -> fittedRegressor: LassoRegressor
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeatureNames` {#safeds.ml.classical.regression.LassoRegressor.getFeatureNames data-toc-label='[function] getFeatureNames'}
 
@@ -161,6 +164,7 @@ Return the names of the feature columns.
     @PythonName("get_feature_names")
     fun getFeatureNames() -> featureNames: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeaturesSchema` {#safeds.ml.classical.regression.LassoRegressor.getFeaturesSchema data-toc-label='[function] getFeaturesSchema'}
 
@@ -181,6 +185,7 @@ Return the schema of the feature columns.
     @PythonName("get_features_schema")
     fun getFeaturesSchema() -> featureSchema: Schema
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetName` {#safeds.ml.classical.regression.LassoRegressor.getTargetName data-toc-label='[function] getTargetName'}
 
@@ -201,6 +206,7 @@ Return the name of the target column.
     @PythonName("get_target_name")
     fun getTargetName() -> targetName: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetType` {#safeds.ml.classical.regression.LassoRegressor.getTargetType data-toc-label='[function] getTargetType'}
 
@@ -221,6 +227,7 @@ Return the type of the target column.
     @PythonName("get_target_type")
     fun getTargetType() -> targetType: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanAbsoluteError` {#safeds.ml.classical.regression.LassoRegressor.meanAbsoluteError data-toc-label='[function] meanAbsoluteError'}
 
@@ -254,6 +261,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanAbsoluteError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanDirectionalAccuracy` {#safeds.ml.classical.regression.LassoRegressor.meanDirectionalAccuracy data-toc-label='[function] meanDirectionalAccuracy'}
 
@@ -291,6 +299,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanDirectionalAccuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanSquaredError` {#safeds.ml.classical.regression.LassoRegressor.meanSquaredError data-toc-label='[function] meanSquaredError'}
 
@@ -326,6 +335,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanSquaredError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `medianAbsoluteDeviation` {#safeds.ml.classical.regression.LassoRegressor.medianAbsoluteDeviation data-toc-label='[function] medianAbsoluteDeviation'}
 
@@ -359,6 +369,7 @@ positive infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> medianAbsoluteDeviation: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.regression.LassoRegressor.predict data-toc-label='[function] predict'}
 
@@ -386,6 +397,7 @@ Predict the target values on the given dataset.
         dataset: union<Table, TabularDataset>
     ) -> prediction: TabularDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeMetrics` {#safeds.ml.classical.regression.LassoRegressor.summarizeMetrics data-toc-label='[function] summarizeMetrics'}
 
@@ -414,3 +426,4 @@ Summarize the regressor's metrics on the given data.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> metrics: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/regression/LinearRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/LinearRegressor.md
@@ -101,6 +101,7 @@ pipeline example {
         ) -> fittedRegressor: LinearRegressor
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.ml.classical.regression.LinearRegressor.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -157,6 +158,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> coefficientOfDetermination: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fit` {#safeds.ml.classical.regression.LinearRegressor.fit data-toc-label='[function] fit'}
 
@@ -184,6 +186,7 @@ This regressor is not modified.
         @PythonName("training_set") trainingSet: TabularDataset
     ) -> fittedRegressor: LinearRegressor
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeatureNames` {#safeds.ml.classical.regression.LinearRegressor.getFeatureNames data-toc-label='[function] getFeatureNames'}
 
@@ -204,6 +207,7 @@ Return the names of the feature columns.
     @PythonName("get_feature_names")
     fun getFeatureNames() -> featureNames: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeaturesSchema` {#safeds.ml.classical.regression.LinearRegressor.getFeaturesSchema data-toc-label='[function] getFeaturesSchema'}
 
@@ -224,6 +228,7 @@ Return the schema of the feature columns.
     @PythonName("get_features_schema")
     fun getFeaturesSchema() -> featureSchema: Schema
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetName` {#safeds.ml.classical.regression.LinearRegressor.getTargetName data-toc-label='[function] getTargetName'}
 
@@ -244,6 +249,7 @@ Return the name of the target column.
     @PythonName("get_target_name")
     fun getTargetName() -> targetName: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetType` {#safeds.ml.classical.regression.LinearRegressor.getTargetType data-toc-label='[function] getTargetType'}
 
@@ -264,6 +270,7 @@ Return the type of the target column.
     @PythonName("get_target_type")
     fun getTargetType() -> targetType: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanAbsoluteError` {#safeds.ml.classical.regression.LinearRegressor.meanAbsoluteError data-toc-label='[function] meanAbsoluteError'}
 
@@ -297,6 +304,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanAbsoluteError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanDirectionalAccuracy` {#safeds.ml.classical.regression.LinearRegressor.meanDirectionalAccuracy data-toc-label='[function] meanDirectionalAccuracy'}
 
@@ -334,6 +342,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanDirectionalAccuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanSquaredError` {#safeds.ml.classical.regression.LinearRegressor.meanSquaredError data-toc-label='[function] meanSquaredError'}
 
@@ -369,6 +378,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanSquaredError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `medianAbsoluteDeviation` {#safeds.ml.classical.regression.LinearRegressor.medianAbsoluteDeviation data-toc-label='[function] medianAbsoluteDeviation'}
 
@@ -402,6 +412,7 @@ positive infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> medianAbsoluteDeviation: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.regression.LinearRegressor.predict data-toc-label='[function] predict'}
 
@@ -429,6 +440,7 @@ Predict the target values on the given dataset.
         dataset: union<Table, TabularDataset>
     ) -> prediction: TabularDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeMetrics` {#safeds.ml.classical.regression.LinearRegressor.summarizeMetrics data-toc-label='[function] summarizeMetrics'}
 
@@ -457,6 +469,7 @@ Summarize the regressor's metrics on the given data.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> metrics: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-enum"></code> `Penalty` {#safeds.ml.classical.regression.LinearRegressor.Penalty data-toc-label='[enum] Penalty'}
 
@@ -514,6 +527,7 @@ Possible penalties for the linear regressor.
         }
     }
     ```
+    { data-search-exclude }
 
 ### <code class="doc-symbol doc-symbol-variant"></code> `ElasticNet` {#safeds.ml.classical.regression.LinearRegressor.Penalty.ElasticNet data-toc-label='[variant] ElasticNet'}
 

--- a/docs/api/safeds/ml/classical/regression/RandomForestRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/RandomForestRegressor.md
@@ -64,6 +64,7 @@ pipeline example {
         ) -> fittedRegressor: RandomForestRegressor
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.ml.classical.regression.RandomForestRegressor.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -132,6 +133,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> coefficientOfDetermination: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fit` {#safeds.ml.classical.regression.RandomForestRegressor.fit data-toc-label='[function] fit'}
 
@@ -159,6 +161,7 @@ This regressor is not modified.
         @PythonName("training_set") trainingSet: TabularDataset
     ) -> fittedRegressor: RandomForestRegressor
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeatureNames` {#safeds.ml.classical.regression.RandomForestRegressor.getFeatureNames data-toc-label='[function] getFeatureNames'}
 
@@ -179,6 +182,7 @@ Return the names of the feature columns.
     @PythonName("get_feature_names")
     fun getFeatureNames() -> featureNames: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeaturesSchema` {#safeds.ml.classical.regression.RandomForestRegressor.getFeaturesSchema data-toc-label='[function] getFeaturesSchema'}
 
@@ -199,6 +203,7 @@ Return the schema of the feature columns.
     @PythonName("get_features_schema")
     fun getFeaturesSchema() -> featureSchema: Schema
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetName` {#safeds.ml.classical.regression.RandomForestRegressor.getTargetName data-toc-label='[function] getTargetName'}
 
@@ -219,6 +224,7 @@ Return the name of the target column.
     @PythonName("get_target_name")
     fun getTargetName() -> targetName: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetType` {#safeds.ml.classical.regression.RandomForestRegressor.getTargetType data-toc-label='[function] getTargetType'}
 
@@ -239,6 +245,7 @@ Return the type of the target column.
     @PythonName("get_target_type")
     fun getTargetType() -> targetType: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanAbsoluteError` {#safeds.ml.classical.regression.RandomForestRegressor.meanAbsoluteError data-toc-label='[function] meanAbsoluteError'}
 
@@ -272,6 +279,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanAbsoluteError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanDirectionalAccuracy` {#safeds.ml.classical.regression.RandomForestRegressor.meanDirectionalAccuracy data-toc-label='[function] meanDirectionalAccuracy'}
 
@@ -309,6 +317,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanDirectionalAccuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanSquaredError` {#safeds.ml.classical.regression.RandomForestRegressor.meanSquaredError data-toc-label='[function] meanSquaredError'}
 
@@ -344,6 +353,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanSquaredError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `medianAbsoluteDeviation` {#safeds.ml.classical.regression.RandomForestRegressor.medianAbsoluteDeviation data-toc-label='[function] medianAbsoluteDeviation'}
 
@@ -377,6 +387,7 @@ positive infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> medianAbsoluteDeviation: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.regression.RandomForestRegressor.predict data-toc-label='[function] predict'}
 
@@ -404,6 +415,7 @@ Predict the target values on the given dataset.
         dataset: union<Table, TabularDataset>
     ) -> prediction: TabularDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeMetrics` {#safeds.ml.classical.regression.RandomForestRegressor.summarizeMetrics data-toc-label='[function] summarizeMetrics'}
 
@@ -432,3 +444,4 @@ Summarize the regressor's metrics on the given data.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> metrics: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/regression/Regressor.md
+++ b/docs/api/safeds/ml/classical/regression/Regressor.md
@@ -175,6 +175,7 @@ A model for regression tasks.
         ) -> medianAbsoluteDeviation: Float
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.ml.classical.regression.Regressor.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -225,6 +226,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> coefficientOfDetermination: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fit` {#safeds.ml.classical.regression.Regressor.fit data-toc-label='[function] fit'}
 
@@ -252,6 +254,7 @@ Create a copy of this model and fit it with the given training data.
         @PythonName("training_set") trainingSet: TabularDataset
     ) -> fittedModel: Regressor
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeatureNames` {#safeds.ml.classical.regression.Regressor.getFeatureNames data-toc-label='[function] getFeatureNames'}
 
@@ -272,6 +275,7 @@ Return the names of the feature columns.
     @PythonName("get_feature_names")
     fun getFeatureNames() -> featureNames: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeaturesSchema` {#safeds.ml.classical.regression.Regressor.getFeaturesSchema data-toc-label='[function] getFeaturesSchema'}
 
@@ -292,6 +296,7 @@ Return the schema of the feature columns.
     @PythonName("get_features_schema")
     fun getFeaturesSchema() -> featureSchema: Schema
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetName` {#safeds.ml.classical.regression.Regressor.getTargetName data-toc-label='[function] getTargetName'}
 
@@ -312,6 +317,7 @@ Return the name of the target column.
     @PythonName("get_target_name")
     fun getTargetName() -> targetName: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetType` {#safeds.ml.classical.regression.Regressor.getTargetType data-toc-label='[function] getTargetType'}
 
@@ -332,6 +338,7 @@ Return the type of the target column.
     @PythonName("get_target_type")
     fun getTargetType() -> targetType: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanAbsoluteError` {#safeds.ml.classical.regression.Regressor.meanAbsoluteError data-toc-label='[function] meanAbsoluteError'}
 
@@ -365,6 +372,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanAbsoluteError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanDirectionalAccuracy` {#safeds.ml.classical.regression.Regressor.meanDirectionalAccuracy data-toc-label='[function] meanDirectionalAccuracy'}
 
@@ -402,6 +410,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanDirectionalAccuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanSquaredError` {#safeds.ml.classical.regression.Regressor.meanSquaredError data-toc-label='[function] meanSquaredError'}
 
@@ -437,6 +446,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanSquaredError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `medianAbsoluteDeviation` {#safeds.ml.classical.regression.Regressor.medianAbsoluteDeviation data-toc-label='[function] medianAbsoluteDeviation'}
 
@@ -470,6 +480,7 @@ positive infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> medianAbsoluteDeviation: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.regression.Regressor.predict data-toc-label='[function] predict'}
 
@@ -497,6 +508,7 @@ Predict the target values on the given dataset.
         dataset: union<Table, TabularDataset>
     ) -> prediction: TabularDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeMetrics` {#safeds.ml.classical.regression.Regressor.summarizeMetrics data-toc-label='[function] summarizeMetrics'}
 
@@ -525,3 +537,4 @@ Summarize the regressor's metrics on the given data.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> metrics: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/regression/RidgeRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/RidgeRegressor.md
@@ -58,6 +58,7 @@ pipeline example {
         ) -> fittedRegressor: RidgeRegressor
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `alpha` {#safeds.ml.classical.regression.RidgeRegressor.alpha data-toc-label='[attribute] alpha'}
 
@@ -114,6 +115,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> coefficientOfDetermination: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fit` {#safeds.ml.classical.regression.RidgeRegressor.fit data-toc-label='[function] fit'}
 
@@ -141,6 +143,7 @@ This regressor is not modified.
         @PythonName("training_set") trainingSet: TabularDataset
     ) -> fittedRegressor: RidgeRegressor
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeatureNames` {#safeds.ml.classical.regression.RidgeRegressor.getFeatureNames data-toc-label='[function] getFeatureNames'}
 
@@ -161,6 +164,7 @@ Return the names of the feature columns.
     @PythonName("get_feature_names")
     fun getFeatureNames() -> featureNames: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeaturesSchema` {#safeds.ml.classical.regression.RidgeRegressor.getFeaturesSchema data-toc-label='[function] getFeaturesSchema'}
 
@@ -181,6 +185,7 @@ Return the schema of the feature columns.
     @PythonName("get_features_schema")
     fun getFeaturesSchema() -> featureSchema: Schema
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetName` {#safeds.ml.classical.regression.RidgeRegressor.getTargetName data-toc-label='[function] getTargetName'}
 
@@ -201,6 +206,7 @@ Return the name of the target column.
     @PythonName("get_target_name")
     fun getTargetName() -> targetName: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetType` {#safeds.ml.classical.regression.RidgeRegressor.getTargetType data-toc-label='[function] getTargetType'}
 
@@ -221,6 +227,7 @@ Return the type of the target column.
     @PythonName("get_target_type")
     fun getTargetType() -> targetType: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanAbsoluteError` {#safeds.ml.classical.regression.RidgeRegressor.meanAbsoluteError data-toc-label='[function] meanAbsoluteError'}
 
@@ -254,6 +261,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanAbsoluteError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanDirectionalAccuracy` {#safeds.ml.classical.regression.RidgeRegressor.meanDirectionalAccuracy data-toc-label='[function] meanDirectionalAccuracy'}
 
@@ -291,6 +299,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanDirectionalAccuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanSquaredError` {#safeds.ml.classical.regression.RidgeRegressor.meanSquaredError data-toc-label='[function] meanSquaredError'}
 
@@ -326,6 +335,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanSquaredError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `medianAbsoluteDeviation` {#safeds.ml.classical.regression.RidgeRegressor.medianAbsoluteDeviation data-toc-label='[function] medianAbsoluteDeviation'}
 
@@ -359,6 +369,7 @@ positive infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> medianAbsoluteDeviation: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.regression.RidgeRegressor.predict data-toc-label='[function] predict'}
 
@@ -386,6 +397,7 @@ Predict the target values on the given dataset.
         dataset: union<Table, TabularDataset>
     ) -> prediction: TabularDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeMetrics` {#safeds.ml.classical.regression.RidgeRegressor.summarizeMetrics data-toc-label='[function] summarizeMetrics'}
 
@@ -414,3 +426,4 @@ Summarize the regressor's metrics on the given data.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> metrics: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/classical/regression/SupportVectorRegressor.md
+++ b/docs/api/safeds/ml/classical/regression/SupportVectorRegressor.md
@@ -92,6 +92,7 @@ pipeline example {
         ) -> fittedRegressor: SupportVectorRegressor
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `c` {#safeds.ml.classical.regression.SupportVectorRegressor.c data-toc-label='[attribute] c'}
 
@@ -154,6 +155,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> coefficientOfDetermination: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `fit` {#safeds.ml.classical.regression.SupportVectorRegressor.fit data-toc-label='[function] fit'}
 
@@ -181,6 +183,7 @@ This regressor is not modified.
         @PythonName("training_set") trainingSet: TabularDataset
     ) -> fittedRegressor: SupportVectorRegressor
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeatureNames` {#safeds.ml.classical.regression.SupportVectorRegressor.getFeatureNames data-toc-label='[function] getFeatureNames'}
 
@@ -201,6 +204,7 @@ Return the names of the feature columns.
     @PythonName("get_feature_names")
     fun getFeatureNames() -> featureNames: List<String>
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getFeaturesSchema` {#safeds.ml.classical.regression.SupportVectorRegressor.getFeaturesSchema data-toc-label='[function] getFeaturesSchema'}
 
@@ -221,6 +225,7 @@ Return the schema of the feature columns.
     @PythonName("get_features_schema")
     fun getFeaturesSchema() -> featureSchema: Schema
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetName` {#safeds.ml.classical.regression.SupportVectorRegressor.getTargetName data-toc-label='[function] getTargetName'}
 
@@ -241,6 +246,7 @@ Return the name of the target column.
     @PythonName("get_target_name")
     fun getTargetName() -> targetName: String
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `getTargetType` {#safeds.ml.classical.regression.SupportVectorRegressor.getTargetType data-toc-label='[function] getTargetType'}
 
@@ -261,6 +267,7 @@ Return the type of the target column.
     @PythonName("get_target_type")
     fun getTargetType() -> targetType: DataType
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanAbsoluteError` {#safeds.ml.classical.regression.SupportVectorRegressor.meanAbsoluteError data-toc-label='[function] meanAbsoluteError'}
 
@@ -294,6 +301,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanAbsoluteError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanDirectionalAccuracy` {#safeds.ml.classical.regression.SupportVectorRegressor.meanDirectionalAccuracy data-toc-label='[function] meanDirectionalAccuracy'}
 
@@ -331,6 +339,7 @@ for other types of data. Because of this, it is not included in the `summarize_m
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanDirectionalAccuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `meanSquaredError` {#safeds.ml.classical.regression.SupportVectorRegressor.meanSquaredError data-toc-label='[function] meanSquaredError'}
 
@@ -366,6 +375,7 @@ infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> meanSquaredError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `medianAbsoluteDeviation` {#safeds.ml.classical.regression.SupportVectorRegressor.medianAbsoluteDeviation data-toc-label='[function] medianAbsoluteDeviation'}
 
@@ -399,6 +409,7 @@ positive infinity.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> medianAbsoluteDeviation: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.classical.regression.SupportVectorRegressor.predict data-toc-label='[function] predict'}
 
@@ -426,6 +437,7 @@ Predict the target values on the given dataset.
         dataset: union<Table, TabularDataset>
     ) -> prediction: TabularDataset
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `summarizeMetrics` {#safeds.ml.classical.regression.SupportVectorRegressor.summarizeMetrics data-toc-label='[function] summarizeMetrics'}
 
@@ -454,6 +466,7 @@ Summarize the regressor's metrics on the given data.
         @PythonName("validation_or_test_set") validationOrTestSet: union<Table, TabularDataset>
     ) -> metrics: Table
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-enum"></code> `Kernel` {#safeds.ml.classical.regression.SupportVectorRegressor.Kernel data-toc-label='[enum] Kernel'}
 
@@ -492,6 +505,7 @@ The kernel functions that can be used in the support vector machine.
         RadialBasisFunction
     }
     ```
+    { data-search-exclude }
 
 ### <code class="doc-symbol doc-symbol-variant"></code> `Linear` {#safeds.ml.classical.regression.SupportVectorRegressor.Kernel.Linear data-toc-label='[variant] Linear'}
 

--- a/docs/api/safeds/ml/metrics/ClassificationMetrics.md
+++ b/docs/api/safeds/ml/metrics/ClassificationMetrics.md
@@ -100,6 +100,7 @@ A collection of classification metrics.
         ) -> recall: Float
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `accuracy` {#safeds.ml.metrics.ClassificationMetrics.accuracy data-toc-label='[static-function] accuracy'}
 
@@ -130,6 +131,7 @@ better. Results range from 0.0 to 1.0.
         expected: union<Column<Any>, TabularDataset, TimeSeriesDataset>
     ) -> accuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `f1Score` {#safeds.ml.metrics.ClassificationMetrics.f1Score data-toc-label='[static-function] f1Score'}
 
@@ -163,6 +165,7 @@ classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> f1Score: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `precision` {#safeds.ml.metrics.ClassificationMetrics.precision data-toc-label='[static-function] precision'}
 
@@ -195,6 +198,7 @@ better the classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> precision: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `recall` {#safeds.ml.metrics.ClassificationMetrics.recall data-toc-label='[static-function] recall'}
 
@@ -227,6 +231,7 @@ better the classifier. Results range from 0.0 to 1.0.
         @PythonName("positive_class") positiveClass: Any
     ) -> recall: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `summarize` {#safeds.ml.metrics.ClassificationMetrics.summarize data-toc-label='[static-function] summarize'}
 
@@ -256,3 +261,4 @@ Summarize classification metrics on the given data.
         @PythonName("positive_class") positiveClass: Any
     ) -> metrics: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/metrics/RegressionMetrics.md
+++ b/docs/api/safeds/ml/metrics/RegressionMetrics.md
@@ -135,6 +135,7 @@ A collection of regression metrics.
         ) -> medianAbsoluteDeviation: Float
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `coefficientOfDetermination` {#safeds.ml.metrics.RegressionMetrics.coefficientOfDetermination data-toc-label='[static-function] coefficientOfDetermination'}
 
@@ -178,6 +179,7 @@ to 1.0. You can interpret the coefficient of determination as follows:
         expected: union<Column<Any>, TabularDataset, TimeSeriesDataset>
     ) -> coefficientOfDetermination: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `meanAbsoluteError` {#safeds.ml.metrics.RegressionMetrics.meanAbsoluteError data-toc-label='[static-function] meanAbsoluteError'}
 
@@ -210,6 +212,7 @@ infinity.
         expected: union<Column<Any>, TabularDataset, TimeSeriesDataset>
     ) -> meanAbsoluteError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `meanDirectionalAccuracy` {#safeds.ml.metrics.RegressionMetrics.meanDirectionalAccuracy data-toc-label='[static-function] meanDirectionalAccuracy'}
 
@@ -246,6 +249,7 @@ for other types of data. Because of this, it is not included in the `summarize` 
         expected: union<Column<Any>, TabularDataset, TimeSeriesDataset>
     ) -> meanDirectionalAccuracy: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `meanSquaredError` {#safeds.ml.metrics.RegressionMetrics.meanSquaredError data-toc-label='[static-function] meanSquaredError'}
 
@@ -280,6 +284,7 @@ infinity.
         expected: union<Column<Any>, TabularDataset, TimeSeriesDataset>
     ) -> meanSquaredError: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `medianAbsoluteDeviation` {#safeds.ml.metrics.RegressionMetrics.medianAbsoluteDeviation data-toc-label='[static-function] medianAbsoluteDeviation'}
 
@@ -312,6 +317,7 @@ positive infinity.
         expected: union<Column<Any>, TabularDataset, TimeSeriesDataset>
     ) -> medianAbsoluteDeviation: Float
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `summarize` {#safeds.ml.metrics.RegressionMetrics.summarize data-toc-label='[static-function] summarize'}
 
@@ -339,3 +345,4 @@ Summarize regression metrics on the given data.
         expected: union<Column<Any>, TabularDataset, TimeSeriesDataset>
     ) -> metrics: Table
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/nn/NeuralNetworkClassifier.md
+++ b/docs/api/safeds/ml/nn/NeuralNetworkClassifier.md
@@ -97,6 +97,7 @@ A NeuralNetworkClassifier is a neural network that is used for classification ta
         ) -> prediction: D
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.ml.nn.NeuralNetworkClassifier.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -151,6 +152,7 @@ pipeline example {
         batchSize >= 1
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.nn.NeuralNetworkClassifier.predict data-toc-label='[function] predict'}
 
@@ -186,6 +188,7 @@ pipeline example {
         @PythonName("test_data") testData: F
     ) -> prediction: D
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `loadPretrainedModel` {#safeds.ml.nn.NeuralNetworkClassifier.loadPretrainedModel data-toc-label='[static-function] loadPretrainedModel'}
 
@@ -212,3 +215,4 @@ Load a pretrained model from a [Huggingface repository](https://huggingface.co/m
         @PythonName("huggingface_repo") huggingfaceRepo: String
     ) -> pretrainedModel: NeuralNetworkClassifier<Any, Any>
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/nn/NeuralNetworkRegressor.md
+++ b/docs/api/safeds/ml/nn/NeuralNetworkRegressor.md
@@ -97,6 +97,7 @@ A NeuralNetworkRegressor is a neural network that is used for regression tasks.
         ) -> prediction: D
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `isFitted` {#safeds.ml.nn.NeuralNetworkRegressor.isFitted data-toc-label='[attribute] isFitted'}
 
@@ -151,6 +152,7 @@ pipeline example {
         batchSize >= 1
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-function"></code> `predict` {#safeds.ml.nn.NeuralNetworkRegressor.predict data-toc-label='[function] predict'}
 
@@ -186,6 +188,7 @@ pipeline example {
         @PythonName("test_data") testData: F
     ) -> prediction: D
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-function"></code> `loadPretrainedModel` {#safeds.ml.nn.NeuralNetworkRegressor.loadPretrainedModel data-toc-label='[static-function] loadPretrainedModel'}
 
@@ -212,3 +215,4 @@ Load a pretrained model from a [Huggingface repository](https://huggingface.co/m
         @PythonName("huggingface_repo") huggingfaceRepo: String
     ) -> pretrainedModel: NeuralNetworkRegressor<Any, Any>
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/nn/converters/InputConversion.md
+++ b/docs/api/safeds/ml/nn/converters/InputConversion.md
@@ -29,3 +29,4 @@ The input conversion for a neural network, defines the input parameters for the 
     ```sds linenums="10"
     class InputConversion<D, in F>
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/nn/converters/InputConversionImageToColumn.md
+++ b/docs/api/safeds/ml/nn/converters/InputConversionImageToColumn.md
@@ -19,3 +19,4 @@ The input conversion for a neural network, defines the input parameters for the 
         @PythonName("image_size") imageSize: ModelImageSize
     ) sub InputConversion<ImageDataset<Column>, ImageList>
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/nn/converters/InputConversionImageToImage.md
+++ b/docs/api/safeds/ml/nn/converters/InputConversionImageToImage.md
@@ -19,3 +19,4 @@ The input conversion for a neural network, defines the input parameters for the 
         @PythonName("image_size") imageSize: ModelImageSize
     ) sub InputConversion<ImageDataset<ImageList>, ImageList>
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/nn/converters/InputConversionImageToTable.md
+++ b/docs/api/safeds/ml/nn/converters/InputConversionImageToTable.md
@@ -19,3 +19,4 @@ The input conversion for a neural network, defines the input parameters for the 
         @PythonName("image_size") imageSize: ModelImageSize
     )  sub InputConversion<ImageDataset<Table>, ImageList>
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/nn/converters/InputConversionTable.md
+++ b/docs/api/safeds/ml/nn/converters/InputConversionTable.md
@@ -11,3 +11,4 @@ The input conversion for a neural network defines the input parameters for the n
     ```sds linenums="7"
     class InputConversionTable() sub InputConversion<TabularDataset, Table>
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/nn/converters/InputConversionTimeSeries.md
+++ b/docs/api/safeds/ml/nn/converters/InputConversionTimeSeries.md
@@ -11,3 +11,4 @@ The input conversion for a neural network, defines the input parameters for the 
     ```sds linenums="7"
     class InputConversionTimeSeries() sub InputConversion<TimeSeriesDataset, TimeSeriesDataset>
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/nn/layers/AveragePooling2DLayer.md
+++ b/docs/api/safeds/ml/nn/layers/AveragePooling2DLayer.md
@@ -32,6 +32,7 @@ An average pooling 2D Layer.
         @PythonName("output_size") attr outputSize: ModelImageSize
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `inputSize` {#safeds.ml.nn.layers.AveragePooling2DLayer.inputSize data-toc-label='[attribute] inputSize'}
 

--- a/docs/api/safeds/ml/nn/layers/Convolutional2DLayer.md
+++ b/docs/api/safeds/ml/nn/layers/Convolutional2DLayer.md
@@ -38,6 +38,7 @@ A convolutional 2D Layer.
         @PythonName("output_size") attr outputSize: ModelImageSize
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `inputSize` {#safeds.ml.nn.layers.Convolutional2DLayer.inputSize data-toc-label='[attribute] inputSize'}
 

--- a/docs/api/safeds/ml/nn/layers/ConvolutionalTranspose2DLayer.md
+++ b/docs/api/safeds/ml/nn/layers/ConvolutionalTranspose2DLayer.md
@@ -27,6 +27,7 @@ A convolutional transpose 2D Layer.
         @PythonName("output_padding") outputPadding: Int = 0
     ) sub Convolutional2DLayer
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `inputSize` {#safeds.ml.nn.layers.ConvolutionalTranspose2DLayer.inputSize data-toc-label='[attribute] inputSize'}
 

--- a/docs/api/safeds/ml/nn/layers/DropoutLayer.md
+++ b/docs/api/safeds/ml/nn/layers/DropoutLayer.md
@@ -24,6 +24,7 @@ A dropout layer.
         attr probability: Float
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `probability` {#safeds.ml.nn.layers.DropoutLayer.probability data-toc-label='[attribute] probability'}
 

--- a/docs/api/safeds/ml/nn/layers/FlattenLayer.md
+++ b/docs/api/safeds/ml/nn/layers/FlattenLayer.md
@@ -20,6 +20,7 @@ A flatten layer.
         @PythonName("output_size") attr outputSize: Int
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `inputSize` {#safeds.ml.nn.layers.FlattenLayer.inputSize data-toc-label='[attribute] inputSize'}
 

--- a/docs/api/safeds/ml/nn/layers/ForwardLayer.md
+++ b/docs/api/safeds/ml/nn/layers/ForwardLayer.md
@@ -30,6 +30,7 @@ A fully connected forward layer.
         @PythonName("output_size") attr outputSize: Int
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `inputSize` {#safeds.ml.nn.layers.ForwardLayer.inputSize data-toc-label='[attribute] inputSize'}
 

--- a/docs/api/safeds/ml/nn/layers/GRULayer.md
+++ b/docs/api/safeds/ml/nn/layers/GRULayer.md
@@ -28,6 +28,7 @@ A gated recurrent unit (GRU) layer.
         @PythonName("output_size") attr outputSize: Int
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `inputSize` {#safeds.ml.nn.layers.GRULayer.inputSize data-toc-label='[attribute] inputSize'}
 

--- a/docs/api/safeds/ml/nn/layers/LSTMLayer.md
+++ b/docs/api/safeds/ml/nn/layers/LSTMLayer.md
@@ -28,6 +28,7 @@ A long short-term memory (LSTM) layer.
         @PythonName("output_size") attr outputSize: Int
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `inputSize` {#safeds.ml.nn.layers.LSTMLayer.inputSize data-toc-label='[attribute] inputSize'}
 

--- a/docs/api/safeds/ml/nn/layers/Layer.md
+++ b/docs/api/safeds/ml/nn/layers/Layer.md
@@ -23,3 +23,4 @@ search:
     ```sds linenums="6"
     class Layer
     ```
+    { data-search-exclude }

--- a/docs/api/safeds/ml/nn/layers/MaxPooling2DLayer.md
+++ b/docs/api/safeds/ml/nn/layers/MaxPooling2DLayer.md
@@ -32,6 +32,7 @@ A maximum Pooling 2D Layer.
         @PythonName("output_size") attr outputSize: ModelImageSize
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `inputSize` {#safeds.ml.nn.layers.MaxPooling2DLayer.inputSize data-toc-label='[attribute] inputSize'}
 

--- a/docs/api/safeds/ml/nn/typing/ConstantImageSize.md
+++ b/docs/api/safeds/ml/nn/typing/ConstantImageSize.md
@@ -20,6 +20,7 @@ A container for constant image size in neural networks.
     ```sds linenums="7"
     class ConstantImageSize sub ModelImageSize
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `channel` {#safeds.ml.nn.typing.ConstantImageSize.channel data-toc-label='[attribute] channel'}
 

--- a/docs/api/safeds/ml/nn/typing/ModelImageSize.md
+++ b/docs/api/safeds/ml/nn/typing/ModelImageSize.md
@@ -32,6 +32,7 @@ A container for image size in neural networks.
         attr channel: Int
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `channel` {#safeds.ml.nn.typing.ModelImageSize.channel data-toc-label='[attribute] channel'}
 

--- a/docs/api/safeds/ml/nn/typing/VariableImageSize.md
+++ b/docs/api/safeds/ml/nn/typing/VariableImageSize.md
@@ -18,6 +18,7 @@ With a `VariableImageSize`, all image sizes that are a multiple of `width` and `
     ```sds linenums="9"
     class VariableImageSize sub ModelImageSize
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `channel` {#safeds.ml.nn.typing.VariableImageSize.channel data-toc-label='[attribute] channel'}
 

--- a/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
+++ b/packages/safe-ds-lang/src/language/generation/safe-ds-markdown-generator.ts
@@ -715,7 +715,7 @@ export class SafeDsMarkdownGenerator {
         const kind = isInPipelineFile(node) ? 'Implementation' : 'Stub';
 
         let result = `??? quote "${kind} code in \`${fileName}\`"\n\n`;
-        result += indent(`\`\`\`sds linenums="${startLine + 1}"\n${text}\n\`\`\``);
+        result += indent(`\`\`\`sds linenums="${startLine + 1}"\n${text}\n\`\`\`\n{ data-search-exclude }`);
 
         return result + '\n';
     }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/deprecated/generated/tests/generation/markdown/annotations/deprecated/MyAnnotation1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/deprecated/generated/tests/generation/markdown/annotations/deprecated/MyAnnotation1.md
@@ -27,3 +27,4 @@
     ```sds linenums="4"
     annotation MyAnnotation1
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/tests/generation/markdown/annotations/documented/MyAnnotation1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/tests/generation/markdown/annotations/documented/MyAnnotation1.md
@@ -25,3 +25,4 @@ Description of MyAnnotation1.
     ```sds linenums="6"
     annotation MyAnnotation1
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/tests/generation/markdown/annotations/documented/MyAnnotation2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/tests/generation/markdown/annotations/documented/MyAnnotation2.md
@@ -32,3 +32,4 @@ Description of MyAnnotation2.
     ```sds linenums="14"
     annotation MyAnnotation2(param1: MyEnum1, param2: Float = 1.0)
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/tests/generation/markdown/annotations/documented/MyAnnotation3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/tests/generation/markdown/annotations/documented/MyAnnotation3.md
@@ -13,3 +13,4 @@ Description of MyAnnotation3.
     ```sds linenums="20"
     annotation MyAnnotation3
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/tests/generation/markdown/annotations/documented/MyAnnotation4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/tests/generation/markdown/annotations/documented/MyAnnotation4.md
@@ -31,3 +31,4 @@ Description of MyAnnotation4.
     ```sds linenums="29"
     annotation MyAnnotation4
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/tests/generation/markdown/annotations/documented/MyEnum1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/documented/generated/tests/generation/markdown/annotations/documented/MyEnum1.md
@@ -7,3 +7,4 @@
     ```sds linenums="22"
     enum MyEnum1
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/experimental/generated/tests/generation/markdown/annotations/experimental/MyAnnotation1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/experimental/generated/tests/generation/markdown/annotations/experimental/MyAnnotation1.md
@@ -23,3 +23,4 @@
     ```sds linenums="4"
     annotation MyAnnotation1
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/undocumented/generated/tests/generation/markdown/annotations/undocumented/MyAnnotation1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/undocumented/generated/tests/generation/markdown/annotations/undocumented/MyAnnotation1.md
@@ -23,3 +23,4 @@
     ```sds linenums="3"
     annotation MyAnnotation1
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/undocumented/generated/tests/generation/markdown/annotations/undocumented/MyAnnotation2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/undocumented/generated/tests/generation/markdown/annotations/undocumented/MyAnnotation2.md
@@ -30,3 +30,4 @@
     ```sds linenums="5"
     annotation MyAnnotation2(param1: Int, param2: Float = 1.0)
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/undocumented/generated/tests/generation/markdown/annotations/undocumented/MyAnnotation3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/annotations/undocumented/generated/tests/generation/markdown/annotations/undocumented/MyAnnotation3.md
@@ -11,3 +11,4 @@
     ```sds linenums="8"
     annotation MyAnnotation3
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/deprecated/generated/tests/generation/markdown/classes/deprecated/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/deprecated/generated/tests/generation/markdown/classes/deprecated/MyClass1.md
@@ -16,3 +16,4 @@ search:
     ```sds linenums="4"
     class MyClass1
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass1.md
@@ -18,3 +18,4 @@ Description of MyClass1.
     ```sds linenums="6"
     class MyClass1
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass2.md
@@ -9,3 +9,4 @@ Description of MyClass2.
     ```sds linenums="11"
     class MyClass2()
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass3.md
@@ -22,3 +22,4 @@ Description of MyClass3.
     ```sds linenums="20"
     class MyClass3<TypeParam1, TypeParam2 sub MyClass1, TypeParam3 = MyClass1>
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass4.md
@@ -16,3 +16,4 @@ Description of MyClass4.
     ```sds linenums="28"
     class MyClass4(param1: MyClass1, param2: Float = 1.0)
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass5.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass5.md
@@ -16,3 +16,4 @@ Description of MyClass5.
     ```sds linenums="33"
     class MyClass5 sub MyClass1
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass6.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass6.md
@@ -57,6 +57,7 @@ Description of MyClass6.
         static attr myAttribute2: Float
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `myAttribute1` {#tests.generation.markdown.classes.documented.MyClass6.myAttribute1 data-toc-label='[attribute] myAttribute1'}
 
@@ -73,6 +74,7 @@ Description of myFunction1.
     ```sds linenums="68"
     @Pure fun myFunction1()
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-attribute"></code> `myAttribute2` {#tests.generation.markdown.classes.documented.MyClass6.myAttribute2 data-toc-label='[static-attribute] myAttribute2'}
 
@@ -89,6 +91,7 @@ Description of myFunction2.
     ```sds linenums="72"
     @Pure static fun myFunction2()
     ```
+    { data-search-exclude }
 
 ---
 search:
@@ -115,6 +118,7 @@ Description of MyClass7.
         attr myAttribute3: Int
     }
     ```
+    { data-search-exclude }
 
 ### <code class="doc-symbol doc-symbol-attribute"></code> `myAttribut4` {#tests.generation.markdown.classes.documented.MyClass6.MyClass7.myAttribut4 data-toc-label='[attribute] myAttribut4'}
 
@@ -148,6 +152,7 @@ Description of MyEnum1.
         MyVariant1
     }
     ```
+    { data-search-exclude }
 
 ### <code class="doc-symbol doc-symbol-variant"></code> `MyVariant1` {#tests.generation.markdown.classes.documented.MyClass6.MyEnum1.MyVariant1 data-toc-label='[variant] MyVariant1'}
 

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass7.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass7.md
@@ -20,3 +20,4 @@ Description of MyClass7.
     ```sds linenums="89"
     class MyClass7
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass8.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/documented/generated/tests/generation/markdown/classes/documented/MyClass8.md
@@ -21,6 +21,7 @@ Description of MyClass8.
         attr myAttribute1: MyClass1
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `myAttribute1` {#tests.generation.markdown.classes.documented.MyClass8.myAttribute1 data-toc-label='[attribute] myAttribute1'}
 
@@ -37,3 +38,4 @@ Description of myFunction1.
     ```sds linenums="68"
     @Pure fun myFunction1()
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/experimental/generated/tests/generation/markdown/classes/experimental/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/experimental/generated/tests/generation/markdown/classes/experimental/MyClass1.md
@@ -12,3 +12,4 @@ search:
     ```sds linenums="4"
     class MyClass1
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/inheritors of builtins/generated/safeds/lang/Float.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/inheritors of builtins/generated/safeds/lang/Float.md
@@ -18,3 +18,4 @@ search:
     ```sds linenums="5"
     class Float sub Number
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/inheritors of builtins/generated/safeds/lang/Number.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/inheritors of builtins/generated/safeds/lang/Number.md
@@ -16,3 +16,4 @@ search:
     ```sds linenums="3"
     class Number
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass1.md
@@ -16,3 +16,4 @@ search:
     ```sds linenums="3"
     class MyClass1
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass2.md
@@ -7,3 +7,4 @@
     ```sds linenums="5"
     class MyClass2()
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass3.md
@@ -20,3 +20,4 @@ search:
     ```sds linenums="7"
     class MyClass3<TypeParam1, TypeParam2 sub Int, TypeParam3 = Int>
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass4.md
@@ -14,3 +14,4 @@
     ```sds linenums="9"
     class MyClass4(param1: Int, param2: Float = 1.0)
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass5.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass5.md
@@ -14,3 +14,4 @@ search:
     ```sds linenums="11"
     class MyClass5 sub MyClass1
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass6.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass6.md
@@ -22,6 +22,7 @@
         }
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `myAttribute1` {#tests.generation.markdown.classes.undocumented.MyClass6.myAttribute1 data-toc-label='[attribute] myAttribute1'}
 
@@ -34,6 +35,7 @@
     ```sds linenums="17"
     @Pure fun myFunction1()
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-static-attribute"></code> `myAttribute2` {#tests.generation.markdown.classes.undocumented.MyClass6.myAttribute2 data-toc-label='[static-attribute] myAttribute2'}
 
@@ -46,6 +48,7 @@
     ```sds linenums="18"
     @Pure static fun myFunction2()
     ```
+    { data-search-exclude }
 
 ---
 search:
@@ -59,6 +62,7 @@ search:
     ```sds linenums="20"
     class MyClass7
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-enum"></code> `MyEnum1` {#tests.generation.markdown.classes.undocumented.MyClass6.MyEnum1 data-toc-label='[enum] MyEnum1'}
 
@@ -69,5 +73,6 @@ search:
         MyVariant1
     }
     ```
+    { data-search-exclude }
 
 ### <code class="doc-symbol doc-symbol-variant"></code> `MyVariant1` {#tests.generation.markdown.classes.undocumented.MyClass6.MyEnum1.MyVariant1 data-toc-label='[variant] MyVariant1'}

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass7.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/classes/undocumented/generated/tests/generation/markdown/classes/undocumented/MyClass7.md
@@ -18,6 +18,7 @@ Description of MyClass7.
         attr myAttribute1: Int
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-attribute"></code> `myAttribute1` {#tests.generation.markdown.classes.undocumented.MyClass7.myAttribute1 data-toc-label='[attribute] myAttribute1'}
 
@@ -30,3 +31,4 @@ Description of MyClass7.
     ```sds linenums="17"
     @Pure fun myFunction1()
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema1.md
@@ -11,3 +11,4 @@
     ```sds linenums="4"
     schema MySchema1 {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema2.md
@@ -13,3 +13,4 @@
     ```sds linenums="9"
     schema MySchema2 {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema3.md
@@ -13,3 +13,4 @@
     ```sds linenums="14"
     schema MySchema3 {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema4.md
@@ -11,3 +11,4 @@
     ```sds linenums="19"
     schema MySchema4 {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema5.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema5.md
@@ -11,3 +11,4 @@
     ```sds linenums="24"
     schema MySchema5 {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema6.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/deprecated/generated/tests/generation/markdown/deprecated/MySchema6.md
@@ -14,3 +14,4 @@
     ```sds linenums="32"
     schema MySchema6 {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/deprecated/generated/tests/generation/markdown/enums/deprecated/MyEnum1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/deprecated/generated/tests/generation/markdown/enums/deprecated/MyEnum1.md
@@ -11,3 +11,4 @@
     ```sds linenums="4"
     enum MyEnum1
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyClass1.md
@@ -12,3 +12,4 @@ search:
     ```sds linenums="33"
     class MyClass1
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyEnum1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyEnum1.md
@@ -9,3 +9,4 @@ Description of MyEnum1.
     ```sds linenums="6"
     enum MyEnum1
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyEnum2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyEnum2.md
@@ -29,6 +29,7 @@ Description of MyEnum2.
         MyVariant3
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-variant"></code> `MyVariant1` {#tests.generation.markdown.enums.documented.MyEnum2.MyVariant1 data-toc-label='[variant] MyVariant1'}
 

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyEnum3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/documented/generated/tests/generation/markdown/enums/documented/MyEnum3.md
@@ -15,3 +15,4 @@ Description of MyEnum3.
     ```sds linenums="40"
     enum MyEnum3
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/experimental/generated/tests/generation/markdown/enums/experimental/MyEnum1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/experimental/generated/tests/generation/markdown/enums/experimental/MyEnum1.md
@@ -7,3 +7,4 @@
     ```sds linenums="4"
     enum MyEnum1
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/undocumented/generated/tests/generation/markdown/enums/undocumented/MyEnum1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/undocumented/generated/tests/generation/markdown/enums/undocumented/MyEnum1.md
@@ -7,3 +7,4 @@
     ```sds linenums="3"
     enum MyEnum1
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/enums/undocumented/generated/tests/generation/markdown/enums/undocumented/MyEnum2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/enums/undocumented/generated/tests/generation/markdown/enums/undocumented/MyEnum2.md
@@ -10,6 +10,7 @@
         MyVariant1
     }
     ```
+    { data-search-exclude }
 
 ## <code class="doc-symbol doc-symbol-variant"></code> `MyVariant1` {#tests.generation.markdown.enums.undocumented.MyEnum2.MyVariant1 data-toc-label='[variant] MyVariant1'}
 

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/examples/generated/tests/generation/markdown/examples/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/examples/generated/tests/generation/markdown/examples/MyClass1.md
@@ -18,3 +18,4 @@ Do not highlight.
     ```sds linenums="7"
     class MyClass1
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/examples/generated/tests/generation/markdown/examples/MyClass2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/examples/generated/tests/generation/markdown/examples/MyClass2.md
@@ -18,3 +18,4 @@ Highlight MyClass2.
     ```sds linenums="13"
     class MyClass2
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/examples/generated/tests/generation/markdown/examples/MyClass3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/examples/generated/tests/generation/markdown/examples/MyClass3.md
@@ -19,3 +19,4 @@ Highlight MyClass3.
     ```sds linenums="20"
     class MyClass3
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/examples/generated/tests/generation/markdown/examples/MyClass4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/examples/generated/tests/generation/markdown/examples/MyClass4.md
@@ -18,3 +18,4 @@ Do not hightligt PrefixMyClass4.
     ```sds linenums="26"
     class MyClass4
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/examples/generated/tests/generation/markdown/examples/MyClass5.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/examples/generated/tests/generation/markdown/examples/MyClass5.md
@@ -18,3 +18,4 @@ Do not hightligt MyClass5Suffix.
     ```sds linenums="32"
     class MyClass5
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/deprecated/generated/tests/generation/markdown/functions/deprecated/myFunction1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/deprecated/generated/tests/generation/markdown/functions/deprecated/myFunction1.md
@@ -11,3 +11,4 @@
     ```sds linenums="5"
     fun myFunction1()
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/MyClass1.md
@@ -12,3 +12,4 @@ search:
     ```sds linenums="49"
     class MyClass1
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/myFunction1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/myFunction1.md
@@ -9,3 +9,4 @@ Description of myFunction1.
     ```sds linenums="7"
     fun myFunction1()
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/myFunction2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/myFunction2.md
@@ -29,3 +29,4 @@ Description of myFunction2.
         param3: TypeParam3,
     )
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/myFunction3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/myFunction3.md
@@ -16,3 +16,4 @@ Description of myFunction3.
     ```sds linenums="30"
     fun myFunction3(param1: MyClass1, param2: Float = 1.0)
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/myFunction4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/myFunction4.md
@@ -16,3 +16,4 @@ Description of myFunction4.
     ```sds linenums="39"
     fun myFunction4() -> (result1: MyClass1, result2: Float)
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/myFunction5.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/documented/generated/tests/generation/markdown/functions/documented/myFunction5.md
@@ -15,3 +15,4 @@ Description of myFunction5.
     ```sds linenums="47"
     fun myFunction5()
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/experimental/generated/tests/generation/markdown/functions/experimental/myFunction1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/experimental/generated/tests/generation/markdown/functions/experimental/myFunction1.md
@@ -7,3 +7,4 @@
     ```sds linenums="5"
     fun myFunction1()
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/undocumented/generated/tests/generation/markdown/functions/undocumented/myFunction1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/undocumented/generated/tests/generation/markdown/functions/undocumented/myFunction1.md
@@ -7,3 +7,4 @@
     ```sds linenums="4"
     fun myFunction1()
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/undocumented/generated/tests/generation/markdown/functions/undocumented/myFunction2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/undocumented/generated/tests/generation/markdown/functions/undocumented/myFunction2.md
@@ -27,3 +27,4 @@
         param3: TypeParam3,
     )
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/undocumented/generated/tests/generation/markdown/functions/undocumented/myFunction3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/undocumented/generated/tests/generation/markdown/functions/undocumented/myFunction3.md
@@ -14,3 +14,4 @@
     ```sds linenums="14"
     fun myFunction3(param1: Int, param2: Float = 1.0)
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/functions/undocumented/generated/tests/generation/markdown/functions/undocumented/myFunction4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/functions/undocumented/generated/tests/generation/markdown/functions/undocumented/myFunction4.md
@@ -14,3 +14,4 @@
     ```sds linenums="17"
     fun myFunction4() -> (result1: Int, result2: Float)
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/link tag/generated/tests/generation/markdown/linkTag/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/link tag/generated/tests/generation/markdown/linkTag/MyClass1.md
@@ -17,3 +17,4 @@ Broken.
     ```sds linenums="10"
     class MyClass1(param1: Int)
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/link tag/generated/tests/generation/markdown/linkTag/MyClass2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/link tag/generated/tests/generation/markdown/linkTag/MyClass2.md
@@ -12,3 +12,4 @@ search:
     ```sds linenums="12"
     class MyClass2
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/multiline/generated/tests/generation/markdown/multiline/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/multiline/generated/tests/generation/markdown/multiline/MyClass1.md
@@ -18,3 +18,4 @@ $$
     ```sds linenums="10"
     class MyClass1
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/multiline/generated/tests/generation/markdown/multiline/MyClass2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/multiline/generated/tests/generation/markdown/multiline/MyClass2.md
@@ -16,3 +16,4 @@ Description of MyClass2.
     ```sds linenums="26"
     class MyClass2(param1: Int, param2: Int)
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/pipelines/generated/tests/generation/markdown/pipelines/mySegment1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/pipelines/generated/tests/generation/markdown/pipelines/mySegment1.md
@@ -7,3 +7,4 @@
     ```sds linenums="6"
     segment mySegment1() {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/deprecated/generated/tests/generation/markdown/schemas/deprecated/MySchema1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/deprecated/generated/tests/generation/markdown/schemas/deprecated/MySchema1.md
@@ -11,3 +11,4 @@
     ```sds linenums="4"
     schema MySchema1 {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/tests/generation/markdown/schemas/documented/MyClass.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/tests/generation/markdown/schemas/documented/MyClass.md
@@ -12,3 +12,4 @@ search:
     ```sds linenums="25"
     class MyClass
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/tests/generation/markdown/schemas/documented/MySchema1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/tests/generation/markdown/schemas/documented/MySchema1.md
@@ -9,3 +9,4 @@ Description of MySchema1.
     ```sds linenums="8"
     schema MySchema1 {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/tests/generation/markdown/schemas/documented/MySchema2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/tests/generation/markdown/schemas/documented/MySchema2.md
@@ -19,3 +19,4 @@ Description of MySchema2.
         "column2": Int,
     }
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/tests/generation/markdown/schemas/documented/MySchema3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/documented/generated/tests/generation/markdown/schemas/documented/MySchema3.md
@@ -15,3 +15,4 @@ Description of MySchema3.
     ```sds linenums="23"
     schema MySchema3 {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/experimental/generated/tests/generation/markdown/schemas/experimental/MySchema1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/experimental/generated/tests/generation/markdown/schemas/experimental/MySchema1.md
@@ -7,3 +7,4 @@
     ```sds linenums="4"
     schema MySchema1 {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/undocumented/generated/tests/generation/markdown/schemas/undocumented/MySchema1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/undocumented/generated/tests/generation/markdown/schemas/undocumented/MySchema1.md
@@ -7,3 +7,4 @@
     ```sds linenums="3"
     schema MySchema1 {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/undocumented/generated/tests/generation/markdown/schemas/undocumented/MySchema2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/schemas/undocumented/generated/tests/generation/markdown/schemas/undocumented/MySchema2.md
@@ -17,3 +17,4 @@
         "column2": Int
     }
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/deprecated/generated/tests/generation/markdown/segments/deprecated/mySegment1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/deprecated/generated/tests/generation/markdown/segments/deprecated/mySegment1.md
@@ -11,3 +11,4 @@
     ```sds linenums="4"
     segment mySegment1() {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/MyClass1.md
@@ -7,3 +7,4 @@
     ```sds linenums="3"
     class MyClass1()
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment1.md
@@ -9,3 +9,4 @@ Description of mySegment1.
     ```sds linenums="6"
     segment mySegment1() {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment3.md
@@ -9,3 +9,4 @@ Description of mySegment3.
     ```sds linenums="16"
     internal segment mySegment3() {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment4.md
@@ -16,3 +16,4 @@ Description of mySegment4.
     ```sds linenums="24"
     segment mySegment4(param1: MyClass1, param2: Float = 1.0) {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment5.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment5.md
@@ -19,3 +19,4 @@ Description of mySegment5.
         yield result2 = 2.0;
     }
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment6.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/documented/generated/tests/generation/markdown/segments/documented/mySegment6.md
@@ -15,3 +15,4 @@ Description of mySegment6.
     ```sds linenums="42"
     segment mySegment6() {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/experimental/generated/tests/generation/markdown/segments/experimental/mySegment1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/experimental/generated/tests/generation/markdown/segments/experimental/mySegment1.md
@@ -7,3 +7,4 @@
     ```sds linenums="4"
     segment mySegment1() {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/undocumented/generated/tests/generation/markdown/segments/undocumented/mySegment1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/undocumented/generated/tests/generation/markdown/segments/undocumented/mySegment1.md
@@ -7,3 +7,4 @@
     ```sds linenums="3"
     segment mySegment1() {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/undocumented/generated/tests/generation/markdown/segments/undocumented/mySegment3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/undocumented/generated/tests/generation/markdown/segments/undocumented/mySegment3.md
@@ -7,3 +7,4 @@
     ```sds linenums="7"
     internal segment mySegment3() {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/undocumented/generated/tests/generation/markdown/segments/undocumented/mySegment4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/undocumented/generated/tests/generation/markdown/segments/undocumented/mySegment4.md
@@ -14,3 +14,4 @@
     ```sds linenums="9"
     segment mySegment4(param1: Int, param2: Float = 1.0) {}
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/segments/undocumented/generated/tests/generation/markdown/segments/undocumented/mySegment5.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/segments/undocumented/generated/tests/generation/markdown/segments/undocumented/mySegment5.md
@@ -17,3 +17,4 @@
         yield result2 = 2.0;
     }
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/MyClass1.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/MyClass1.md
@@ -12,3 +12,4 @@ search:
     ```sds linenums="3"
     class MyClass1
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/MyClass2.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/MyClass2.md
@@ -12,3 +12,4 @@ search:
     ```sds linenums="5"
     class MyClass2
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/MyClass3.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/MyClass3.md
@@ -12,3 +12,4 @@ search:
     ```sds linenums="3"
     class MyClass3
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/subpackage/MyClass5.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package1/subpackage/MyClass5.md
@@ -12,3 +12,4 @@ search:
     ```sds linenums="3"
     class MyClass5
     ```
+    { data-search-exclude }

--- a/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package2/MyClass4.md
+++ b/packages/safe-ds-lang/tests/resources/generation/markdown/summary/generated/tests/generation/markdown/summary/package2/MyClass4.md
@@ -12,3 +12,4 @@ search:
     ```sds linenums="3"
     class MyClass4
     ```
+    { data-search-exclude }


### PR DESCRIPTION
### Summary of Changes

When searching for names of API elements, the search previously only showed the stub/implementation code blocks. This was confusing and unhelpful, since users would rather see a description of the API element.

This PR, hence, excludes the code blocks from search, which also reduces the size of the search index and speeds up the search as a side effect.
