### PR TITLE
feat: improve error messages from linker

### DIFF
--- a/packages/safe-ds-cli/tests/cli/main.test.ts
+++ b/packages/safe-ds-cli/tests/cli/main.test.ts
@@ -150,7 +150,7 @@ describe('safe-ds', () => {
         it('should show an error if a Safe-DS file has errors', () => {
             const process = spawnDocumentProcess([], ['.']);
             expect(process.stderr.toString()).toContain(
-                "Could not resolve reference to SdsNamedTypeDeclaration named 'Unresolved'",
+                "Could not find a declaration named 'Unresolved' in this context.",
             );
             expect(process.status).toBe(ExitCode.FileHasErrors);
         });
@@ -259,7 +259,7 @@ describe('safe-ds', () => {
         it('should show an error if a Safe-DS file has errors', () => {
             const process = spawnGenerateProcess([], ['.']);
             expect(process.stderr.toString()).toContain(
-                "Could not resolve reference to SdsNamedTypeDeclaration named 'Unresolved'",
+                "Could not find a declaration named 'Unresolved' in this context.",
             );
             expect(process.status).toBe(ExitCode.FileHasErrors);
         });

--- a/packages/safe-ds-lang/src/language/safe-ds-module.ts
+++ b/packages/safe-ds-lang/src/language/safe-ds-module.ts
@@ -57,6 +57,7 @@ import { SafeDsServiceRegistry } from './safe-ds-service-registry.js';
 import { SafeDsPythonServer } from './runtime/safe-ds-python-server.js';
 import { SafeDsSlicer } from './flow/safe-ds-slicer.js';
 import { SafeDsSyntheticProperties } from './helpers/safe-ds-synthetic-properties.js';
+import { SafeDsLinker } from './scoping/safe-ds-linker.js';
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -184,6 +185,7 @@ export const SafeDsModule: Module<SafeDsServices, PartialLangiumServices & SafeD
         PurityComputer: (services) => new SafeDsPurityComputer(services),
     },
     references: {
+        Linker: (services) => new SafeDsLinker(services),
         ScopeComputation: (services) => new SafeDsScopeComputation(services),
         ScopeProvider: (services) => new SafeDsScopeProvider(services),
     },

--- a/packages/safe-ds-lang/src/language/scoping/safe-ds-linker.ts
+++ b/packages/safe-ds-lang/src/language/scoping/safe-ds-linker.ts
@@ -1,0 +1,34 @@
+import { AstNodeDescription, DefaultLinker, isLinkingError, LinkingError, ReferenceInfo } from 'langium';
+import { isSdsMemberAccess, isSdsReference } from '../generated/ast.js';
+
+export class SafeDsLinker extends DefaultLinker {
+    override getCandidate(refInfo: ReferenceInfo): AstNodeDescription | LinkingError {
+        const superResult = super.getCandidate(refInfo);
+
+        if (!isLinkingError(superResult)) {
+            return superResult;
+        }
+
+        const node = refInfo.container;
+
+        // Create a default error message
+        const message = `Could not find a declaration named '${refInfo.reference.$refText}' in this context.`;
+        let resolution = 'Did you spell the name correctly and add all needed imports?';
+
+        // Improve the error message if Python keywords False, True, or None are used as references
+        if (isSdsReference(node) && refInfo.property === 'target' && !isSdsMemberAccess(node.$container)) {
+            if (refInfo.reference.$refText === 'False') {
+                resolution = "Did you mean to write 'false'?";
+            } else if (refInfo.reference.$refText === 'True') {
+                resolution = "Did you mean to write 'true'?";
+            } else if (refInfo.reference.$refText === 'None') {
+                resolution = "Did you mean to write 'null'?";
+            }
+        }
+
+        return {
+            ...superResult,
+            message: `${message}\n${resolution}`,
+        };
+    }
+}

--- a/packages/safe-ds-lang/tests/resources/validation/linking/default error/main.sds
+++ b/packages/safe-ds-lang/tests/resources/validation/linking/default error/main.sds
@@ -1,0 +1,6 @@
+package tests.validation.linking.defaultError
+
+pipeline test {
+    // $TEST$ error r"Could not find a declaration named 'Unknown' in this context\.\nDid you spell the name correctly and add all needed imports\?"
+    »Unknown«;
+}

--- a/packages/safe-ds-lang/tests/resources/validation/linking/usage of python keywords/main.sds
+++ b/packages/safe-ds-lang/tests/resources/validation/linking/usage of python keywords/main.sds
@@ -1,0 +1,21 @@
+package tests.validation.linking.usageOfPythonKeywords
+
+pipeline test {
+    // $TEST$ error r"Did you mean to write 'false'\?"
+    out »False«;
+
+    // $TEST$ error r"Did you mean to write 'true'\?"
+    out »True«;
+
+    // $TEST$ error r"Did you mean to write 'null'\?"
+    out »None«;
+
+    // $TEST$ no error r"Did you mean to write 'false'\?"
+    out a.»False«;
+
+    // $TEST$ no error r"Did you mean to write 'true'\?"
+    out a.»True«;
+
+    // $TEST$ no error r"Did you mean to write 'null'\?"
+    out a».None«;
+}


### PR DESCRIPTION
Closes #1268

### Summary of Changes

* Improve default error message of the linker.
* Add a default resolution to the message that might solve the issue (check spelling and imports).
* Add special resolutions, if users likely used Python keywords instead of Safe-DS keywords by accident (e.g. `True` instead of `true`).
