### PR TITLE
feat: show placeholders in outline

### DIFF
--- a/packages/safe-ds-lang/src/language/lsp/safe-ds-document-symbol-provider.ts
+++ b/packages/safe-ds-lang/src/language/lsp/safe-ds-document-symbol-provider.ts
@@ -5,6 +5,7 @@ import {
     isSdsAttribute,
     isSdsClass,
     isSdsEnumVariant,
+    isSdsExpression,
     isSdsFunction,
     isSdsPipeline,
     isSdsSegment,
@@ -52,6 +53,18 @@ export class SafeDsDocumentSymbolProvider extends DefaultDocumentSymbolProvider 
             } else {
                 return undefined;
             }
+        } else if (isSdsPipeline(node)) {
+            if (node.body) {
+                return super.getChildSymbols(document, node.body);
+            } else {
+                return undefined;
+            }
+        } else if (isSdsSegment(node)) {
+            if (node.body) {
+                return super.getChildSymbols(document, node.body);
+            } else {
+                return undefined;
+            }
         } else {
             return super.getChildSymbols(document, node);
         }
@@ -62,9 +75,8 @@ export class SafeDsDocumentSymbolProvider extends DefaultDocumentSymbolProvider 
             isSdsAnnotation(node) ||
             isSdsAttribute(node) ||
             isSdsEnumVariant(node) ||
-            isSdsFunction(node) ||
-            isSdsPipeline(node) ||
-            isSdsSegment(node)
+            isSdsExpression(node) ||
+            isSdsFunction(node)
         );
     }
 }

--- a/packages/safe-ds-lang/tests/language/lsp/safe-ds-document-symbol-provider.test.ts
+++ b/packages/safe-ds-lang/tests/language/lsp/safe-ds-document-symbol-provider.test.ts
@@ -137,6 +137,7 @@ describe('SafeDsSemanticTokenProvider', async () => {
                     val a = 1;
 
                     (q: Int) {
+                        val b = 1;
                         yield r = 1;
                     };
                 }
@@ -145,6 +146,12 @@ describe('SafeDsSemanticTokenProvider', async () => {
                 {
                     name: 'p',
                     kind: SymbolKind.Function,
+                    children: [
+                        {
+                            name: 'a',
+                            kind: SymbolKind.Variable,
+                        },
+                    ],
                 },
             ],
         },
@@ -155,6 +162,7 @@ describe('SafeDsSemanticTokenProvider', async () => {
                     val a = 1;
 
                     (p: Int) {
+                        val b = 1;
                         yield r = 1;
                     };
                 }
@@ -164,6 +172,12 @@ describe('SafeDsSemanticTokenProvider', async () => {
                     name: 's',
                     kind: SymbolKind.Function,
                     detail: '(p: Int) -> (r: Int)',
+                    children: [
+                        {
+                            name: 'a',
+                            kind: SymbolKind.Variable,
+                        },
+                    ],
                 },
             ],
         },


### PR DESCRIPTION
### Summary of Changes

Placeholders that are defined directly inside the body of a pipeline or segment are now included in the outline. It is also possible to search for them using the command palette. For example, `@trainingSet` searches for any symbol named `trainingSet`, which now includes placeholders.