### PR TITLE
ci: dependency groups for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,26 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  # root
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'monthly'
+    commit-message:
+      prefix: 'build'
+      include: 'scope'
+
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'monthly'
     versioning-strategy: 'increase'
+    commit-message:
+      prefix: 'build'
+      include: 'scope'
 
-  # docs
   - package-ecosystem: 'pip'
     directory: '/docs'
     schedule:
       interval: 'monthly'
+    commit-message:
+      prefix: 'build'
+      include: 'scope'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,41 @@
 version: 2
 updates:
-  - package-ecosystem: 'github-actions'
+  - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: monthly
     commit-message:
       prefix: 'build'
-      include: 'scope'
+      include: scope
 
-  - package-ecosystem: 'npm'
+  - package-ecosystem: npm
     directory: '/'
     schedule:
-      interval: 'monthly'
-    versioning-strategy: 'increase'
+      interval: monthly
+    versioning-strategy: increase
     commit-message:
       prefix: 'build'
-      include: 'scope'
+      include: scope
+    groups:
+      development:
+        applies-to: version-updates
+        dependency-type: development
+        update-types:
+          - patch
+          - minor
 
-  - package-ecosystem: 'pip'
+  - package-ecosystem: pip
     directory: '/docs'
     schedule:
-      interval: 'monthly'
+      interval: monthly
     commit-message:
       prefix: 'build'
-      include: 'scope'
+      include: scope
+    groups:
+      mkdocs:
+        applies-to: version-updates
+        patterns:
+          - 'mkdocs*'
+        update-types:
+          - patch
+          - minor


### PR DESCRIPTION
### Summary of Changes

Create a few groups for Dependabot to reduce the number of PRs it creates.
