### PR TITLE
fix: allow callable types and union types in type aliases

### DIFF
--- a/packages/safe-ds-lang/src/language/validation/other/types/getNodesToCheckForContext.ts
+++ b/packages/safe-ds-lang/src/language/validation/other/types/getNodesToCheckForContext.ts
@@ -14,11 +14,13 @@ export const getNodesToCheckForContextProvider = (services: SafeDsServices) => {
                 .flatMap((it) => {
                     const document = langiumDocuments.getDocument(it.sourceUri);
                     if (!document) {
+                        /* c8 ignore next 2 */
                         return [];
                     }
 
                     const root = document.parseResult?.value;
                     if (!root) {
+                        /* c8 ignore next 2 */
                         return [];
                     }
 

--- a/packages/safe-ds-lang/src/language/validation/other/types/getNodesToCheckForContext.ts
+++ b/packages/safe-ds-lang/src/language/validation/other/types/getNodesToCheckForContext.ts
@@ -1,0 +1,32 @@
+import { isSdsTypeAlias, SdsType } from '../../../generated/ast.js';
+import { AstNode } from 'langium';
+import { SafeDsServices } from '../../../safe-ds-module.js';
+
+export const getNodesToCheckForContextProvider = (services: SafeDsServices) => {
+    const langiumDocuments = services.shared.workspace.LangiumDocuments;
+    const locator = services.workspace.AstNodeLocator;
+    const referenceProvider = services.references.References;
+
+    return (node: SdsType): AstNode[] => {
+        if (isSdsTypeAlias(node.$container)) {
+            return referenceProvider
+                .findReferences(node.$container, { includeDeclaration: false })
+                .flatMap((it) => {
+                    const document = langiumDocuments.getDocument(it.sourceUri);
+                    if (!document) {
+                        return [];
+                    }
+
+                    const root = document.parseResult?.value;
+                    if (!root) {
+                        return [];
+                    }
+
+                    return locator.getAstNode(root, it.sourcePath) ?? [];
+                })
+                .toArray();
+        } else {
+            return [node];
+        }
+    };
+};

--- a/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
+++ b/packages/safe-ds-lang/src/language/validation/safe-ds-validator.ts
@@ -248,7 +248,7 @@ export const registerValidationChecks = function (services: SafeDsServices) {
             callReceiverMustBeCallable(services),
         ],
         SdsCallableType: [
-            callableTypeMustBeUsedInCorrectContext,
+            callableTypeMustBeUsedInCorrectContext(services),
             callableTypeMustContainUniqueNames,
             callableTypeMustNotHaveOptionalParameters,
             callableTypeParametersMustNotBeAnnotated,
@@ -390,7 +390,7 @@ export const registerValidationChecks = function (services: SafeDsServices) {
             typeParameterListShouldNotBeEmpty(services),
         ],
         SdsUnionType: [
-            unionTypeMustBeUsedInCorrectContext,
+            unionTypeMustBeUsedInCorrectContext(services),
             unionTypeMustHaveTypes,
             unionTypesShouldBeUsedWithCaution(services),
             unionTypeShouldNotHaveDuplicateTypes(services),

--- a/packages/safe-ds-lang/tests/resources/validation/other/types/callable types/context/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/validation/other/types/callable types/context/main.sdsdev
@@ -1,68 +1,100 @@
 package tests.validation.other.types.callableTypes.context
 
+// $TEST$ no error "Callable types must only be used for parameters."
+typealias Alias = »() -> ()«
+
 annotation MyAnnotation(
     // $TEST$ no error "Callable types must only be used for parameters."
-    p: »() -> ()«,
+    p1: »() -> ()«,
+    // $TEST$ no error "Callable types must only be used for parameters."
+    p2: »Alias«,
 )
 
 class MyClass<T>(
     // $TEST$ no error "Callable types must only be used for parameters."
-    p: »() -> ()«,
+    p1: »() -> ()«,
+    // $TEST$ no error "Callable types must only be used for parameters."
+    p2: »Alias«,
 ) {
     // $TEST$ error "Callable types must only be used for parameters."
-    attr a: »() -> ()«
+    attr a1: »() -> ()«
+    // $TEST$ error "Callable types must only be used for parameters."
+    attr a2: »Alias«
 }
 
 enum MyEnum {
     MyEnumVariant(
         // $TEST$ no error "Callable types must only be used for parameters."
-        p: »() -> ()«,
+        p1: »() -> ()«,
+        // $TEST$ no error "Callable types must only be used for parameters."
+        p2: »Alias«,
     )
 }
 
 fun myFunction(
     // $TEST$ no error "Callable types must only be used for parameters."
-    p: »() -> ()«,
+    p1: »() -> ()«,
+    // $TEST$ no error "Callable types must only be used for parameters."
+    p2: »Alias«,
 ) -> (
     // $TEST$ error "Callable types must only be used for parameters."
-    r: »() -> ()«,
+    r1: »() -> ()«,
+    // $TEST$ error "Callable types must only be used for parameters."
+    r2: »Alias«,
 )
 
 segment mySegment1(
     // $TEST$ no error "Callable types must only be used for parameters."
-    p: »() -> ()«,
+    p1: »() -> ()«,
+    // $TEST$ no error "Callable types must only be used for parameters."
+    p2: »Alias«,
 ) -> (
     // $TEST$ error "Callable types must only be used for parameters."
-    r: »() -> ()«,
+    r1: »() -> ()«,
+    // $TEST$ error "Callable types must only be used for parameters."
+    r2: »Alias«,
 ) {}
 
 segment mySegment2(
     // $TEST$ no error "Callable types must only be used for parameters."
     // $TEST$ error "Callable types must only be used for parameters."
-    c: (p: »() -> ()«) -> (r: »() -> ()«),
+    c1: (p: »() -> ()«) -> (r: »() -> ()«),
+    // $TEST$ no error "Callable types must only be used for parameters."
+    // $TEST$ error "Callable types must only be used for parameters."
+    c2: (p: »Alias«) -> (r: »Alias«),
 ) {
     // $TEST$ no error "Callable types must only be used for parameters."
+    // $TEST$ no error "Callable types must only be used for parameters."
     (
-        p: »() -> ()«,
+        p1: »() -> ()«,
+        p2: »Alias«,
     ) {};
 
     // $TEST$ no error "Callable types must only be used for parameters."
+    // $TEST$ no error "Callable types must only be used for parameters."
     (
-        p: »() -> ()«,
+        p1: »() -> ()«,
+        p2: »Alias«,
     ) -> 1;
 }
 
 segment mySegment3(
     // $TEST$ error "Callable types must only be used for parameters."
     p1: MyClass<»() -> ()«>,
+    // $TEST$ error "Callable types must only be used for parameters."
+    p2: MyClass<»Alias«>,
 ) {}
 
 segment mySegment4(
     // $TEST$ error "Callable types must only be used for parameters."
-    p1: »() -> ()«.MyClass
+    p1: »() -> ()«.MyClass,
+    // $TEST$ error "Callable types must only be used for parameters."
+    p2: Alias.MyClass
 ) {}
 
 segment mySegment5(
     // $TEST$ error "Callable types must only be used for parameters."
-    p1: union<»() -> ()«>
+    p1: union<»() -> ()«>,
+    // $TEST$ error "Callable types must only be used for parameters."
+    p2: union<»Alias«>
 ) {}

--- a/packages/safe-ds-lang/tests/resources/validation/other/types/callable types/context/nested.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/validation/other/types/callable types/context/nested.sdsdev
@@ -6,11 +6,16 @@ package tests.validation.other.types.callableTypes.context
 
 class MyClass1 {
     // $TEST$ no error "Callable types must only be used for parameters."
-    attr a: () -> (r: »() -> ()«)
+    attr a1: () -> (r: »() -> ()«)
+    // $TEST$ no error "Callable types must only be used for parameters."
+    attr a2: () -> (r: »Alias«)
 }
 
 class MyClass2 {
     // $TEST$ no error "Callable types must only be used for parameters."
     // $TEST$ no error "Callable types must only be used for parameters."
-    attr a: () -> (r: (p: »() -> ()«) -> (r: »() -> ()«))
+    attr a1: () -> (r: (p: »() -> ()«) -> (r: »() -> ()«))
+    // $TEST$ no error "Callable types must only be used for parameters."
+    // $TEST$ no error "Callable types must only be used for parameters."
+    attr a2: () -> (r: (p: »Alias«) -> (r: »Alias«))
 }

--- a/packages/safe-ds-lang/tests/resources/validation/other/types/union types/context/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/validation/other/types/union types/context/main.sdsdev
@@ -1,63 +1,93 @@
 package tests.validation.other.types.unionTypes.context
 
+// $TEST$ no error "Union types must only be used for parameters of annotations, classes, and functions."
+typealias Alias = »union<Int>«
+
 annotation MyAnnotation(
     // $TEST$ no error "Union types must only be used for parameters of annotations, classes, and functions."
-    p: »union<Int>«,
+    p1: »union<Int>«,
+    // $TEST$ no error "Union types must only be used for parameters of annotations, classes, and functions."
+    p2: »Alias«,
 )
 
 class MyClass<T>(
     // $TEST$ no error "Union types must only be used for parameters of annotations, classes, and functions."
-    p: »union<Int>«,
+    p1: »union<Int>«,
+    // $TEST$ no error "Union types must only be used for parameters of annotations, classes, and functions."
+    p2: »Alias«,
 ) {
     // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
-    attr a: »union<Int>«
+    attr a1: »union<Int>«
+    // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
+    attr a2: »Alias«
 }
 
 enum MyEnum {
     MyEnumVariant(
         // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
-        p: »union<Int>«,
+        p1: »union<Int>«,
+        // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
+        p2: »Alias«,
     )
 }
 
 fun myFunction(
     // $TEST$ no error "Union types must only be used for parameters of annotations, classes, and functions."
-    p: »union<Int>«,
+    p1: »union<Int>«,
+    // $TEST$ no error "Union types must only be used for parameters of annotations, classes, and functions."
+    p2: »Alias«,
 ) -> (
     // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
-    r: »union<Int>«,
+    r1: »union<Int>«,
+    // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
+    r2: »Alias«,
 )
 
 segment mySegment1(
     // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
-    p: »union<Int>«,
+    p1: »union<Int>«,
+    // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
+    p2: »Alias«,
 ) -> (
     // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
-    r: »union<Int>«,
+    r1: »union<Int>«,
+    // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
+    r2: »Alias«,
 ) {}
 
 segment mySegment2(
     // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
     // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
-    c: (p: »union<Int>«) -> (r: »union<Int>«),
+    c1: (p: »union<Int>«) -> (r: »union<Int>«),
+    // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
+    // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
+    c2: (p: »Alias«) -> (r: »Alias«),
 ) {
     // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
+    // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
     (
-        p: »union<Int>«,
+        p1: »union<Int>«,
+        p2: »Alias«,
     ) {};
 
     // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
+    // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
     (
-        p: »union<Int>«,
+        p1: »union<Int>«,
+        p2: »Alias«,
     ) -> 1;
 }
 
 segment mySegment3(
     // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
     p1: MyClass<»union<Int>«>,
+    // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
+    p2: MyClass<»Alias«>,
 ) {}
 
 segment mySegment4(
     // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
-    p1: »union<Int>«.MyClass
+    p1: »union<Int>«.MyClass,
+    // $TEST$ error "Union types must only be used for parameters of annotations, classes, and functions."
+    p2: »Alias«.MyClass
 ) {}

--- a/packages/safe-ds-lang/tests/resources/validation/other/types/union types/context/nested.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/validation/other/types/union types/context/nested.sdsdev
@@ -6,11 +6,16 @@ package tests.validation.other.types.unionTypes.context
 
 class MyClass1 {
     // $TEST$ no error "Union types must only be used for parameters of annotations, classes, and functions."
-    attr a: union<Int, »union<Int>«>
+    attr a1: union<Int, »union<Int>«>
+    // $TEST$ no error "Union types must only be used for parameters of annotations, classes, and functions."
+    attr a2: union<Int, »Alias«>
 }
 
 class MyClass2 {
     // $TEST$ no error "Union types must only be used for parameters of annotations, classes, and functions."
     // $TEST$ no error "Union types must only be used for parameters of annotations, classes, and functions."
-    attr a: union<Int, (p: »union<Int>«) -> (r: »union<Int>«)>
+    attr a1: union<Int, (p: »union<Int>«) -> (r: »union<Int>«)>
+    // $TEST$ no error "Union types must only be used for parameters of annotations, classes, and functions."
+    // $TEST$ no error "Union types must only be used for parameters of annotations, classes, and functions."
+    attr a2: union<Int, (p: »Alias«) -> (r: »Alias«)>
 }

--- a/packages/safe-ds-vscode/syntaxes/safe-ds-dev.tmLanguage.json
+++ b/packages/safe-ds-vscode/syntaxes/safe-ds-dev.tmLanguage.json
@@ -5,22 +5,6 @@
     "patterns": [
         {
             "include": "source.safe-ds#shared"
-        },
-        {
-            "name": "storage.type.safe-ds-dev",
-            "match": "\\b(annotation|attr|class|enum|fun|package|pipeline|segment|typealias|val)\\b"
-        },
-        {
-            "name": "storage.modifier.safe-ds-dev",
-            "match": "\\b(const|in|internal|out|private|static)\\b"
-        },
-        {
-            "name": "keyword.operator.expression.safe-ds-dev",
-            "match": "\\b(and|not|or|sub)\\b"
-        },
-        {
-            "name": "variable.language.safe-ds-dev",
-            "match": "\\b(this)\\b"
         }
     ]
 }

--- a/packages/safe-ds-vscode/syntaxes/safe-ds-stub.tmLanguage.json
+++ b/packages/safe-ds-vscode/syntaxes/safe-ds-stub.tmLanguage.json
@@ -5,22 +5,6 @@
     "patterns": [
         {
             "include": "source.safe-ds#shared"
-        },
-        {
-            "name": "storage.type.safe-ds-stub",
-            "match": "\\b(annotation|attr|class|enum|fun|package|typealias|val)\\b"
-        },
-        {
-            "name": "storage.modifier.safe-ds-stub",
-            "match": "\\b(const|in|internal|out|private|static)\\b"
-        },
-        {
-            "name": "keyword.operator.expression.safe-ds-stub",
-            "match": "\\b(and|not|or|sub)\\b"
-        },
-        {
-            "name": "variable.language.safe-ds-stub",
-            "match": "\\b(this)\\b"
         }
     ]
 }

--- a/packages/safe-ds-vscode/syntaxes/safe-ds.tmLanguage.json
+++ b/packages/safe-ds-vscode/syntaxes/safe-ds.tmLanguage.json
@@ -5,19 +5,6 @@
     "patterns": [
         {
             "include": "#shared"
-        },
-
-        {
-            "name": "storage.type.safe-ds",
-            "match": "\\b(package|pipeline|segment|typealias|val)\\b"
-        },
-        {
-            "name": "storage.modifier.safe-ds",
-            "match": "\\b(const|internal|out|private)\\b"
-        },
-        {
-            "name": "keyword.operator.expression.safe-ds",
-            "match": "\\b(and|not|or)\\b"
         }
     ],
     "repository": {
@@ -30,6 +17,22 @@
                 {
                     "name": "constant.language.safe-ds",
                     "match": "\\b(false|null|true|unknown)\\b"
+                },
+                {
+                    "name": "storage.type.safe-ds",
+                    "match": "\\b(annotation|attr|class|enum|fun|package|pipeline|segment|typealias|val)\\b"
+                },
+                {
+                    "name": "storage.modifier.safe-ds",
+                    "match": "\\b(const|in|internal|out|private|static)\\b"
+                },
+                {
+                    "name": "variable.language.safe-ds-stub",
+                    "match": "\\b(this)\\b"
+                },
+                {
+                    "name": "keyword.operator.expression.safe-ds",
+                    "match": "\\b(and|not|or|sub)\\b"
                 },
                 {
                     "name": "keyword.other.safe-ds",


### PR DESCRIPTION
### Summary of Changes

Callable types and union types may now be used in type aliases. Usages of type aliases are checked like the type they alias, so a type alias referring to a union type may not be used as a result type.