### PR TITLE
fix: subtype check for literal and union types

### DIFF
--- a/packages/safe-ds-lang/tests/language/typing/type checker/isSubOrSupertypeOf.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/type checker/isSubOrSupertypeOf.test.ts
@@ -508,6 +508,11 @@ const basic = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             type2: factory.createUnionType(coreTypes.String),
             expected: false,
         },
+        {
+            type1: factory.createLiteralType(new IntConstant(1n), new StringConstant('')),
+            type2: factory.createUnionType(coreTypes.Int, coreTypes.String),
+            expected: true,
+        },
         // Literal type to other
         {
             type1: factory.createLiteralType(), // Empty literal type


### PR DESCRIPTION
### Summary of Changes

Previously, the type checker incorrectly showed an error in the following program at the call marked with the arrow:

```
package bug

@Pure fun bug1(p: union<Int, String>)
@Pure fun bug2() -> r: literal<1, "">

pipeline bug3 {
    val a = bug2();
    bug1(a); // <----
}
```

This was caused because the quantifiers when comparing literal and union types were in the wrong order: 

- We checked whether there was an option in the union type that all constants of the literal type could be assigned to.
- Now we check whether, for each constant of the literal type, there is an option in the union type they could be assigned to.