### PR TITLE
feat: disable inlay hints for assignee types by default

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -7,15 +7,15 @@ To set up a powerful _integrated development environment_ (_IDE_) for Safe-DS, f
 
 To run Safe-DS programs, you also need the [Safe-DS Runner](https://github.com/Safe-DS/Runner):
 
-1. **Install [Python](https://www.python.org/) (3.11 or 3.12)**. Make sure to add Python to your
-   system's `PATH` during installation. Verify installation by running `python --version` in a
-   command line. You should get output similar to `Python 3.12.2`.
+1. **Install [Python](https://www.python.org/) (3.11 or 3.12)**. Make sure to add Python to your system's `PATH` during
+   installation. Verify installation by running `python --version` in a command line. You should get output similar to
+   `Python 3.12.2`.
 2. **Open VS Code**.
 3. **Open the command palette** (Menu bar > View > Command Palette).
-4. **Type `Install the Safe-DS Runner`**.
+4. **Type `Install the Safe-DS Runner`** and **Press ++enter++**.
 5. **Select where to install the Safe-DS Runner**.
-6. **Press ++enter++**. Installation may take a few minutes, since it downloads and installs several large libraries
-   like PyTorch.
+
+Installation may take a few minutes, since it downloads and installs several large libraries like PyTorch.
 
 ## Updating the Safe-DS Extension
 

--- a/packages/safe-ds-vscode/README.md
+++ b/packages/safe-ds-vscode/README.md
@@ -1,7 +1,7 @@
 # Safe-DS
 
-Safely develop Data Science programs with a statically checked domain specific language (DSL) and integrated tools for data
-inspection.
+Safely develop Data Science programs with a statically checked domain specific language (DSL) and integrated tools for
+data inspection.
 
 ![demo](https://github.com/Safe-DS/DSL/raw/main/docs/img/home/demo.gif)
 
@@ -14,15 +14,15 @@ To set up a powerful _integrated development environment_ (_IDE_) for Safe-DS, f
 
 To run Safe-DS programs, you also need the [Safe-DS Runner](https://github.com/Safe-DS/Runner):
 
-1. **Install [Python](https://www.python.org/) (3.11 or 3.12)**. Make sure to add Python to your
-   system's `PATH` during installation. Verify installation by running `python --version` in a
-   command line. You should get output similar to `Python 3.12.2`.
+1. **Install [Python](https://www.python.org/) (3.11 or 3.12)**. Make sure to add Python to your system's `PATH` during
+   installation. Verify installation by running `python --version` in a command line. You should get output similar to
+   `Python 3.12.2`.
 2. **Open VS Code**.
 3. **Open the command palette** (Menu bar > View > Command Palette).
-4. **Type `Install the Safe-DS Runner`**.
+4. **Type `Install the Safe-DS Runner`** and **Press Enter**.
 5. **Select where to install the Safe-DS Runner**.
-6. **Press Enter**. Installation may take a few minutes, since it downloads and installs several large libraries
-   like PyTorch.
+
+Installation may take a few minutes, since it downloads and installs several large libraries like PyTorch.
 
 ## Documentation
 

--- a/packages/safe-ds-vscode/package.json
+++ b/packages/safe-ds-vscode/package.json
@@ -136,7 +136,7 @@
             "properties": {
                 "safe-ds.inlayHints.assigneeTypes.enabled": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "Show inferred types for named assignees."
                 },
                 "safe-ds.inlayHints.lambdaParameterTypes.enabled": {


### PR DESCRIPTION
### Summary of Changes

Disable inlay hints for assignee types by default. These were confusing for novices, who tried to type them out when they created their first assignments, given an example.
