### PR TITLE
fix: do not suggest references to type alias

### DIFF
--- a/packages/safe-ds-lang/src/language/lsp/safe-ds-completion-provider.ts
+++ b/packages/safe-ds-lang/src/language/lsp/safe-ds-completion-provider.ts
@@ -16,6 +16,7 @@ import {
     isSdsTypeParameter,
     SdsAnnotation,
     SdsPipeline,
+    SdsTypeAlias,
 } from '../generated/ast.js';
 import { Class, getPackageName } from '../helpers/nodeProperties.js';
 import { isInPipelineFile, isInStubFile } from '../helpers/fileExtensions.js';
@@ -46,7 +47,7 @@ export class SafeDsCompletionProvider extends DefaultCompletionProvider {
             .filter((description) => this.filterReferenceCandidate(refInfo, description));
     }
 
-    private illegalNodeTypesForReferences = new Set([SdsAnnotation, SdsPipeline]);
+    private illegalNodeTypesForReferences = new Set([SdsAnnotation, SdsPipeline, SdsTypeAlias]);
 
     private filterReferenceCandidate(refInfo: ReferenceInfo, description: AstNodeDescription): boolean {
         if (isSdsNamedType(refInfo.container)) {

--- a/packages/safe-ds-lang/tests/language/lsp/safe-ds.completion-provider.test.ts
+++ b/packages/safe-ds-lang/tests/language/lsp/safe-ds.completion-provider.test.ts
@@ -362,6 +362,18 @@ describe('SafeDsCompletionProvider', async () => {
                     shouldNotContain: ['myPipeline'],
                 },
             },
+            {
+                testName: 'reference to type alias',
+                code: `
+                    typealias MyAlias = Int
+
+                    pipeline myPipeline {
+                        <|>
+                `,
+                expectedLabels: {
+                    shouldNotContain: ['MyAlias'],
+                },
+            },
 
             // Special cases
             {


### PR DESCRIPTION
### Summary of Changes

The code-completion no longer suggests references (expression context) to type aliases.