### PR TITLE
feat: prevent editing built-in stubs

### DIFF
--- a/packages/safe-ds-vscode/package.json
+++ b/packages/safe-ds-vscode/package.json
@@ -223,6 +223,9 @@
                 "editor.wordBasedSuggestions": "off",
                 "editor.wordSeparators": "`~!@#%^&*()-=+[]{}\\|;:'\",.<>/?»«",
                 "files.trimTrailingWhitespace": true
+            },
+            "files.readonlyInclude": {
+                "**/dist/resources/builtins/**/*.sdsstub": true
             }
         },
         "commands": [

--- a/packages/safe-ds-vscode/package.json
+++ b/packages/safe-ds-vscode/package.json
@@ -217,21 +217,7 @@
             }
         },
         "configurationDefaults": {
-            "[safe-ds]": {
-                "editor.semanticHighlighting.enabled": true,
-                "editor.suggest.snippetsPreventQuickSuggestions": true,
-                "editor.wordBasedSuggestions": "off",
-                "editor.wordSeparators": "`~!@#%^&*()-=+[]{}\\|;:'\",.<>/?»«",
-                "files.trimTrailingWhitespace": true
-            },
-            "[safe-ds-stub]": {
-                "editor.semanticHighlighting.enabled": true,
-                "editor.suggest.snippetsPreventQuickSuggestions": true,
-                "editor.wordBasedSuggestions": "off",
-                "editor.wordSeparators": "`~!@#%^&*()-=+[]{}\\|;:'\",.<>/?»«",
-                "files.trimTrailingWhitespace": true
-            },
-            "[safe-ds-dev]": {
+            "[safe-ds][safe-ds-stub][safe-ds-dev]": {
                 "editor.semanticHighlighting.enabled": true,
                 "editor.suggest.snippetsPreventQuickSuggestions": true,
                 "editor.wordBasedSuggestions": "off",


### PR DESCRIPTION
### Summary of Changes

Prevent accidental edits to built-in stubs by marking them as read-only by default. 

Unfortunately, if users specify their own value for the `files.readonlyInclude` setting, our default gets overwritten completely and stubs can be edited again. But it is the best we can do currently.

Scoping the setting to a Safe-DS language variant did not work. Stubs were still editable again afterward.