### PR TITLE
fix: subtype check for literal and union types (part 2)

### DIFF
--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-checker.ts
@@ -280,8 +280,14 @@ export class SafeDsTypeChecker {
     }
 
     private constantIsSubtypeOf(constant: Constant, other: Type, options: TypeCheckOptions): boolean {
-        const classType = this.typeComputer().computeClassTypeForConstant(constant);
-        return this.isSubtypeOf(classType, other, options);
+        if (other instanceof ClassType) {
+            const classType = this.typeComputer().computeClassTypeForConstant(constant);
+            return this.isSubtypeOf(classType, other, options);
+        } else if (other instanceof LiteralType) {
+            return other.constants.some((otherConstant) => constant.equals(otherConstant));
+        } else {
+            return false;
+        }
     }
 
     private namedTupleTypeIsSubtypeOf(

--- a/packages/safe-ds-lang/tests/language/typing/type checker/isSubOrSupertypeOf.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/type checker/isSubOrSupertypeOf.test.ts
@@ -513,6 +513,14 @@ const basic = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             type2: factory.createUnionType(coreTypes.Int, coreTypes.String),
             expected: true,
         },
+        {
+            type1: factory.createLiteralType(new IntConstant(1n), new StringConstant('')),
+            type2: factory.createUnionType(
+                factory.createLiteralType(new IntConstant(1n)),
+                factory.createLiteralType(new StringConstant('')),
+            ),
+            expected: true,
+        },
         // Literal type to other
         {
             type1: factory.createLiteralType(), // Empty literal type

--- a/packages/safe-ds-lang/tests/language/typing/type checker/isSubOrSupertypeOf.test.ts
+++ b/packages/safe-ds-lang/tests/language/typing/type checker/isSubOrSupertypeOf.test.ts
@@ -521,6 +521,11 @@ const basic = async (): Promise<IsSubOrSupertypeOfTest[]> => {
             ),
             expected: true,
         },
+        {
+            type1: factory.createLiteralType(new IntConstant(1n)),
+            type2: factory.createUnionType(factory.createNamedTupleType()),
+            expected: false,
+        },
         // Literal type to other
         {
             type1: factory.createLiteralType(), // Empty literal type


### PR DESCRIPTION
### Summary of Changes

The type checker previously did not regard `literal<1, "">` as a subtype of `union<literal<1>, literal<"">`. This is fixed now.
