### PR TITLE
fix: handling of aliases of nullable types

### DIFF
--- a/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
+++ b/packages/safe-ds-lang/src/language/typing/safe-ds-type-computer.ts
@@ -708,13 +708,20 @@ export class SafeDsTypeComputer {
     }
 
     private computeTypeOfNamedType(node: SdsNamedType) {
-        const unparameterizedType = this.computeType(node.declaration?.ref).withExplicitNullability(node.isNullable);
-        if (!(unparameterizedType instanceof ClassType)) {
-            return unparameterizedType;
+        let baseType = this.computeType(node.declaration?.ref);
+
+        // Update nullability
+        if (node.isNullable) {
+            baseType = baseType.withExplicitNullability(true);
         }
 
-        const substitutions = this.computeSubstitutionsForNamedType(node, unparameterizedType.declaration);
-        return this.factory.createClassType(unparameterizedType.declaration, substitutions, node.isNullable);
+        // Substitute type parameters
+        if (!(baseType instanceof ClassType)) {
+            return baseType;
+        }
+
+        const substitutions = this.computeSubstitutionsForNamedType(node, baseType.declaration);
+        return this.factory.createClassType(baseType.declaration, substitutions, baseType.isExplicitlyNullable);
     }
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/packages/safe-ds-lang/tests/resources/typing/declarations/type aliases/main.sdsdev
+++ b/packages/safe-ds-lang/tests/resources/typing/declarations/type aliases/main.sdsdev
@@ -2,4 +2,10 @@ package tests.typing.declarations.typeAliases
 
 // $TEST$ equivalence_class RHS
 // $TEST$ equivalence_class RHS
-typealias »MyAlias« = »Int«
+typealias »MyAlias1« = »Int?«
+
+// $TEST$ equivalence_class Alias
+typealias »MyAlias2« = Int?
+
+// $TEST$ equivalence_class Alias
+class MyClass1(p: »MyAlias2«) /* There used to be a bug where nullable types were turned into non-nullable types. */


### PR DESCRIPTION
### Summary of Changes

Fix an issue where the nullability of type aliases for nullable types was lost.